### PR TITLE
Template and Service resources in Applications should required partition

### DIFF
--- a/f5/bigip/sys/application.py
+++ b/f5/bigip/sys/application.py
@@ -73,7 +73,9 @@ class Services(Collection):
 class Service(Resource):
     def __init__(self, service_s):
         super(Service, self).__init__(service_s)
-        self._meta_data['required_creation_parameters'].update(('template',))
+        self._meta_data['required_creation_parameters'].update(
+            ('template', 'partition')
+        )
         self._meta_data['required_refresh_parameters'].update(('partition',))
         self._meta_data['required_json_kind'] =\
             'tm:sys:application:service:servicestate'
@@ -161,5 +163,7 @@ class Templates(Collection):
 class Template(Resource):
     def __init__(self, template_s):
         super(Template, self).__init__(template_s)
+        self._meta_data['required_creation_parameters'].update(('partition',))
+        self._meta_data['required_refresh_parameters'].update(('partition',))
         self._meta_data['required_json_kind'] =\
             'tm:sys:application:template:templatestate'

--- a/f5/bigip/sys/test/test_sys_application.py
+++ b/f5/bigip/sys/test/test_sys_application.py
@@ -153,11 +153,17 @@ class TestServiceCreate(object):
             FakeService.create()
         assert 'name' in ex.value.message
         assert 'template' in ex.value.message
+        assert 'partition' in ex.value.message
 
     def test_create_no_template(self, FakeService):
         with pytest.raises(MissingRequiredCreationParameter) as ex:
             FakeService.create(name='test_service')
         assert 'template' in ex.value.message
+
+    def test_create_no_partition(self, FakeService):
+        with pytest.raises(MissingRequiredCreationParameter) as ex:
+            FakeService.create(name='test_service', template='test_template')
+        assert 'partition' in ex.value.message
 
     def test_create_uri_collision(self, FakeService):
         FakeService._meta_data = {'uri': 'already_defined'}
@@ -265,6 +271,7 @@ class TestTemplateCreate(object):
         with pytest.raises(MissingRequiredCreationParameter) as ex:
             FakeTemplate.create()
         assert 'name' in ex.value.message
+        assert 'partition' in ex.value.message
 
 
 class TestAPLScript(object):

--- a/test/functional/sys/test_sys_application.py
+++ b/test/functional/sys/test_sys_application.py
@@ -127,7 +127,8 @@ class TestTemplate(object):
             templ_s,
             test_templ,
             'template',
-            name='test_template'
+            name='test_template',
+            partition='Common'
         )
 
 


### PR DESCRIPTION
@pjbreaux 

Take a look at the code I added because I assume you also want `partition` for the `template.load()` so I added it as a required refresh parameter.  Maybe this isn't right?

Also added unit and functional tests for the new arg.

Issues:
Fixes #200

Problem:
Partition should be requred for template and services for iApps when they are created instead
of letting the system add whatever partition it wants.

Analysis:
* Added 'partition' to the `self._meta_data['required_creation_args']`
* Added 'partitoin' to the `self._meta_data['required_refresh_args']`
* Added unit and functional tests to cover the new parameters.

Tests:
* Ran all functional tests
* Ran all unit tests