### PR TITLE
First draft all CRLUD implemented and pass 1 test!

### DIFF
--- a/f5/bigip/ltm/nat.py
+++ b/f5/bigip/ltm/nat.py
@@ -41,3 +41,18 @@ class NAT(CRUDResource):
                 " kind must be 'tm:ltm:nat:natstate' but creation returned" +\
                 " JSON with kind: %r" % self.kind
             raise KindTypeMismatch(error_message)
+
+    def refresh(self):
+        self._refresh()
+
+    def load(self, **kwargs):
+        self._load(**kwargs)
+
+    def update(self, **kwargs):
+        # Need to implement checking for valid params here.
+        self._update(**kwargs)
+
+    def delete(self):
+        # Need to implement checking for ? here.
+        self._delete()
+        # Need to implement correct teardown here.

--- a/test/functional_test_nat.py
+++ b/test/functional_test_nat.py
@@ -17,15 +17,15 @@ from f5.bigip.mixins import LazyAttributesRequired
 
 bigip = BigIP('10.190.5.7', 'admin', 'admin')
 nat1 = bigip.ltm.natcollection.nat
+nat2 = bigip.ltm.natcollection.nat
 try:
-    nat1.create(name='aaa59', partition='Common',
-                originatingAddress='192.168.2.59',
-                translationAddress='192.168.1.59')
+    nat1.create(name='za_test_001', partition='Common',
+                originatingAddress='192.168.3.1',
+                translationAddress='192.168.3.2')
 except LazyAttributesRequired as LAR:
-    print("Inside LAR exception.")
-    print(LAR)
-    print(nat1.__dict__)
     raise
-print("No LAR!!")
-nat1._read()
-print(nat1.__dict__)
+nat2.load(partition='Common', name='za_test_001')
+nat2.update(arp=u'disabled')
+print('******')
+nat2.refresh()
+nat1.delete()


### PR DESCRIPTION
@swormke 
#### Basic ltm/nat functionality!

Issues:
Fixes #92
Fixes #93
NOTE:  There are many open issues related to this functionality (unittests, param-checking, generalizations, etc.) but the basic CRLUD works for ltm/nat in this commit.
#### Implement:

load, refresh

test **init**, create, load, update, refresh, and delete for ltm/nat
#### Start with the functional tests:

Actually start by merging the `response.text` fix in f5-incontrol-rest-python, then install that new version of that library.

Then:

read f5-common-python/test/functional_test_nat.py

and

`cd f5-common-python/test`

and then:

`PYTHONPATH=../ python ./functional_test_nat.py`
#### Context:

Part of the migration to object reprs of the REST interface.
