### PR TITLE
Reference Issue:   https://github.com/F5Networks/f5-common-python/issues/7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,14 @@
+sudo: false
+language: python
+python:
+    - "2.7"
+    - "2.6"
+before_install:
+    - git config --global user.email "OpenStack_TravisCI@f5.com"
+    - git config --global user.name "Travis F5 Openstack"
+    - git fetch --depth=100
+install:
+    - pip install hacking pytest pytest-cov
+script:
+    - flake8 .
+    - py.test --cov .

--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
 Introduction
 ============
+[![Build Status](https://magnum.travis-ci.com/zancas/f5-common-python.svg?token=PavrH4nsyFx2fjwRkpnH&branch=feature.ci_initialization)](https://magnum.travis-ci.com/zancas/f5-common-python)
 
 This repository provides a set of interfaces for controlling F5 devices in an Openstack cloud environment.
+


### PR DESCRIPTION
Purpose:           This commit sets up basic travis/pytest/slack/github integration.

Changes:           Adds an appropriate .travis.yml, and a build badge to the README.md.
