### PR TITLE
get_collection() loaded created objects with sub-collections raises L…

### DIFF
--- a/f5/bigip/ltm/pool.py
+++ b/f5/bigip/ltm/pool.py
@@ -33,12 +33,9 @@ class Pool(Resource):
     def __init__(self, pool_collection):
         super(Pool, self).__init__(pool_collection)
         self._meta_data['required_json_kind'] = 'tm:ltm:pool:poolstate'
-
-    def create(self, **kwargs):
-        self._create(**kwargs)
-        # This idiom is specific to subcollections!
-        self._meta_data['allowed_lazy_attributes'] = [MembersCollection]
-        return self
+        self._meta_data['collection_registry'] = {
+            'tm:ltm:pool:memberscollectionstate': MembersCollection
+        }
 
 
 class MembersCollection(Collection):

--- a/f5/bigip/mixins.py
+++ b/f5/bigip/mixins.py
@@ -64,7 +64,8 @@ class LazyAttributeMixin(object):
             error_message = '%r does not have self._meta_data' % cls_name
             raise LazyAttributesRequired(error_message)
         elif 'allowed_lazy_attributes' not in self._meta_data:
-            error_message = '"allowed_lazy_attributes" not in self._meta_data'
+            error_message = ('"allowed_lazy_attributes" not in',
+                             'self._meta_data for class %s' % cls_name)
             raise LazyAttributesRequired(error_message)
 
         # ensure the requested attr is present

--- a/f5/bigip/net/vlan.py
+++ b/f5/bigip/net/vlan.py
@@ -30,11 +30,8 @@ class VLAN(Resource):
     def __init__(self, vlan_collection):
         super(VLAN, self).__init__(vlan_collection)
         self._meta_data['required_json_kind'] = 'tm:net:vlan:vlanstate'
-
-    def create(self, **kwargs):
-        self._create(**kwargs)
-        self._meta_data['allowed_lazy_attributes'] = [InterfacesCollection]
-        return self
+        self._meta_data['collection_registry'] =\
+            {'tm:net:vlan:interfacescollectionstate': InterfacesCollection}
 
 
 class InterfacesCollection(Collection):

--- a/f5/bigip/resource.py
+++ b/f5/bigip/resource.py
@@ -329,6 +329,7 @@ class Resource(ResourceBase):
 
         # Update the object to have the correct functional uri.
         self._build_meta_data_uri(self.selfLink)
+        self._update_lazy_attributes()
         return self
 
     def create(self, **kwargs):
@@ -350,6 +351,7 @@ class Resource(ResourceBase):
         response = read_session.get(base_uri, **kwargs)
         self._local_update(response.json())
         self._build_meta_data_uri(self.selfLink)
+        self._update_lazy_attributes()
         return self
 
     def load(self, **kwargs):
@@ -429,7 +431,12 @@ class Resource(ResourceBase):
         response = session.get(self._meta_data['uri'])
         current_gen = response.json().get('generation', None)
         if current_gen is not None and current_gen != self.generation:
-            error_message = "The generation of the object on the BigIP (%s)" +\
-                            "does not match the current object (%s)" % (
-                                current_gen, self.generation)
+            error_message = ("The generation of the object on the BigIP " +
+                             "(" + str(current_gen) + ")" +
+                             " does not match the current object" +
+                             "(" + str(self.generation) + ")")
             raise GenerationMismatch(error_message)
+
+    def _update_lazy_attributes(self):
+        collection_reg = self._meta_data.get('collection_registry', {})
+        self._meta_data['allowed_lazy_attributes'] = collection_reg.values()

--- a/test/functional/net/test_vlan.py
+++ b/test/functional/net/test_vlan.py
@@ -186,5 +186,5 @@ class TestVLAN(object):
         '''
         setup_interfaces_test(request, bigip, 'v1', 'Common')
         v2 = bigip.net.vlancollection.vlan.load(name='v1', partition='Common')
-        v2_ifcs = v2.interfacecollection.get_collection()
+        v2_ifcs = v2.interfacescollection.get_collection()
         assert len(v2_ifcs) == 1


### PR DESCRIPTION
@zancas 
#### What issues does this address?

Fixes #148 
#### What's this change do?

Adds logic to the base `Resource` class to automatically add lazy attributes if the `Resource` has `self._meta_data['collection_registry'] entries.
#### Where should the reviewer start?

Take a look at the new method in `resource.py` and where it is called in `_create()` and `load()`
#### Any background context?
- This is the same fix we put in for create for Resources with subcollections (VLAN and Pool)
- Move this logic to the Resource base class and add a function to update the lazy attributes if there are object that are in the collection registry metadata
- Also fixed a few error messages to be more clear.
#### Tests
- Ran the failing VLAN test and the pool tests that also had the problem and there are no new failures.
