### PR TITLE
_build_meta_data.. and _manage_.. --> activate_URI

### DIFF
--- a/f5/bigip/sys/application.py
+++ b/f5/bigip/sys/application.py
@@ -146,7 +146,7 @@ class Service(Resource):
 
         response = read_session.get(load_uri, uri_as_parts=False, **kwargs)
         self._local_update(response.json())
-        self._build_meta_data_uri(self.selfLink)
+        self._activate_URI(self.selfLink)
         return self
 
 

--- a/f5/bigip/sys/folder.py
+++ b/f5/bigip/sys/folder.py
@@ -64,7 +64,7 @@ class Folder(Resource):
 
         response = read_session.get(load_uri, uri_as_parts=False, **kwargs)
         self._local_update(response.json())
-        self._build_meta_data_uri(self.selfLink)
+        self._activate_URI(self.selfLink)
         return self
 
     def update(self, **kwargs):

--- a/f5/bigip/sys/test/test_sys_application.py
+++ b/f5/bigip/sys/test/test_sys_application.py
@@ -162,7 +162,7 @@ class TestServiceCreate(object):
     def test_create_uri_collision(self, FakeService):
         FakeService._meta_data = {'uri': 'already_defined'}
         with pytest.raises(URICreationCollision) as ex:
-            FakeService.create(name='test_service', template='tt')
+            FakeService._activate_URI('FAKEURI')
         assert "There was an attempt to assign a new uri to this resource, " \
             "the _meta_data['uri'] is already_defined and it should not be " \
             "changed." in ex.value.message


### PR DESCRIPTION
@pjbreaux 
Issues:
Fixes https://github.com/F5Networks/f5-common-python/issues/202

Problem: We used to have logic that all belonged in one function spread across
a function and a decorator, that was called in multiple places.

Analysis: We've simplified the code by moving that logic into a single function
and re-naming the function intelligently.

Tests: unit, and functional see changed unittest.