### PR TITLE
Subset of modules needed by LBaaSv2 and Heat projects

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,7 +38,7 @@ pip-log.txt
 .coverage
 .tox
 nosetests.xml
-htmlcov/*
+htmlcov
 .cache
 test/*/logs/*
 
@@ -47,3 +47,6 @@ test/*/logs/*
 
 # Docs
 docs/_build
+
+# iControl REST logs
+logs

--- a/docs/apidoc/f5.bigip.cm.rst
+++ b/docs/apidoc/f5.bigip.cm.rst
@@ -1,0 +1,22 @@
+f5.bigip.cm package
+===================
+
+Submodules
+----------
+
+f5.bigip.cm.device module
+-------------------------
+
+.. automodule:: f5.bigip.cm.device
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+
+Module contents
+---------------
+
+.. automodule:: f5.bigip.cm
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/apidoc/f5.bigip.net.rst
+++ b/docs/apidoc/f5.bigip.net.rst
@@ -11,6 +11,14 @@ Subpackages
 Submodules
 ----------
 
+f5.bigip.net.arp module
+-----------------------
+
+.. automodule:: f5.bigip.net.arp
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
 f5.bigip.net.interface module
 -----------------------------
 
@@ -19,10 +27,26 @@ f5.bigip.net.interface module
     :undoc-members:
     :show-inheritance:
 
+f5.bigip.net.route module
+-------------------------
+
+.. automodule:: f5.bigip.net.route
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
 f5.bigip.net.selfip module
 --------------------------
 
 .. automodule:: f5.bigip.net.selfip
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+f5.bigip.net.tunnels module
+---------------------------
+
+.. automodule:: f5.bigip.net.tunnels
     :members:
     :undoc-members:
     :show-inheritance:

--- a/docs/apidoc/f5.bigip.net.test.rst
+++ b/docs/apidoc/f5.bigip.net.test.rst
@@ -1,0 +1,22 @@
+f5.bigip.net.test package
+=========================
+
+Submodules
+----------
+
+f5.bigip.net.test.test_interface module
+---------------------------------------
+
+.. automodule:: f5.bigip.net.test.test_interface
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+
+Module contents
+---------------
+
+.. automodule:: f5.bigip.net.test
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/apidoc/f5.bigip.rst
+++ b/docs/apidoc/f5.bigip.rst
@@ -6,6 +6,7 @@ Subpackages
 
 .. toctree::
 
+    f5.bigip.cm
     f5.bigip.ltm
     f5.bigip.net
     f5.bigip.pycontrol
@@ -14,14 +15,6 @@ Subpackages
 
 Submodules
 ----------
-
-f5.bigip.imports module
------------------------
-
-.. automodule:: f5.bigip.imports
-    :members:
-    :undoc-members:
-    :show-inheritance:
 
 f5.bigip.mixins module
 ----------------------

--- a/docs/apidoc/f5.bigip.sys.rst
+++ b/docs/apidoc/f5.bigip.sys.rst
@@ -19,10 +19,50 @@ f5.bigip.sys.application module
     :undoc-members:
     :show-inheritance:
 
+f5.bigip.sys.db module
+----------------------
+
+.. automodule:: f5.bigip.sys.db
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+f5.bigip.sys.failover module
+----------------------------
+
+.. automodule:: f5.bigip.sys.failover
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
 f5.bigip.sys.folder module
 --------------------------
 
 .. automodule:: f5.bigip.sys.folder
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+f5.bigip.sys.global_settings module
+-----------------------------------
+
+.. automodule:: f5.bigip.sys.global_settings
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+f5.bigip.sys.ntp module
+-----------------------
+
+.. automodule:: f5.bigip.sys.ntp
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+f5.bigip.sys.performance module
+-------------------------------
+
+.. automodule:: f5.bigip.sys.performance
     :members:
     :undoc-members:
     :show-inheritance:

--- a/docs/apidoc/f5.bigip.sys.test.rst
+++ b/docs/apidoc/f5.bigip.sys.test.rst
@@ -4,6 +4,22 @@ f5.bigip.sys.test package
 Submodules
 ----------
 
+f5.bigip.sys.test.test_db module
+--------------------------------
+
+.. automodule:: f5.bigip.sys.test.test_db
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+f5.bigip.sys.test.test_performance module
+-----------------------------------------
+
+.. automodule:: f5.bigip.sys.test.test_performance
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
 f5.bigip.sys.test.test_sys_application module
 ---------------------------------------------
 

--- a/docs/apidoc/f5.bigip.test.rst
+++ b/docs/apidoc/f5.bigip.test.rst
@@ -36,6 +36,14 @@ f5.bigip.test.test_mixins module
     :undoc-members:
     :show-inheritance:
 
+f5.bigip.test.test_resource module
+----------------------------------
+
+.. automodule:: f5.bigip.test.test_resource
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
 
 Module contents
 ---------------

--- a/f5/bigip/__init__.py
+++ b/f5/bigip/__init__.py
@@ -17,6 +17,7 @@
 import logging
 import os
 
+from f5.bigip.cm import CM
 from f5.bigip.ltm import LTM
 from f5.bigip.net import Net
 from f5.bigip.pycontrol import pycontrol as pc
@@ -26,7 +27,7 @@ from f5.common import constants as const
 from icontrol.session import iControlRESTSession
 
 LOG = logging.getLogger(__name__)
-allowed_lazy_attributes = [LTM, Net, Sys]
+allowed_lazy_attributes = [CM, LTM, Net, Sys]
 
 
 def _get_icontrol(hostname, username, password, timeout=None):

--- a/f5/bigip/cm/__init__.py
+++ b/f5/bigip/cm/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2015 F5 Networks Inc.
+# Copyright 2016 F5 Networks Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -13,25 +13,15 @@
 # limitations under the License.
 #
 
-from f5.bigip.net.arp import Arps
-from f5.bigip.net.interface import Interfaces
-from f5.bigip.net.route import Routes
-from f5.bigip.net.selfip import SelfIPs
-from f5.bigip.net.tunnels import Tunnels_s
-from f5.bigip.net.vlan import VLANs
+from f5.bigip.cm.device import Devices
+from f5.bigip.cm.device_group import Device_Groups
+from f5.bigip.cm.traffic_group import Traffic_Groups
 from f5.bigip.resource import OrganizingCollection
 
-base_uri = 'net/'
 
-
-class Net(OrganizingCollection):
+class CM(OrganizingCollection):
     def __init__(self, bigip):
-        super(Net, self).__init__(bigip)
+        super(CM, self).__init__(bigip)
         self._meta_data['allowed_lazy_attributes'] = [
-            Arps,
-            Interfaces,
-            Routes,
-            SelfIPs,
-            Tunnels_s,
-            VLANs
+            Devices, Device_Groups, Traffic_Groups,
         ]

--- a/f5/bigip/cm/device.py
+++ b/f5/bigip/cm/device.py
@@ -1,4 +1,4 @@
-# Copyright 2014-2015 F5 Networks Inc.
+# Copyright 2016 F5 Networks Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -17,17 +17,16 @@ from f5.bigip.resource import Collection
 from f5.bigip.resource import Resource
 
 
-class Rules(Collection):
-    def __init__(self, ltm):
-        super(Rules, self).__init__(ltm)
-        self._meta_data['allowed_lazy_attributes'] = [Rule]
+class Devices(Collection):
+    def __init__(self, cm):
+        super(Devices, self).__init__(cm)
+        self._meta_data['allowed_lazy_attributes'] = [Device]
         self._meta_data['attribute_registry'] =\
-            {'tm:ltm:rule:rulestate': Rule}
+            {'tm:cm:device:devicestate': Device}
 
 
-class Rule(Resource):
-    def __init__(self, rule_s):
-        super(Rule, self).__init__(rule_s)
-        self._meta_data['required_json_kind'] = 'tm:ltm:rule:rulestate'
-        self._meta_data['required_creation_parameters'].update(
-            ('name', 'partition', 'apiAnonymous'))
+class Device(Resource):
+    def __init__(self, device_s):
+        super(Device, self).__init__(device_s)
+        self._meta_data['required_json_kind'] = 'tm:cm:device:devicestate'
+        self._meta_data['required_creation_parameters'].update(('partition',))

--- a/f5/bigip/cm/device_group.py
+++ b/f5/bigip/cm/device_group.py
@@ -1,0 +1,58 @@
+# Copyright 2016 F5 Networks Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+from f5.bigip.resource import Collection
+from f5.bigip.resource import Resource
+
+
+class Device_Groups(Collection):
+    def __init__(self, cm):
+        super(Device_Groups, self).__init__(cm)
+        endpoint = 'device-group'
+        self._meta_data['uri'] =\
+            self._meta_data['container']._meta_data['uri'] + endpoint + '/'
+        self._meta_data['allowed_lazy_attributes'] = [Device_Group]
+        self._meta_data['attribute_registry'] =\
+            {'tm:cm:device:device-groupstate': Device_Group}
+
+
+class Device_Group(Resource):
+    def __init__(self, device_groups):
+        super(Device_Group, self).__init__(device_groups)
+        self._meta_data['read_only_attributes'].append('type')
+        self._meta_data['required_creation_parameters'].update(('partition',))
+        self._meta_data['required_json_kind'] =\
+            'tm:cm:device-group:device-groupstate'
+        self._meta_data['attribute_registry'] = {
+            'tm:cm:device-group:devices:devicescollectionstate': Devices_s
+        }
+
+
+class Devices_s(Collection):
+    def __init__(self, device_group):
+        super(Devices_s, self).__init__(device_group)
+        self._meta_data['allowed_lazy_attributes'] = [Devices]
+        self._meta_data['required_json_kind'] =\
+            'tm:cm:device-group:devices:devicescollectionstate'
+        self._meta_data['attribute_registry'] =\
+            {'tm:cm:device-group:devices:devicesstate': Devices}
+
+
+class Devices(Resource):
+    def __init__(self, devices_s):
+        super(Devices, self).__init__(devices_s)
+        self._meta_data['required_json_kind'] =\
+            'tm:cm:device-group:devices:devicesstate'
+        self._meta_data['required_creation_parameters'].update(('partition',))

--- a/f5/bigip/cm/traffic_group.py
+++ b/f5/bigip/cm/traffic_group.py
@@ -1,0 +1,36 @@
+# Copyright 2016 F5 Networks Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+from f5.bigip.resource import Collection
+from f5.bigip.resource import Resource
+
+
+class Traffic_Groups(Collection):
+    def __init__(self, cm):
+        super(Traffic_Groups, self).__init__(cm)
+        endpoint = 'traffic-group'
+        self._meta_data['uri'] =\
+            self._meta_data['container']._meta_data['uri'] + endpoint + '/'
+        self._meta_data['allowed_lazy_attributes'] = [Traffic_Group]
+        self._meta_data['attribute_registry'] =\
+            {'tm:cm:traffic-group:traffic-groupstate': Traffic_Group}
+
+
+class Traffic_Group(Resource):
+    def __init__(self, traffic_groups):
+        super(Traffic_Group, self).__init__(traffic_groups)
+        self._meta_data['required_json_kind'] =\
+            'tm:cm:traffic-group:traffic-groupstate'
+        self._meta_data['required_creation_parameters'].update(('partition',))

--- a/f5/bigip/mixins.py
+++ b/f5/bigip/mixins.py
@@ -108,3 +108,52 @@ class ExclusiveAttributesMixin(object):
                     [self.__dict__.pop(n, '') for n in new_set]
         # Now set the attribute
         super(ExclusiveAttributesMixin, self).__setattr__(key, value)
+
+
+class UnnamedResourceMixin(object):
+    '''This makes a resource object work if there is no name.
+
+    These objects do not support create or delete and are often found
+    as Resources that are under an organizing collection.  For example
+    the `mgmt/tm/sys/global-settings` is one of these and has a kind of
+    `tm:sys:global-settings:global-settingsstate` and the URI does not
+    match the kind.
+    '''
+    class UnsupportedMethod(Exception):
+        pass
+
+    def create(self, **kwargs):
+        '''Create is not supported for unnamed resources
+
+        :raises: UnsupportedOperation
+        '''
+        raise self.UnsupportedMethod(
+            "%s does not support the create method" % self.__class__.__name__
+        )
+
+    def delete(self, **kwargs):
+        '''Delete is not supported for unnamed resources
+
+        :raises: UnsupportedOperation
+        '''
+        raise self.UnsupportedMethod(
+            "%s does not support the delete method" % self.__class__.__name__
+        )
+
+    def load(self, **kwargs):
+        return self._load(**kwargs)
+
+    def _load(self, **kwargs):
+        '''Override _load because Unnamed Resources use their uri directly.
+
+        The Unnamed resources don't have URIs that match their kinds so
+        we need to use their URI directly instead of the container's URI
+        with name/partitions.
+        '''
+        self._check_load_parameters(**kwargs)
+        kwargs['uri_as_parts'] = True
+        read_session = self._meta_data['bigip']._meta_data['icr_session']
+        base_uri = self._meta_data['uri']
+        response = read_session.get(base_uri, **kwargs)
+        self._local_update(response.json())
+        return self

--- a/f5/bigip/net/arp.py
+++ b/f5/bigip/net/arp.py
@@ -1,4 +1,4 @@
-# Copyright 2014-2015 F5 Networks Inc.
+# Copyright 2016 F5 Networks Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -17,17 +17,20 @@ from f5.bigip.resource import Collection
 from f5.bigip.resource import Resource
 
 
-class Rules(Collection):
-    def __init__(self, ltm):
-        super(Rules, self).__init__(ltm)
-        self._meta_data['allowed_lazy_attributes'] = [Rule]
-        self._meta_data['attribute_registry'] =\
-            {'tm:ltm:rule:rulestate': Rule}
+class Arps(Collection):
+    def __init__(self, net):
+        super(Arps, self).__init__(net)
+        self._meta_data['allowed_lazy_attributes'] = [Arp]
+        self._meta_data['attribute_registry'] = {
+            'tm:net:arp:arpstate': Arp
+        }
 
 
-class Rule(Resource):
-    def __init__(self, rule_s):
-        super(Rule, self).__init__(rule_s)
-        self._meta_data['required_json_kind'] = 'tm:ltm:rule:rulestate'
+class Arp(Resource):
+    def __init__(self, arp_s):
+        super(Arp, self).__init__(arp_s)
+        self._meta_data['required_json_kind'] = 'tm:net:arp:arpstate'
         self._meta_data['required_creation_parameters'].update(
-            ('name', 'partition', 'apiAnonymous'))
+            ('partition', 'name', 'ipAddress', 'macAddress')
+        )
+        self._meta_data['read_only_attributes'].append('ipAddress')

--- a/f5/bigip/net/route.py
+++ b/f5/bigip/net/route.py
@@ -1,0 +1,59 @@
+# Copyright 2016 F5 Networks Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+from f5.bigip.mixins import ExclusiveAttributesMixin
+from f5.bigip.resource import Collection
+from f5.bigip.resource import MissingRequiredCreationParameter
+from f5.bigip.resource import Resource
+
+
+class Routes(Collection):
+    def __init__(self, net):
+        super(Routes, self).__init__(net)
+        self._meta_data['allowed_lazy_attributes'] = [Route]
+        self._meta_data['attribute_registry'] = {
+            'tm:net:route:routestate': Route
+        }
+
+
+class Route(Resource, ExclusiveAttributesMixin):
+    def __init__(self, route_s):
+        super(Route, self).__init__(route_s)
+        self._meta_data['required_json_kind'] = 'tm:net:route:routestate'
+        self._meta_data['read_only_attributes'].append('network')
+        self._meta_data['required_creation_parameters'].update(
+            ('partition', 'name', 'network'))
+        self._meta_data['exclusive_attributes'].append(
+            ('blackhole', 'gw', 'tmInterface', 'pool'))
+
+    def create(self, **kwargs):
+        '''Create a Route on the BigIP and the associated python object.
+
+        :params kwargs: keyword arguments passed in from create call
+        :raises: KindTypeMismatch
+        :raises: MissingRequiredCreationParameter
+        :raises: HTTPError
+        :returns: Python Route object
+        '''
+        # We need to check that we have one of the available gateways set
+        # when we create.  This isn't exactly the same as
+        # required_creation_parameters because it needs to be one of the
+        # gateways in the list.
+        gateways = ['blackhole', 'gw', 'tmInterface', 'pool']
+        if not [k for k in kwargs.keys() if k in gateways]:
+            raise MissingRequiredCreationParameter(
+                "One of %s gateways is required." % gateways
+            )
+        return self._create(**kwargs)

--- a/f5/bigip/net/test/test_interface.py
+++ b/f5/bigip/net/test/test_interface.py
@@ -1,0 +1,38 @@
+# Copyright 2016 F5 Networks Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import mock
+import pytest
+
+from f5.bigip.net.interface import Interface
+from f5.bigip.resource import UnsupportedOperation
+
+
+@pytest.fixture
+def FakeInterface():
+    fake_interface_s = mock.MagicMock()
+    return Interface(fake_interface_s)
+
+
+class TestInterface(object):
+    def test_create_raises(self):
+        with pytest.raises(UnsupportedOperation):
+            i = FakeInterface()
+            i.create(name='1.1')
+
+    def test_delete_raises(self):
+        with pytest.raises(UnsupportedOperation):
+            i = FakeInterface()
+            i.delete()

--- a/f5/bigip/net/tunnels.py
+++ b/f5/bigip/net/tunnels.py
@@ -1,0 +1,75 @@
+# Copyright 2016 F5 Networks Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+from f5.bigip.resource import Collection
+from f5.bigip.resource import Resource
+
+
+class Tunnels_s(Collection):
+    def __init__(self, net):
+        super(Tunnels_s, self).__init__(net)
+        self._meta_data['allowed_lazy_attributes'] = [
+            Gres,
+            Tunnels,
+            Vxlans,
+        ]
+
+
+class Tunnels(Collection):
+    def __init__(self, tunnels_s):
+        super(Tunnels, self).__init__(tunnels_s)
+        self._meta_data['allowed_lazy_attributes'] = [Gres, Tunnel, Vxlans]
+        self._meta_data['attribute_registry'] =\
+            {'tm:net:tunnels:tunnel:tunnelstate': Tunnel}
+
+
+class Tunnel(Resource):
+    def __init__(self, tunnels):
+        super(Tunnel, self).__init__(tunnels)
+        self._meta_data['required_creation_parameters'].update(('partition',))
+        self._meta_data['required_json_kind'] =\
+            'tm:net:tunnels:tunnel:tunnelstate'
+
+
+class Gres(Collection):
+    def __init__(self, tunnels_s):
+        super(Gres, self).__init__(tunnels_s)
+        self._meta_data['allowed_lazy_attributes'] = [Gre]
+        self._meta_data['attribute_registry'] =\
+            {'tm:net:tunnels:gre:grestate': Gre}
+
+
+class Gre(Resource):
+    def __init__(self, gres):
+        super(Gre, self).__init__(gres)
+        self._meta_data['required_creation_parameters'].update(('partition',))
+        self._meta_data['required_json_kind'] =\
+            'tm:net:tunnels:gre:grestate'
+
+
+class Vxlans(Collection):
+    def __init__(self, tunnels_s):
+        super(Vxlans, self).__init__(tunnels_s)
+        self._meta_data['allowed_lazy_attributes'] = [Vxlan]
+        self._meta_data['attribute_registry'] =\
+            {'tm:net:tunnels:vxlan:vxlanstate': Vxlan}
+
+
+class Vxlan(Resource):
+    def __init__(self, vxlans):
+        super(Vxlan, self).__init__(vxlans)
+        self._meta_data['required_creation_parameters'].update(('partition',))
+        self._meta_data['required_json_kind'] =\
+            'tm:net:tunnels:vxlan:vxlanstate'

--- a/f5/bigip/resource.py
+++ b/f5/bigip/resource.py
@@ -621,8 +621,11 @@ class Resource(ResourceBase):
         # when it fails
         for attr in read_only:
             data_dict.pop(attr, '')
+
+        # Remove params so you can pass it to put
+        params = kwargs.pop('params', {})
         data_dict.update(kwargs)
-        response = session.put(update_uri, json=data_dict)
+        response = session.put(update_uri, json=data_dict, params=params)
         self._meta_data = temp_meta
         self._local_update(response.json())
 

--- a/f5/bigip/sys/__init__.py
+++ b/f5/bigip/sys/__init__.py
@@ -16,12 +16,22 @@
 from f5.bigip.resource import OrganizingCollection
 from f5.bigip.sys.application import Applications
 from f5.bigip.sys.db import Dbs
+from f5.bigip.sys.failover import Failover
 from f5.bigip.sys.folder import Folders
+from f5.bigip.sys.global_settings import Global_Settings
+from f5.bigip.sys.ntp import Ntp
+from f5.bigip.sys.performance import Performance
 
 
 class Sys(OrganizingCollection):
     def __init__(self, bigip):
         super(Sys, self).__init__(bigip)
         self._meta_data['allowed_lazy_attributes'] = [
-            Folders, Applications, Dbs
+            Folders,
+            Applications,
+            Performance,
+            Dbs,
+            Global_Settings,
+            Ntp,
+            Failover,
         ]

--- a/f5/bigip/sys/db.py
+++ b/f5/bigip/sys/db.py
@@ -32,16 +32,28 @@ class Db(Resource):
         self._meta_data['required_json_kind'] = 'tm:sys:db:dbstate'
 
     def create(self, **kwargs):
+        '''Create is not supported for db resources.
+
+        :raises: UnsupportedOperation
+        '''
         raise UnsupportedOperation(
             "DB resources doesn't support create, only load and refresh"
         )
 
     def update(self, **kwargs):
+        '''Update is not supported for db resources.
+
+        :raises: UnsupportedOperation
+        '''
         raise UnsupportedOperation(
             "DB resources doesn't support update, only load and refresh"
         )
 
     def delete(self, **kwargs):
+        '''Delete is not supported for db resources.
+
+        :raises: UnsupportedOperation
+        '''
         raise UnsupportedOperation(
             "DB resources doesn't support delete, only load and refresh"
         )

--- a/f5/bigip/sys/failover.py
+++ b/f5/bigip/sys/failover.py
@@ -1,0 +1,37 @@
+# Copyright 2016 F5 Networks Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+from f5.bigip.mixins import UnnamedResourceMixin
+from f5.bigip.resource import Resource
+
+
+class Failover(UnnamedResourceMixin, Resource):
+    '''Failover stats and state change.
+
+    The failover object only supports load and update because it is an
+    unnamed resource.
+
+    To force the unit to standby call the `update()` method as follows:
+
+    ``f.update(command='run', standby=None, trafficGroup='mytrafficgroup')``
+    '''
+    def __init__(self, sys):
+        super(Failover, self).__init__(sys)
+        endpoint = self.__class__.__name__.lower()
+        self._meta_data['required_refresh_parameters'] = set()
+        self._meta_data['required_json_kind'] =\
+            'tm:sys:failover:failoverstats'
+        self._meta_data['uri'] =\
+            self._meta_data['container']._meta_data['uri'] + endpoint + '/'

--- a/f5/bigip/sys/global_settings.py
+++ b/f5/bigip/sys/global_settings.py
@@ -1,0 +1,28 @@
+# Copyright 2016 F5 Networks Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+from f5.bigip.mixins import UnnamedResourceMixin
+from f5.bigip.resource import Resource
+
+
+class Global_Settings(UnnamedResourceMixin, Resource):
+    def __init__(self, sys):
+        super(Global_Settings, self).__init__(sys)
+        endpoint = self.__class__.__name__.lower().replace('_', '-')
+        self._meta_data['required_refresh_parameters'] = set()
+        self._meta_data['required_json_kind'] =\
+            'tm:sys:global-settings:global-settingsstate'
+        self._meta_data['uri'] =\
+            self._meta_data['container']._meta_data['uri'] + endpoint + '/'

--- a/f5/bigip/sys/ntp.py
+++ b/f5/bigip/sys/ntp.py
@@ -1,0 +1,48 @@
+# Copyright 2016 F5 Networks Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+
+from f5.bigip.mixins import UnnamedResourceMixin
+from f5.bigip.resource import Collection
+from f5.bigip.resource import Resource
+
+
+class Ntp(UnnamedResourceMixin, Resource):
+    def __init__(self, sys):
+        super(Ntp, self).__init__(sys)
+        endpoint = self.__class__.__name__.lower()
+        self._meta_data['required_refresh_parameters'] = set()
+        self._meta_data['required_json_kind'] = 'tm:sys:ntp:ntpstate'
+        self._meta_data['uri'] =\
+            self._meta_data['container']._meta_data['uri'] + endpoint + '/'
+        self._meta_data['attribute_registry'] = {
+            'tm:sys:ntp:restrict:restrictcollectionstate': Restricts
+        }
+
+
+class Restricts(Collection):
+    def __init__(self, ntp):
+        super(Restricts, self).__init__(ntp)
+        self._meta_data['allowed_lazy_attributes'] = [Restrict]
+        self._meta_data['required_json_kind'] =\
+            'tm:sys:ntp:restrict:restrictcollectionstate'
+        self._meta_data['attribute_registry'] =\
+            {'tm:sys:ntp:restrict:restrictstate': Restrict}
+
+
+class Restrict(Resource):
+    def __init__(self, restricts):
+        super(Restrict, self).__init__(restricts)
+        self._meta_data['required_json_kind'] =\
+            'tm:sys:ntp:restrict:restrictstate'

--- a/f5/bigip/sys/performance.py
+++ b/f5/bigip/sys/performance.py
@@ -1,0 +1,55 @@
+# Copyright 2016 F5 Networks Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+from f5.bigip.mixins import UnnamedResourceMixin
+from f5.bigip.resource import Collection
+from f5.bigip.resource import Resource
+from f5.bigip.resource import UnsupportedOperation
+
+
+class Performance(Collection):
+    def __init__(self, sys):
+        super(Performance, self).__init__(sys)
+        self._meta_data['allowed_lazy_attributes'] = [All_Stats]
+        self._meta_data['uri'] =\
+            self._meta_data['container']._meta_data['uri'] + "performance/"
+
+    def get_collection(self):
+        '''Performance collections are not proper BigIP collection objects.
+
+        :raises: UnsupportedOperation
+        '''
+        raise UnsupportedOperation(
+            "The iControl REST URI mgmt/sys/performance/ does not respond " +
+            "GET requests."
+        )
+
+
+class All_Stats(UnnamedResourceMixin, Resource):
+    def __init__(self, performance):
+        super(All_Stats, self).__init__(performance)
+        self._meta_data['required_refresh_parameters'] = set()
+        self._meta_data['required_json_kind'] =\
+            'tm:sys:performance:all-stats:all-statsstats'
+        self._meta_data['uri'] =\
+            self._meta_data['container']._meta_data['uri'] + "all-stats/"
+
+    def update(self, **kwargs):
+        '''Update is not supported for statistics.
+
+        :raises: UnsupportedOperation
+        '''
+        raise UnsupportedOperation(
+            'Stats do not support create, only load and refresh')

--- a/f5/bigip/sys/test/test_performance.py
+++ b/f5/bigip/sys/test/test_performance.py
@@ -1,0 +1,54 @@
+# Copyright 2016 F5 Networks Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import mock
+import pytest
+
+from f5.bigip.mixins import UnnamedResourceMixin
+from f5.bigip.resource import UnsupportedOperation
+from f5.bigip.sys.performance import Performance
+
+
+@pytest.fixture
+def FakePerformance():
+    fake_sys = mock.MagicMock()
+    return Performance(fake_sys)
+
+
+class TestPerformance(object):
+    def test_get_collection_raises(self):
+        perf = FakePerformance()
+        with pytest.raises(UnsupportedOperation):
+            perf.get_collection()
+
+
+class TestAllStats(object):
+    def test_create_raises(self):
+        perf = FakePerformance()
+        allstats = perf.all_stats
+        with pytest.raises(UnnamedResourceMixin.UnsupportedMethod):
+            allstats.create()
+
+    def test_update_raises(self):
+        perf = FakePerformance()
+        allstats = perf.all_stats
+        with pytest.raises(UnsupportedOperation):
+            allstats.update()
+
+    def test_delete_raises(self):
+        perf = FakePerformance()
+        allstats = perf.all_stats
+        with pytest.raises(UnnamedResourceMixin.UnsupportedMethod):
+            allstats.delete()

--- a/f5/bigip/test/test_mixins.py
+++ b/f5/bigip/test/test_mixins.py
@@ -13,8 +13,10 @@
 # limitations under the License.
 #
 import json
+import pytest
 
 from f5.bigip.mixins import ToDictMixin
+from f5.bigip.mixins import UnnamedResourceMixin
 
 
 class MixinTestClass(ToDictMixin):
@@ -101,3 +103,15 @@ def test_TestClass_Basic():
     TDMAttrObj.y = TestClass()
     mtc_as_dict = TDMAttrObj.to_dict()
     assert json.dumps(mtc_as_dict) == '{"y": {"test_attribute": 42}}'
+
+
+class TestUnnamedResourceMixin(object):
+    def test_create_raises(self):
+        unnamed_resource = UnnamedResourceMixin()
+        with pytest.raises(UnnamedResourceMixin.UnsupportedMethod):
+            unnamed_resource.create()
+
+    def test_delete_raises(self):
+        unnamed_resource = UnnamedResourceMixin()
+        with pytest.raises(UnnamedResourceMixin.UnsupportedMethod):
+            unnamed_resource.create()

--- a/test/functional/cm/test_device.py
+++ b/test/functional/cm/test_device.py
@@ -1,0 +1,65 @@
+# Copyright 2016 F5 Networks Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+from requests import HTTPError
+
+TEST_DESCR = "TEST DESCRIPTION"
+
+
+def setup_device_test(request, bigip, name, partition, **kwargs):
+    def teardown():
+        try:
+            d.delete()
+        except HTTPError as err:
+            if err.response.status_code is not 404:
+                raise
+    request.addfinalizer(teardown)
+    d = bigip.cm.devices.device.create(
+        name=name, partition=partition, **kwargs)
+    return d
+
+
+class TestDevices(object):
+    def test_device_list(self, bigip):
+        devices = bigip.cm.devices.get_collection()
+        assert len(devices)
+        assert devices[0].generation > 0
+        assert hasattr(devices[0], 'hostname')
+
+
+class TestDevice(object):
+    def test_device_CURDL(self, request, bigip):
+        # Create and Delete are done by setup/teardown
+        d1 = setup_device_test(
+            request, bigip, 'test-device', 'Common', hostname='test')
+        assert d1.generation > 0
+
+        # Load
+        d2 = bigip.cm.devices.device.load(
+            name=d1.name, partition=d1.partition)
+        assert d1.hostname == d2.hostname
+        assert d1.generation == d2.generation
+
+        # Update
+        d1.description = TEST_DESCR
+        d1.update()
+        assert d1.description == TEST_DESCR
+        assert not hasattr(d2, 'description')
+        assert d1.generation != d2.generation
+
+        # Refresh
+        d2.refresh()
+        assert d2.description == TEST_DESCR
+        assert d1.generation == d2.generation

--- a/test/functional/cm/test_device_group.py
+++ b/test/functional/cm/test_device_group.py
@@ -1,0 +1,70 @@
+# Copyright 2016 F5 Networks Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+from requests import HTTPError
+
+
+TEST_DESCR = "TEST DESCRIPTION"
+
+
+def setup_device_group_test(request, bigip, name, partition):
+    def teardown():
+        try:
+            for d in dg.devices_s.get_collection():
+                d.delete()
+            dg.delete()
+        except HTTPError as err:
+            if err.response.status_code != 404:
+                raise
+    request.addfinalizer(teardown)
+
+    dgs = bigip.cm.device_groups
+    dg = dgs.device_group
+    dg.create(name=name, partition=partition)
+    return dg, dgs
+
+
+class TestDeviceGroup(object):
+    def test_device_group_CURDL(self, request, bigip):
+        # Create and delete are taken care of by setup
+        dg1, dgs = setup_device_group_test(
+            request, bigip, name='test-device-group', partition='Common')
+        assert dg1.generation > 0
+        assert dg1.name == 'test-device-group'
+
+        # Load
+        dg2 = bigip.cm.device_groups.device_group.load(
+            name=dg1.name, partition=dg1.partition)
+        assert dg1.generation == dg2.generation
+
+        # Update
+        dg1.update(description=TEST_DESCR)
+        assert dg1.generation > dg2.generation
+        assert dg1.description == TEST_DESCR
+
+        # Refresh
+        dg2.refresh()
+        assert dg1.generation == dg2.generation
+        assert dg2.description == TEST_DESCR
+
+    def test_add_device(self, request, bigip):
+        dg1, dgs = setup_device_group_test(
+            request, bigip, name='test-group', partition='Common')
+        devices = bigip.cm.devices.get_collection()
+        this_device = devices[0]
+        d1 = dg1.devices_s.devices.create(
+            name=this_device.name, partition=this_device.partition)
+        assert len(dg1.devices_s.get_collection()) == 1
+        assert d1.name == this_device.name

--- a/test/functional/cm/test_traffic_group.py
+++ b/test/functional/cm/test_traffic_group.py
@@ -1,0 +1,64 @@
+# Copyright 2016 F5 Networks Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+from requests import HTTPError
+
+TEST_DESCR = "TEST DESCRIPTION"
+
+
+def setup_traffic_group_test(request, bigip, name, partition, **kwargs):
+    def teardown():
+        try:
+            tg.delete()
+        except HTTPError as err:
+            if err.response.status_code is not 404:
+                raise
+    request.addfinalizer(teardown)
+    tg = bigip.cm.traffic_groups.traffic_group.create(
+        name=name, partition=partition, **kwargs)
+    return tg
+
+
+class TestTrafficGroups(object):
+    def test_device_list(self, bigip):
+        groups = bigip.cm.traffic_groups.get_collection()
+        assert len(groups)
+        assert groups[0].generation > 0
+        assert hasattr(groups[0], 'mac')
+
+
+class TestDevice(object):
+    def test_device_CURDL(self, request, bigip):
+        # Create and Delete are done by setup/teardown
+        tg1 = setup_traffic_group_test(
+            request, bigip, 'test-tg', 'Common')
+        assert tg1.generation > 0
+
+        # Load
+        tg2 = bigip.cm.traffic_groups.traffic_group.load(
+            name=tg1.name, partition=tg1.partition)
+        assert tg1.generation == tg2.generation
+
+        # Update
+        tg1.description = TEST_DESCR
+        tg1.update()
+        assert tg1.description == TEST_DESCR
+        assert not hasattr(tg2, 'description')
+        assert tg1.generation > tg2.generation
+
+        # Refresh
+        tg2.refresh()
+        assert tg2.description == TEST_DESCR
+        assert tg1.generation == tg2.generation

--- a/test/functional/net/test_arp.py
+++ b/test/functional/net/test_arp.py
@@ -1,0 +1,72 @@
+# Copyright 2016 F5 Networks Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import pytest
+
+from f5.bigip.resource import MissingRequiredCreationParameter
+from requests.exceptions import HTTPError
+
+
+TEST_IP = '192.168.98.100'
+TEST_MAC = '02:00:00:00:00:01'
+
+
+def delete_resource(resources):
+    for resource in resources.get_collection():
+        try:
+            resource.delete()
+        except HTTPError as err:
+            if err.response.status_code != 404:
+                raise
+
+
+def setup_arp_test(request, bigip, partition, name, ip, mac):
+    def teardown():
+        delete_resource(ac1)
+    request.addfinalizer(teardown)
+
+    ac1 = bigip.net.arps
+    a1 = ac1.arp
+    a1.create(partition=partition, name=name, ipAddress=ip, macAddress=mac)
+    return a1, ac1
+
+
+class TestArp(object):
+    def test_create_missing_args(self, request, bigip):
+        a = bigip.net.arps.arp
+        with pytest.raises(MissingRequiredCreationParameter):
+            a.create(name='s1', partition='Common')
+
+    def test_CURDL(self, request, bigip):
+        # We assume that setup and teardown will create/delete
+        name = 'arp_test'
+        partition = 'Common'
+        a1, ac1 = setup_arp_test(
+            request, bigip, partition, name, TEST_IP, TEST_MAC)
+        a2 = bigip.net.arps.arp
+        a2.load(name=name, partition=partition)
+        assert a1.name == name
+        assert a1.ipAddress == TEST_IP
+        assert a1.macAddress == TEST_MAC
+        assert a1.name == a2.name
+        assert a1.generation == a2.generation
+
+        a1.macAddress = '02:00:00:00:00:02'
+        a1.update()
+        assert a1.macAddress != a2.macAddress
+
+        a2.refresh()
+        assert a1.macAddress == a2.macAddress
+        assert a1.generation == a2.generation

--- a/test/functional/net/test_interface.py
+++ b/test/functional/net/test_interface.py
@@ -1,0 +1,53 @@
+# Copyright 2016 F5 Networks Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+
+def cleanup_test(request, bigip):
+    def teardown():
+        for ifc in bigip.net.interfaces.get_collection():
+            ifc.enabled = True
+            ifc.update()
+    request.addfinalizer(teardown)
+
+
+class TestInterfaces(object):
+    def test_interfaces_list(self, bigip):
+        ifcs = bigip.net.interfaces.get_collection()
+        assert len(ifcs)
+        for ifc in ifcs:
+            assert ifc.generation
+
+
+class TestInterface(object):
+    def test_RUL(self, request, bigip):
+        cleanup_test(request, bigip)
+        # We can't create or delete interfaces so we will load them to start
+        ifc1 = bigip.net.interfaces.interface.load(name='1.1')
+        ifc2 = bigip.net.interfaces.interface.load(name='1.1')
+        assert ifc1.generation == ifc2.generation
+        assert ifc1.name == ifc2.name
+
+        # Update by disabling the interface
+        ifc1.disabled = True
+        ifc1.update()
+        assert ifc1.disabled is True
+        assert not hasattr(ifc1, 'enabled')
+        assert ifc1.generation != ifc2.generation
+
+        # Refresh ifc2
+        ifc2.refresh()
+        assert ifc2.disabled is True
+        assert not hasattr(ifc2, 'enabled')
+        assert ifc1.generation == ifc2.generation

--- a/test/functional/net/test_route.py
+++ b/test/functional/net/test_route.py
@@ -1,0 +1,97 @@
+# Copyright 2016 F5 Networks Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import pytest
+
+from f5.bigip.resource import MissingRequiredCreationParameter
+
+POOL_NAME = "route-pool"
+VLAN_NAME = "route-vlan"
+SELF_NAME = "route-self"
+SELF_IP = "192.168.100.1/24"
+GW_IP = "192.168.100.254"
+
+
+def delete_resource(resources):
+    for resource in resources.get_collection():
+        resource.delete()
+
+
+def setup_route_test(request, bigip, partition, name, network):
+    def teardown():
+        delete_resource(routes)
+        delete_resource(pools)
+        delete_resource(selfips)
+        delete_resource(vlans)
+    request.addfinalizer(teardown)
+
+    # Need to create a VLAN interface, Pool and SelfIP for testing gateways
+    pools = bigip.ltm.pools
+    pools.pool.create(partition='Common', name=POOL_NAME)
+
+    vlans = bigip.net.vlans
+    vlans.vlan.create(partition=partition, name=VLAN_NAME)
+
+    selfips = bigip.net.selfips
+    selfips.selfip.create(partition=partition, name=name,
+                          address=SELF_IP, vlan=VLAN_NAME)
+
+    routes = bigip.net.routes
+    route = routes.route.create(partition=partition, name=name,
+                                network=network, blackhole=True)
+    return route, routes
+
+
+class TestRoute(object):
+    def test_missing_create_param(self, bigip):
+        # Test that the gw types raise an error
+        with pytest.raises(MissingRequiredCreationParameter):
+            bigip.net.routes.route.create(
+                partition='Common', name='test-route',
+                network='192.168.1.1/32'
+            )
+        # Test that the other required args raise an error
+        with pytest.raises(MissingRequiredCreationParameter):
+            bigip.net.routes.route.create(
+                name='test-route', network='192.168.1.1/32', gw='192.168.1.1')
+
+    def test_CURDL(self, request, bigip):
+        partition = 'Common'
+        name = 'test-route'
+        network = '192.168.90.0/24'
+
+        # We assume that setup and teardown will create/delete
+        r1, rc1 = setup_route_test(request, bigip, partition, name, network)
+        r2 = rc1.route.load(partition=partition, name=name)
+        assert r1.name == name
+        assert r1.partition == partition
+        assert r1.network == network
+        assert r1.blackhole is True
+        assert r2.name == r1.name
+        assert r2.generation == r1.generation
+
+        r1.pool = '/%s/%s' % (partition, POOL_NAME)
+        r1.update()
+        assert r1.generation > r2.generation
+
+        r2.refresh()
+        assert r1.generation == r2.generation
+        assert r1.pool == r2.pool
+
+        # Test the other gw types
+        r1.tmInterface = "/%s/%s" % (partition, VLAN_NAME)
+        r1.update()
+        r1.gw = GW_IP
+        r1.update()

--- a/test/functional/net/test_tunnels.py
+++ b/test/functional/net/test_tunnels.py
@@ -1,0 +1,140 @@
+# Copyright 2016 F5 Networks Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+from requests.exceptions import HTTPError
+
+
+TEST_DESCR = "TEST DESCRIPTION"
+
+
+def delete_resource(resource):
+    try:
+        resource.delete()
+    except HTTPError as err:
+        if err.response.status_code != 404:
+            raise
+
+
+def setup_tunnel_test(request, bigip, name, partition, ip, profile):
+    def teardown():
+        delete_resource(tunnel)
+    request.addfinalizer(teardown)
+
+    tunnel = bigip.net.tunnels_s.tunnels.tunnel.create(
+        name=name, partition=partition, localAddress=ip, profile=profile)
+    return tunnel
+
+
+def setup_gre_test(request, bigip, name, partition):
+    def teardown():
+        delete_resource(gre)
+    request.addfinalizer(teardown)
+
+    gre = bigip.net.tunnels_s.gres.gre.create(
+        name=name, partition=partition)
+    return gre
+
+
+def setup_vxlan_test(request, bigip, name, partition):
+    def teardown():
+        delete_resource(vxlan)
+    request.addfinalizer(teardown)
+
+    vxlan = bigip.net.tunnels_s.vxlans.vxlan.create(
+        name=name, partition=partition)
+    return vxlan
+
+
+class TestTunnels(object):
+    def test_tunnel_list(self, bigip):
+        tunnels = bigip.net.tunnels_s.tunnels.get_collection()
+        assert len(tunnels)
+        for tunnel in tunnels:
+            assert tunnel.generation
+
+
+class TestTunnel(object):
+    def test_tunnel_CURDL(self, request, bigip):
+        # Create and Delete are tested by the setup/teardown
+        t1 = setup_tunnel_test(
+            request, bigip, 'tunnel-test', 'Common',
+            '192.168.1.1', '/Common/gre'
+        )
+
+        # Load
+        t2 = bigip.net.tunnels_s.tunnels.tunnel.load(
+            name='tunnel-test', partition='Common')
+        assert t1.name == 'tunnel-test'
+        assert t1.name == t2.name
+        assert t1.generation == t2.generation
+
+        # Update
+        t1.description = TEST_DESCR
+        t1.update()
+        assert t1.description == TEST_DESCR
+        assert t1.generation > t2.generation
+
+        # Refresh
+        t2.refresh()
+        assert t2.description == TEST_DESCR
+        assert t1.generation == t2.generation
+
+
+class TestGre(object):
+    def test_gre_CURDL(self, request, bigip):
+        # Create and Delete are tested by the setup/teardown
+        g1 = setup_gre_test(request, bigip, 'gre-test', 'Common')
+        assert g1.name == 'gre-test'
+
+        # Load
+        g2 = bigip.net.tunnels_s.gres.gre.load(
+            name='gre-test', partition='Common')
+        assert g1.name == g2.name
+        assert g1.generation == g2.generation
+
+        # Update
+        g1.description = TEST_DESCR
+        g1.update()
+        assert g1.description == TEST_DESCR
+        assert g1.generation > g2.generation
+
+        # Refresh
+        g2.refresh()
+        assert g2.description == g1.description
+        assert g2.generation == g1.generation
+
+
+class TestVxlan(object):
+    def test_vxlan_CURDL(self, request, bigip):
+        # Create and Delete are tested by the setup/teardown
+        vx1 = setup_vxlan_test(request, bigip, 'vxlan-test', 'Common')
+        assert vx1.name == 'vxlan-test'
+
+        # Load
+        vx2 = bigip.net.tunnels_s.vxlans.vxlan.load(
+            name='vxlan-test', partition='Common')
+        assert vx1.name == vx2.name
+        assert vx1.generation == vx2.generation
+
+        # Update
+        vx1.description = TEST_DESCR
+        vx1.update()
+        assert vx1.description == TEST_DESCR
+        assert vx1.generation > vx2.generation
+
+        # Refresh
+        vx2.refresh()
+        assert vx2.description == vx1.description
+        assert vx2.generation == vx1.generation

--- a/test/functional/sys/test_failover.py
+++ b/test/functional/sys/test_failover.py
@@ -1,0 +1,30 @@
+# Copyright 2016 F5 Networks Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+
+class TestFailover(object):
+    def test_failover_LR(self, bigip):
+        '''Test failover refresh and load.
+
+        Test that the failover object can be refreshed and loaded. The object
+        also supports update, but this will force a failover on the
+        device and this may have negative consequences to the device we
+        are using to test if it is not setup properly so I am not testing
+        it here.
+        '''
+        f = bigip.sys.failover.load()
+        assert f.apiRawValues['apiAnonymous'].startswith('Failover active')
+        f.refresh()
+        assert f.apiRawValues['apiAnonymous'].startswith('Failover active')

--- a/test/functional/sys/test_global_settings.py
+++ b/test/functional/sys/test_global_settings.py
@@ -1,0 +1,42 @@
+# Copyright 2016 F5 Networks Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+
+def set_global_settings_test(request, bigip):
+    def teardown():
+        gs.usernamePrompt = 'Username'
+        gs.update()
+    request.addfinalizer(teardown)
+    gs = bigip.sys.global_settings.load()
+    return gs
+
+
+class TestGlobal_Setting(object):
+    def test_RUL(self, request, bigip):
+        # Load
+        gs1 = set_global_settings_test(request, bigip)
+        gs2 = bigip.sys.global_settings.load()
+        assert gs1.usernamePrompt == 'Username'
+        assert gs1.usernamePrompt == gs2.usernamePrompt
+
+        # Update
+        gs1.usernamePrompt = 'User'
+        gs1.update()
+        assert gs1.usernamePrompt == 'User'
+        assert gs2.usernamePrompt == 'Username'
+
+        # Refresh
+        gs2.refresh()
+        assert gs1.usernamePrompt == gs2.usernamePrompt

--- a/test/functional/sys/test_ntp.py
+++ b/test/functional/sys/test_ntp.py
@@ -1,0 +1,43 @@
+# Copyright 2016 F5 Networks Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+
+
+def setup_ntp_test(request, bigip):
+    def teardown():
+        n.servers = servers
+        n.update()
+    request.addfinalizer(teardown)
+    n = bigip.sys.ntp.load()
+    servers = n.servers
+    return n, servers
+
+
+class TestGlobal_Setting(object):
+    def test_RUL(self, request, bigip):
+        # Load
+        ip = '192.168.1.1'
+        ntp1, orig_servers = setup_ntp_test(request, bigip)
+        ntp2 = bigip.sys.ntp.load()
+        assert len(ntp1.servers) == len(ntp2.servers)
+
+        # Update
+        ntp1.servers = [ip]
+        ntp1.update()
+        assert ip in ntp1.servers
+        assert ip not in ntp2.servers
+
+        # Refresh
+        ntp2.refresh()
+        assert ip in ntp2.servers

--- a/test/functional/sys/test_performance.py
+++ b/test/functional/sys/test_performance.py
@@ -1,0 +1,22 @@
+# Copyright 2016 F5 Networks Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+
+class TestAllStats(object):
+    def test_RL(self, bigip):
+        allstats = bigip.sys.performance.all_stats.load()
+        assert hasattr(allstats, 'apiRawValues')
+        allstats.refresh()
+        assert hasattr(allstats, 'apiRawValues')


### PR DESCRIPTION
@zancas @jlongstaf 

#### What issues does this address?
Fixes #197 

#### What's this change do?
We need to make sure that we support the objects that are needed by the various OpenStack projects that are in progress.  This change adds all of the objects that were being used via the REST API.

#### Where should the reviewer start?
These are the same patterns used for the other objects.  It should be pretty straight forward.  I added some unit tests for things that didn't need to go to the actual device.

Also there is one new mixin to deal with things that don't have a named URI.

#### Any background context?
There are a few things that the old library looks like it is doing with the SOAP API.  We will need to figure out where these go and add them in using REST if possible.

#### Tests
* Flake8
* New functional and unit tests
* Old functional and unit tests