### PR TITLE
Update CLA landing page link

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -100,6 +100,6 @@ See the License for the specific language governing permissions and
 limitations under the License.
  
 ### Contributor License Agreement
-Individuals or business entities who contribute to this project must have completed and submitted the [F5 Contributor License Agreement](http://f5networks.github.io/f5-openstack-docs/cla_landing/index.html) to Openstack_CLA@f5.com prior to their
+Individuals or business entities who contribute to this project must have completed and submitted the [F5 Contributor License Agreement](http://f5-openstack-docs.readthedocs.org/en/latest/cla_landing.html) to Openstack_CLA@f5.com prior to their
 code submission being included in this project.
 

--- a/README.rst
+++ b/README.rst
@@ -170,7 +170,7 @@ Contributor License Agreement
 
 Individuals or business entities who contribute to this project must have
 completed and submitted the `F5 Contributor License Agreement
-<http://f5networks.github.io/f5-openstack-docs/cla_landing/index.html>`__
+<http://f5-openstack-docs.readthedocs.org/en/latest/cla_landing.html>`__
 to Openstack_CLA@f5.com prior to their code submission being included in this
 project.
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -76,7 +76,7 @@ Contributor License Agreement
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 Individuals or business entities who contribute to this project must have
 completed and submitted the `F5 Contributor License Agreement
-<http://f5networks.github.io/f5-openstack-docs/cla_landing/index.html>`__
+<http://f5-openstack-docs.readthedocs.org/en/latest/cla_landing.html>`__
 to Openstack_CLA@f5.com prior to their code submission being included in this
 project.
 


### PR DESCRIPTION
Fixes: #224 
@swormke 

#### What's this change do?
I did a search and replace to swap the old github.io URL with the new read the docs URL.

#### Where should the reviewer start?
Review the changes below.

#### Any background context?
