### PR TITLE
Refactor ltm.rule to be a CRLUDResource

### DIFF
--- a/f5/bigip/ltm/__init__.py
+++ b/f5/bigip/ltm/__init__.py
@@ -15,7 +15,7 @@
 from f5.bigip.ltm.monitor import Monitor
 from f5.bigip.ltm.nat import NATCollection
 from f5.bigip.ltm.pool import Pool
-from f5.bigip.ltm.rule import Rule
+from f5.bigip.ltm.rule import RuleCollection
 from f5.bigip.ltm.snat import SNAT
 from f5.bigip.ltm.ssl import SSL
 from f5.bigip.ltm.virtual_server import VirtualServer
@@ -25,5 +25,9 @@ from f5.bigip.resource import CollectionResource
 class LTM(CollectionResource):
     def __init__(self, bigip):
         super(LTM, self).__init__(bigip)
-        self._meta_data['allowed_lazy_attributes'] =\
-            [Monitor, NATCollection, Pool, Rule, SNAT, SSL, VirtualServer]
+        self._meta_data['allowed_lazy_attributes'] = [
+            NATCollection, RuleCollection,
+            Monitor, Pool,
+            SNAT, SSL,
+            VirtualServer
+        ]

--- a/f5/bigip/ltm/test/test_rule.py
+++ b/f5/bigip/ltm/test/test_rule.py
@@ -1,0 +1,44 @@
+# Copyright 2015 F5 Networks Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import mock
+import pytest
+
+from f5.bigip import BigIP
+from f5.bigip.ltm.nat import NAT
+from f5.bigip.resource import MissingRequiredCreationParameter
+
+
+@pytest.fixture
+def FakeRule():
+    fake_rule_collection = mock.MagicMock()
+    fake_rule = NAT(fake_rule_collection)
+    return fake_rule
+
+
+class TestCreate(object):
+    def test_create_two(self):
+        b = BigIP('192.168.1.1', 'admin', 'admin')
+        r1 = b.ltm.rulecollection.rule
+        r2 = b.ltm.rulecollection.rule
+        assert r1 is not r2
+
+    def test_create_no_args(self, FakeRule):
+        with pytest.raises(MissingRequiredCreationParameter):
+            FakeRule.create()
+
+    def test_create_partition(self, FakeRule):
+        with pytest.raises(MissingRequiredCreationParameter):
+            FakeRule.create(name='myname', partition='Common')

--- a/f5/bigip/resource.py
+++ b/f5/bigip/resource.py
@@ -169,6 +169,7 @@ class Resource(LazyAttributeMixin, ToDictMixin):
         response = read_session.get(base_uri, **kwargs)
         self._local_update(response.json())
         self._meta_data['uri'] = self.selfLink.replace('localhost', hostname)
+        return self
 
     def create(self):
         error_message = "Only CRLUDResources support http 'create'."


### PR DESCRIPTION
@zancas 
#### What issues does this address?

Fixes #123 
#### What's this change do?

Refactors ltm.rule to be a CRLUDResource
#### Where should the reviewer start?

Look at the rule.py file and the tests that go with it.
#### Any background context?

Used the nat.py as an example
