### PR TITLE
Implement get_collection CollectionResource method

### DIFF
--- a/f5/bigip/ltm/nat.py
+++ b/f5/bigip/ltm/nat.py
@@ -21,6 +21,8 @@ class NATCollection(CollectionResource):
     def __init__(self, ltm):
         super(NATCollection, self).__init__(ltm)
         self._meta_data['allowed_lazy_attributes'] = [NAT]
+        self._meta_data['collection_registry'] =\
+            {'tm:ltm:nat:natstate': NAT}
 
 
 class NAT(CRLUDResource):

--- a/test/functional_test_nat.py
+++ b/test/functional_test_nat.py
@@ -26,6 +26,15 @@ except LazyAttributesRequired as LAR:
     raise
 nat2.load(partition='Common', name='za_test_001')
 nat2.update(arp=u'disabled')
+nc = bigip.ltm.natcollection
+# print(nc.__dict__)
 print('******')
+CRLUDs = nc.get_collection()
+print('******')
+# print(nc.__dict__['items'])
 nat2.refresh()
+print(CRLUDs)
 nat1.delete()
+CRLUDs2 = nc.get_collection()
+print('!!!!!!!!!!')
+print(CRLUDs2)


### PR DESCRIPTION
@swormke
Issues:
Fixes https://github.com/F5Networks/f5-common-python/issues/121

Problem: CollectionResources provide a list of collection contents, when `gets`
are submitted to their uri.  The `get_collection` method now implements
handling of getting, instantiating, appending, and returning a list of objects
that represent the listed resources.

Analysis: This implements a the basic list-of-objects creation functionality
that "collection" uris support via HTTP `get`.

Tests: This is functionally tested in test/functional_test_nat.py, unittests to
follow.
