### PR TITLE
get_collection no longer chats with device

### DIFF
--- a/f5/bigip/resource.py
+++ b/f5/bigip/resource.py
@@ -250,12 +250,11 @@ class Collection(ResourceBase):
         if 'items' in self.__dict__:
             for item in self.items:
                 kind = item['kind']
-                name = item['name']
-                partition = item.get('partition', '')
                 if kind in self._meta_data['collection_registry']:
                     instance =\
                         self._meta_data['collection_registry'][kind](self)
-                    instance.load(name=name, partition=partition)
+                    instance._local_update(item)
+                    instance._build_meta_data_uri(instance.selfLink)
                     list_of_contents.append(instance)
                 else:
                     error_message = '%r is not registered!' % kind


### PR DESCRIPTION
@swormke
Issues:
Fixes https://github.com/F5Networks/f5-common-python/issues/171

Problem: get_collection was issuing HTTP requests for each object in items,
even though it didn't need new information

Analysis: this version only runs local operations after an initial _refresh.
NOTE:  This reveals the generation discrepancy bug!

Tests:  No new tests, new test failure caused by gen. disc. bug
