### PR TITLE
Add a _set() method to the base class

### DIFF
--- a/f5/bigip/rest_collection.py
+++ b/f5/bigip/rest_collection.py
@@ -158,6 +158,21 @@ class RESTInterfaceCollection(object):
                                               timeout=timeout)
         return response.json().get(select, None)
 
+    @log
+    def _set(self, name, folder, key, value):
+        payload = {key: value}
+        try:
+            self.bigip.icr_session.put(
+                self.base_uri,
+                instance_name=name,
+                folder=folder,
+                json=payload,
+                timeout=const.CONNECTION_TIMEOUT)
+        except HTTPError as err:
+            Log.error(self.__class__.__name__, err.response.text)
+            raise
+        return True
+
 
 def prefixed(name):
     """Put object prefix in front of name """


### PR DESCRIPTION
@jlongstaf 
#### What issues does this address?

Fixes #67
#### What's this change do?

Creates a `_set()` method to the `RESTInterfaceCollection` base class that the interface objects can use for their many `set_*()` methods.
#### Where should the reviewer start?

Look at the `_set()` method and the tests.  Notice that the arguments are required and not optional which is what we want to move to for future signatures in these classes.
#### Any background context?
