### PR TITLE
Modify BigIP class to use new icontrolRESTSession object.

### DIFF
--- a/f5/bigip/__init__.py
+++ b/f5/bigip/__init__.py
@@ -19,17 +19,17 @@ import os
 
 from f5.bigip import rest_collection
 
-from f5.bigip.cm import CM as cm
-from f5.bigip.cm.device import Device as device
-from f5.bigip.ltm import LTM as ltm
-from f5.bigip.net import Net as net
+from f5.bigip.cm import CM
+from f5.bigip.cm.device import Device
+from f5.bigip.ltm import LTM
+from f5.bigip.net import Net
 from f5.bigip.pycontrol import pycontrol as pc
-from f5.bigip.sys import Sys as sys
+from f5.bigip.sys import Sys
 from f5.common import constants as const
 from icontrol.session import iControlRESTSession
 
 LOG = logging.getLogger(__name__)
-root_collection_classes = [cm, device, ltm, net, sys]
+root_collection_classes = [CM, Device, LTM, Net, Sys]
 
 
 class BigIP(object):

--- a/f5/bigip/test/test___init__.py
+++ b/f5/bigip/test/test___init__.py
@@ -16,10 +16,10 @@ import pytest
 
 from f5.bigip import BigIP
 
-from f5.bigip.cm import CM as cm
-from f5.bigip.ltm import LTM as ltm
-from f5.bigip.net import Net as net
-from f5.bigip.sys import Sys as sys
+from f5.bigip.cm import CM
+from f5.bigip.ltm import LTM
+from f5.bigip.net import Net
+from f5.bigip.sys import Sys
 
 
 @pytest.fixture
@@ -30,12 +30,12 @@ def FakeBigIP():
 
 def test___get__attr(FakeBigIP):
     bigip_dot_cm = FakeBigIP.cm
-    assert isinstance(bigip_dot_cm, cm)
+    assert isinstance(bigip_dot_cm, CM)
     bigip_dot_ltm = FakeBigIP.ltm
-    assert isinstance(bigip_dot_ltm, ltm)
+    assert isinstance(bigip_dot_ltm, LTM)
     bigip_dot_net = FakeBigIP.net
-    assert isinstance(bigip_dot_net, net)
+    assert isinstance(bigip_dot_net, Net)
     bigip_dot_sys = FakeBigIP.sys
-    assert isinstance(bigip_dot_sys, sys)
+    assert isinstance(bigip_dot_sys, Sys)
     with pytest.raises(AttributeError):
         FakeBigIP.this_is_not_a_real_attribute


### PR DESCRIPTION
#### What's this change do?

Modifies BigIP class to use icontrolRESTSession object from f5-icontrol-rest project.
#### Where should the reviewer start?

f5/bigip/**init**.py has all the modified code.
#### Any background context?

This will break the build f5-common-python does NOT yet have the new icontrolRESTSession installed. This needs to happen to restore the build to success.
