### PR TITLE
RTD link in README is incorrect

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -39,7 +39,7 @@ Usage
 Documentation
 -------------
 
-Documentation is hosted on `Read the Docs <https://f5-python-sdk.readthedocs.org>`__
+Documentation is hosted on `Read the Docs <https://f5-sdk.readthedocs.org>`__
 
 Filing Issues
 -------------


### PR DESCRIPTION
@zancas 
Issues:
Fixes #204

Problem:
RTD link in README is incorrect.

Analysis:
* We took the 'python' out of the name on RTD and didn't update the docs.

Tests:
N/A