### PR TITLE
Use json() instead of .json to get JSON data from response.

### DIFF
--- a/f5/bigip/rest_collection.py
+++ b/f5/bigip/rest_collection.py
@@ -82,7 +82,7 @@ class RESTInterfaceCollection(object):
         response = self.bigip.icr_session.get(
             self.base_uri, params=params, timeout=timeout)
 
-        items =  response.json().get('items', [])
+        items = response.json().get('items', [])
         for item in items:
             # This is where we had startswith(self.OBJ_PREFIX)
             if item['name'].startswith(startswith):
@@ -121,11 +121,11 @@ class RESTInterfaceCollection(object):
                 return items
             raise
 
-        items =  response.json().get('items', [])
+        items = response.json().get('items', [])
         if select:
-          for item in items:
-              if select in item:
-                  items.append(strip_folder_and_prefix(item[select]))
+            for item in items:
+                if select in item:
+                    items.append(strip_folder_and_prefix(item[select]))
 
         return items
 
@@ -140,8 +140,11 @@ class RESTInterfaceCollection(object):
 
         # No try here because original code was not doing exceptional things
         # with error messages like self._get()
-        response = self.bigip.icr_session.get(uri, instance_name=name, folder=folder,
-                                              params=params, timeout=timeout)
+        response = self.bigip.icr_session.get(uri,
+                                              instance_name=name,
+                                              folder=folder,
+                                              params=params,
+                                              timeout=timeout)
         return response.json().get(select, None)
 
 


### PR DESCRIPTION
#### What's this change do?

Fixes two issues:
1. iControlRESTSession methods need to be called with instance_name argument, not name.
2. To get json data from response object, the method json() needs to be called, not
the property .json.
#### Where should the reviewer start?

Reviedw changes in rest_collection.py
#### Any background context?

Found when unit testing using responses library.
