### PR TITLE
Sys folder should require subPath as a creation parameter #194

### DIFF
--- a/f5/bigip/sys/folder.py
+++ b/f5/bigip/sys/folder.py
@@ -40,6 +40,7 @@ class Folder(Resource):
         self._meta_data['required_json_kind'] = 'tm:sys:folder:folderstate'
         # refresh() and load() require partition, not name
         self._meta_data['required_refresh_parameters'] = set()
+        self._meta_data['required_creation_parameters'].update(('subPath',))
 
     def _load(self, **kwargs):
         name = kwargs.pop('name', '')

--- a/f5/bigip/sys/test/test_folder.py
+++ b/f5/bigip/sys/test/test_folder.py
@@ -1,0 +1,35 @@
+# Copyright 2016 F5 Networks Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import mock
+import pytest
+
+from f5.bigip.resource import MissingRequiredCreationParameter
+from f5.bigip.sys.folder import Folders
+
+
+@pytest.fixture
+def FakeFolders():
+    fake_sys = mock.MagicMock()
+    return Folders(fake_sys)
+
+
+class TestFolder(object):
+    def test_missing_create_args(self):
+        folders = FakeFolders()
+        folder = folders.folder
+        with pytest.raises(MissingRequiredCreationParameter) as ex:
+            folder.create(name='test_folder')
+            assert 'subPath' in ex.value.message


### PR DESCRIPTION
@pjbreaux 
Issues:
Fixes #194

Problem:
The subPath appears to be required when creating a sys folder on the BigIP. This parameter should be a `required_creation_parameter` for that resource.

Analysis:
* Added the subPath as a required creation parameter
* Added a unit test to test if it is missing.

Tests:
* Ran folder unit and functional tests