### PR TITLE
Initial alpha release on PyPi

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -24,6 +24,9 @@ Installation
 
     $> pip install f5-sdk
 
+*NOTE:* If you are using a pre-release version you must use the ``--pre``
+option for the ``pip`` command.
+
 Usage
 -----
 
@@ -36,7 +39,7 @@ Usage
 Documentation
 -------------
 
-Documentation is hosted on `Read the Docs <https://f5-sdk.readthedocs.org>`__
+Documentation is hosted on `Read the Docs <https://f5-python-sdk.readthedocs.org>`__
 
 Filing Issues
 -------------
@@ -171,5 +174,5 @@ completed and submitted the `F5 Contributor License Agreement
 to Openstack_CLA@f5.com prior to their code submission being included in this
 project.
 
-.. |Build Status| image:: https://travis-ci.com/F5Networks/f5-common-python.svg?token=s9yQgrQoSkLe6ec4WQKS&branch=develop
-   :target: https://travis-ci.com/F5Networks/f5-common-python
+.. |Build Status| image:: https://travis-ci.org/F5Networks/f5-common-python.svg?branch=0.1
+    :target: https://travis-ci.org/F5Networks/f5-common-python

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -21,6 +21,9 @@ Installation
 
     $> pip install f5-sdk
 
+*NOTE:* If you are using a pre-release version you must use the ``--pre``
+option with the pip command.
+
 Usage
 -----
 .. code:: python

--- a/f5/__init__.py
+++ b/f5/__init__.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-__version__ = '0.1.1-alpha.1'
+__version__ = '0.1.1a1'

--- a/setup.py
+++ b/setup.py
@@ -41,9 +41,6 @@ setup(
     packages=find_packages(
         exclude=["*.test", "*.test.*", "test.*", "test_*", "test", "test*"]
     ),
-    exclude_package_data={
-        '': ['conftest.py', "*.pyc"]
-    },
     classifiers=[
         'Development Status :: 3 - Alpha',
         'License :: OSI Approved :: Apache Software License',


### PR DESCRIPTION
@pjbreaux 

Issues:
Fixes #186

Problem:
We need to make the module available on PyPi.

Analysis:
* Updated README and docs to include the `--pre` option for the `pip install` command.
* Update the version to use the recommended string for python `0.1.1a1`
* Update setup.py

Tests: