### PR TITLE
Develop breaux four way cluster

### DIFF
--- a/f5/bigip/interfaces/cluster.py
+++ b/f5/bigip/interfaces/cluster.py
@@ -93,7 +93,7 @@ class Cluster(object):
             response_obj = json.loads(response.text)
             if 'items' in response_obj:
                 for device in response_obj['items']:
-                    if device['selfDevice'].lower() == "true":
+                    if device['selfDevice'].lower() == 'true':
                         return device['name']
         else:
             Log.error('device', response.text)
@@ -111,7 +111,7 @@ class Cluster(object):
             response_obj = json.loads(response.text)
             if 'items' in response_obj:
                 for device in response_obj['items']:
-                    if device['selfDevice'].lower() == "true":
+                    if device['selfDevice'].lower() == 'true':
                         return device['managementIp']
         else:
             Log.error('device', response.text)


### PR DESCRIPTION
@pjbreaux
#### What's this change do?

Fixes a bug related to clustering devices where the host doing the peering changes throughout the peering process.
#### Where should the reviewer start?

The only file changed was cluster.py.
#### Any background context or associated information?

This was found while attempting to create a four-way cluster. A logic bug resulted in different hosts being returned from the get_local_device_name() and get_local_device_addr() depending on the results returned from an icontrol call. This was causing peering to break with the following error message:

The device used to peer <peer_host_name> was already itself peered from root device: <root_host_name>
