### PR TITLE
Handle Exclusive Object Attributes

### DIFF
--- a/f5/bigip/mixins.py
+++ b/f5/bigip/mixins.py
@@ -101,11 +101,9 @@ class ExclusiveAttributesMixin(object):
         '''
         if '_meta_data' in self.__dict__:
             # Sometimes this is called prior to full object construction
-            for s in self.__dict__['_meta_data']['exclusive_attributes']:
-                if key in s:
-                    new_s = s - key
-                    for n in new_s:
-                        # Avoid key errors if the attribute wasn't there
-                        self.__dict__.pop(n, '')
+            for attr_set in self._meta_data['exclusive_attributes']:
+                if key in attr_set:
+                    new_set = set(attr_set) - set([key])
+                    [self.__dict__.pop(n, '') for n in new_set]
         # Now set the attribute
         super(ExclusiveAttributesMixin, self).__setattr__(key, value)


### PR DESCRIPTION
@zancas 
### Issues:

Fixes #144
### Problem

There are object attributes that cannot be set at the same time. For example in the `f5.bigip.net.vlan.interfaces` object you cannot have both the `tagged` and `untagged` attribute set because when you do an update to the BIGIP it throws an error. We need to handle this for users by removing any of the attributes that are exclusive in their relationship.
### Analysis
- Added a mixin that can be used by objects that require this
  functionality.
- The mixin overrides the `__setattr__` for the class and
  if the attribute being set is in one of the sets in
  `self._meta_data['exclusive_attributes']` it removes the other
  members of that set prior to assigning the value to the attr.

**NOTE** You must call `super(CLASSNAME, self).__setattr__` at the
end of the mixin to be sure that you actually set the attribute
like you wanted to.
### Tests
- Need to do 
