### PR TITLE
Create an exists() method for resource objects. #226

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -299,4 +299,6 @@ texinfo_documents = [
 
 
 # Example configuration for intersphinx: refer to the Python standard library.
-intersphinx_mapping = {'https://docs.python.org/': None}
+intersphinx_mapping = {
+    'requests': ('http://docs.python-requests.org/en/latest/', None)
+}

--- a/test/functional/ltm/test_node.py
+++ b/test/functional/ltm/test_node.py
@@ -38,7 +38,7 @@ class TestNode(object):
         with pytest.raises(MissingRequiredCreationParameter):
             n1.create(name="n1", partition='Common')
 
-    def test_CURDL(self, request, bigip):
+    def test_CURDLE(self, request, bigip):
         # We will assume that the setup/teardown will test create/delete
         n1, nc1 = setup_node_test(
             request, bigip, 'Common', 'node1', '192.168.100.1')
@@ -57,6 +57,11 @@ class TestNode(object):
         n2.refresh()
         assert n1.generation == n2.generation
         assert n2.description == n1.description
+
+        # Exists
+        assert bigip.ltm.nodes.node.exists(name='node1', partition='Common')
+        assert not bigip.ltm.nodes.node.exists(name='node2',
+                                               partition='Common')
 
 
 class TestNodes(object):


### PR DESCRIPTION
@zancas @jlongstaf 
Issues:
Fixes #226

Problem:
A very common thing for the projects using this SDK to do is to check
for the existence of an object. While this can be done by doing
something like using try/except to catch HTTPErrors on create and
then looking and the status code for 404 we can hide a lot of that
detail from the users with an exists() method.

Analysis:
* Added `exists()` method to the `Resource` base class.
* Added unit tests for 100% coverage of the new code
* Added a functional test to the nodes test to test on a live system.
* Added intersphinx config to link to the requests library.
* We don't want to do `load()` because we don't want to create the object so we are just doing a get to the device.

Tests:
* Ran unit tests
* Ran functional tests
* Ran flake8 tests