### PR TITLE
Allow users to pass requests_params to requests

### DIFF
--- a/f5/bigip/ltm/pool.py
+++ b/f5/bigip/ltm/pool.py
@@ -56,17 +56,17 @@ class Members_s(Collection):
     """BigIP LTM pool members sub-collection"""
     def __init__(self, pool):
         super(Members_s, self).__init__(pool)
-        self._meta_data['allowed_lazy_attributes'] = [Member]
+        self._meta_data['allowed_lazy_attributes'] = [Members]
         self._meta_data['required_json_kind'] =\
             'tm:ltm:pool:members:memberscollectionstate'
         self._meta_data['attribute_registry'] =\
-            {'tm:ltm:pool:members:membersstate': Member}
+            {'tm:ltm:pool:members:membersstate': Members}
 
 
-class Member(Resource):
+class Members(Resource):
     """BigIP LTM pool members sub-collection resource"""
-    def __init__(self, member_s):
-        super(Member, self).__init__(member_s)
+    def __init__(self, members_s):
+        super(Members, self).__init__(members_s)
         self._meta_data['required_json_kind'] =\
             'tm:ltm:pool:members:membersstate'
         self._meta_data['required_creation_parameters'].update(('partition',))

--- a/f5/bigip/resource.py
+++ b/f5/bigip/resource.py
@@ -573,6 +573,9 @@ class Resource(ResourceBase):
             query args, or hash fragments.
 
         :param kwargs: All the key-values needed to create the resource
+        NOTE: If kwargs has a 'requests_params' key the corresponding dict will
+        be passed to the underlying requests.session.post method where it will
+        be handled according to that API. THIS IS HOW TO PASS QUERY-ARGS!
         :returns: ``self`` - A python object that represents the object's
                   configuration and state on the BigIP.
 
@@ -605,6 +608,9 @@ class Resource(ResourceBase):
             this may, or may not, be true for a specific service.
 
         :param kwargs: typically contains "name" and "partition"
+        NOTE: If kwargs has a 'requests_params' key the corresponding dict will
+        be passed to the underlying requests.session.get method where it will
+        be handled according to that API. THIS IS HOW TO PASS QUERY-ARGS!
         :returns: a Resource Instance (with a populated _meta_data['uri'])
         """
         self._load(**kwargs)
@@ -675,6 +681,9 @@ class Resource(ResourceBase):
         * read-only attributes that are unchangeable are removed
 
         :param kwargs: keys and associated values to alter on the device
+        NOTE: If kwargs has a 'requests_params' key the corresponding dict will
+        be passed to the underlying requests.session.put method where it will
+        be handled according to that API. THIS IS HOW TO PASS QUERY-ARGS!
 
         """
         # Need to implement checking for valid params here.
@@ -702,6 +711,11 @@ class Resource(ResourceBase):
 
         After this method is called, and status_code 200 response is received
         ``instance.__dict__`` is replace with ``{'deleted': True}``
+
+        :param kwargs: The only current use is to pass kwargs to the requests
+        API. If kwargs has a 'requests_params' key the corresponding dict will
+        be passed to the underlying requests.session.delete method where it
+        will be handled according to that API. THIS IS HOW TO PASS QUERY-ARGS!
         """
         # Need to implement checking for ? here.
         self._delete(**kwargs)
@@ -718,7 +732,10 @@ class Resource(ResourceBase):
 
         For any other errors are raised as-is.
 
-        :param kwargs: Keyword arguments required to load objects
+        :param kwargs: Keyword arguments required to get objects
+        NOTE: If kwargs has a 'requests_params' key the corresponding dict will
+        be passed to the underlying requests.session.get method where it will
+        be handled according to that API. THIS IS HOW TO PASS QUERY-ARGS!
         :returns: bool -- The objects exists on BigIP or not.
         :raises: :exc:`requests.HTTPError`, Any HTTP error that was not status
                  code 404.

--- a/f5/bigip/sys/folder.py
+++ b/f5/bigip/sys/folder.py
@@ -111,7 +111,10 @@ class Folder(Resource):
         ``status_code`` is ``404``
         it will return error.  All other errors are raised as is.
 
-        :param kwargs: Keyword arguments required to load objects
+        :param kwargs: Keyword arguments required to get objects
+        NOTE: If kwargs has a 'requests_params' key the corresponding dict will
+        be passed to the underlying requests.session.get method where it will
+        be handled according to that API. THIS IS HOW TO PASS QUERY-ARGS!
         :returns: bool -- The objects exists on BigIP or not.
         :raises: :exc:`requests.HTTPError`, Any HTTP error that was not status
             code 404.

--- a/f5/bigip/sys/folder.py
+++ b/f5/bigip/sys/folder.py
@@ -27,6 +27,7 @@ REST Kind
 
 from f5.bigip.resource import Collection
 from f5.bigip.resource import Resource
+from requests.exceptions import HTTPError
 
 
 class Folders(Collection):
@@ -58,12 +59,10 @@ class Folder(Resource):
         self._meta_data['required_refresh_parameters'] = set()
         self._meta_data['required_creation_parameters'].update(('subPath',))
 
-    def _load(self, **kwargs):
+    def _create_subpath_uri(self, kwargs):
+        base_uri = self._meta_data['container']._meta_data['uri']
         name = kwargs.pop('name', '')
         partition = kwargs.pop('partition', '')
-        read_session = self._meta_data['bigip']._meta_data['icr_session']
-        base_uri = self._meta_data['container']._meta_data['uri']
-
         if not name and not partition:
             # Root folder - https://localhost/mgmt/tm/sys/folder/~
             load_uri = base_uri + '~'
@@ -78,7 +77,11 @@ class Folder(Resource):
             # https://localhost/mgmt/tm/sys/folder/~partition~f1~f2
             name = name.replace('/', '~')
             load_uri = base_uri + '~' + partition + '~' + name
+        return load_uri
 
+    def _load(self, **kwargs):
+        read_session = self._meta_data['bigip']._meta_data['icr_session']
+        load_uri = self._create_subpath_uri(kwargs)
         response = read_session.get(load_uri, uri_as_parts=False, **kwargs)
         self._local_update(response.json())
         self._activate_URI(self.selfLink)
@@ -98,3 +101,32 @@ class Folder(Resource):
         if inherit_device_group == 'true':
             self.__dict__.pop('deviceGroup')
         return self._update(**kwargs)
+
+    def exists(self, **kwargs):
+        """Check for the existence of the named object on the BigIP
+
+        Tries to `load()` the object and if it fails checks the exception
+        for 404.  If the `load()` is successful it returns `True` if the
+        exception is :exc:`requests.HTTPError` and the
+        ``status_code`` is ``404``
+        it will return error.  All other errors are raised as is.
+
+        :param kwargs: Keyword arguments required to load objects
+        :returns: bool -- The objects exists on BigIP or not.
+        :raises: :exc:`requests.HTTPError`, Any HTTP error that was not status
+            code 404.
+        """
+        requests_params = self._handle_requests_params(kwargs)
+        self._check_load_parameters(**kwargs)
+        load_uri = self._create_subpath_uri(kwargs)
+        session = self._meta_data['bigip']._meta_data['icr_session']
+        kwargs.update(requests_params)
+        try:
+            session.get(load_uri, **kwargs)
+        except HTTPError as err:
+            print(err.response.text)
+            if err.response.status_code == 404:
+                return False
+            else:
+                raise
+        return True

--- a/f5/bigip/test/test_resource.py
+++ b/f5/bigip/test/test_resource.py
@@ -25,6 +25,7 @@ from f5.bigip.resource import KindTypeMismatch
 from f5.bigip.resource import MissingRequiredCreationParameter
 from f5.bigip.resource import MissingRequiredReadParameter
 from f5.bigip.resource import OrganizingCollection
+from f5.bigip.resource import RequestParamKwargCollision
 from f5.bigip.resource import Resource
 from f5.bigip.resource import ResourceBase
 from f5.bigip.resource import UnregisteredKind
@@ -285,6 +286,15 @@ class TestResource_load(object):
             r.load(partition='Common', name='test_load')
         assert MRREIO.value.message ==\
             "Missing required params: set(['IMPOSSIBLE'])"
+
+    def test_requests_params_collision(self):
+        r = Resource(mock.MagicMock())
+        with pytest.raises(RequestParamKwargCollision) as RPKCEIO:
+            r.load(partition='Common', name='test_load',
+                   requests_params={'partition': 'ERROR'})
+        assert RPKCEIO.value.message ==\
+            "Requests Parameter 'partition' collides with a load parameter"\
+                " of the same name."
 
     def test_success(self):
         r = Resource(mock.MagicMock())

--- a/f5/bigip/test/test_resource.py
+++ b/f5/bigip/test/test_resource.py
@@ -294,7 +294,7 @@ class TestResource_load(object):
                    requests_params={'partition': 'ERROR'})
         assert RPKCEIO.value.message ==\
             "Requests Parameter 'partition' collides with a load parameter"\
-                " of the same name."
+            " of the same name."
 
     def test_success(self):
         r = Resource(mock.MagicMock())

--- a/test/functional/conftest.py
+++ b/test/functional/conftest.py
@@ -52,3 +52,42 @@ def bigip(opt_bigip, opt_username, opt_password, scope="module"):
 def NAT(bigip):
     n = bigip.ltm.nats.nat
     return n
+
+
+def _delete_pools_members(bigip, pool_records):
+    for pr in pool_records:
+        if bigip.ltm.pools.pool.exists(partition=pr.partition, name=pr.name):
+            pool_inst = bigip.ltm.pools.pool.load(partition=pr.partition,
+                                                  name=pr.name)
+            members_list = pool_inst.members_s.get_collection()
+            pool_inst.delete()
+            for mem_inst in members_list:
+                mem_inst.delete()
+
+
+@pytest.fixture
+def pool_factory():
+    def _setup_boilerplate(bigip, request, pool_records):
+        _delete_pools_members(bigip, pool_records)
+        pool_registry = {}
+        member_registry = {}
+        for pr in pool_records:
+            pool_registry[pr.name] =\
+                bigip.ltm.pools.pool.create(partition=pr.partition,
+                                            name=pr.name)
+            if pr.memberconfigs != (tuple(),):
+                member_collection = pool_registry[pr.name].members_s
+                for memconf in pr.memberconfigs:
+                    member_registry[memconf.memname] =\
+                        member_collection.member\
+                        .create(partition=memconf.mempartition,
+                                name=memconf.memname)
+
+        def deleter():
+            for member_instance in member_registry.values():
+                member_instance.delete()
+            for pool_instance in pool_registry.values():
+                pool_instance.delete()
+        request.addfinalizer(deleter)
+        return pool_registry, member_registry
+    return _setup_boilerplate

--- a/test/functional/conftest.py
+++ b/test/functional/conftest.py
@@ -70,24 +70,24 @@ def pool_factory():
     def _setup_boilerplate(bigip, request, pool_records):
         _delete_pools_members(bigip, pool_records)
         pool_registry = {}
-        member_registry = {}
+        members_registry = {}
         for pr in pool_records:
             pool_registry[pr.name] =\
                 bigip.ltm.pools.pool.create(partition=pr.partition,
                                             name=pr.name)
             if pr.memberconfigs != (tuple(),):
-                member_collection = pool_registry[pr.name].members_s
+                members_collection = pool_registry[pr.name].members_s
                 for memconf in pr.memberconfigs:
-                    member_registry[memconf.memname] =\
-                        member_collection.member\
+                    members_registry[memconf.memname] =\
+                        members_collection.members\
                         .create(partition=memconf.mempartition,
                                 name=memconf.memname)
 
         def deleter():
-            for member_instance in member_registry.values():
+            for member_instance in members_registry.values():
                 member_instance.delete()
             for pool_instance in pool_registry.values():
                 pool_instance.delete()
         request.addfinalizer(deleter)
-        return pool_registry, member_registry
+        return pool_registry, members_registry
     return _setup_boilerplate

--- a/test/functional/ltm/test_pool.py
+++ b/test/functional/ltm/test_pool.py
@@ -52,7 +52,7 @@ def setup_basic_test(request, bigip, name, partition):
 def setup_member_test(request, bigip, name, partition,
                       memname="192.168.15.15:80"):
     p1 = setup_basic_test(request, bigip, name, partition)
-    member = p1.members_s.member
+    member = p1.members_s.members
     member.create(name=memname, partition=partition)
     assert member.name == "192.168.15.15:80"
     return member, p1
@@ -62,7 +62,7 @@ class TestPoolMembersCollection(object):
     def test_get_collection(self, request, bigip):
         member1, pool1 = setup_member_test(request, bigip, 'membertestpool1',
                                            'Common')
-        pool1.members_s.member.create(
+        pool1.members_s.members.create(
             name='192.168.16.16:8080', partition='Common')
         selfLinks = []
         for mem in pool1.members_s.get_collection():
@@ -116,7 +116,7 @@ class TestPoolMembers(object):
                                            'Common')
         member1.description = TESTDESCRIPTION
         member1.update(state=None)
-        member2 = pool1.members_s.member
+        member2 = pool1.members_s.members
         member2.load(name='192.168.15.15:80', partition='Common')
         assert member2.description == TESTDESCRIPTION
         assert member2.selfLink == member1.selfLink

--- a/test/functional/test_requests_params.py
+++ b/test/functional/test_requests_params.py
@@ -1,0 +1,53 @@
+# Copyright 2015-2016 F5 Networks Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+from collections import namedtuple
+PoolConfig = namedtuple('PoolConfig', 'partition name memberconfigs')
+MemberConfig = namedtuple('MemberConfig', 'mempartition memname')
+
+
+def test_get_collection(request, bigip, pool_factory):
+    Pool1MemberConfigs = (MemberConfig('Common', '192.168.15.15:80'),
+                          MemberConfig('Common', '192.168.16.16:8080'),)
+    Pool1Config = PoolConfig('Common', 'TEST', Pool1MemberConfigs)
+    test_pools = (Pool1Config,)
+    pool_registry, member_registry =\
+        pool_factory(bigip, request, test_pools)
+    selfLinks = []
+    for pool_inst in pool_registry.values():
+        for mem in pool_inst.members_s.get_collection():
+            selfLinks.append(mem.selfLink)
+    assert selfLinks[0] == u'https://localhost/mgmt/tm/ltm/pool/' +\
+        '~Common~TEST/members/~Common~192.168.15.15:80' +\
+        '?ver=11.6.0'
+    assert selfLinks[1] == u'https://localhost/mgmt/tm/ltm/pool/' +\
+        '~Common~TEST/members/~Common~192.168.16.16:8080' +\
+        '?ver=11.6.0'
+
+
+def test_get_dollar_filtered_collection(request, bigip, pool_factory):
+    if bigip.sys.folders.folder.exists(name='za', partition=''):
+        bigip.sys.folders.folder.load(name='za', partition='')
+    else:
+        bigip.sys.folders.folder.create(name='za', partition='/')
+    Pool1Config = PoolConfig('Common', 'TEST', ((),))
+    Pool2Config = PoolConfig('za', 'TEST', ((),))
+    test_pools = (Pool1Config, Pool2Config)
+    pool_registry, member_registry =\
+        pool_factory(bigip, request, test_pools)
+    rp = {'params': {'$filter': 'partition eq za'}}
+    pools_in_za = bigip.ltm.pools.get_collection(requests_params=rp)
+    muri = pools_in_za[0]._meta_data['uri']
+    assert muri == 'https://host-vm-15/mgmt/tm/ltm/pool/~za~TEST/'


### PR DESCRIPTION
@jlongstaf 
Fixes:  https://github.com/F5Networks/f5-common-python/issues/207

Allow f5-sdk to pass parameters to requests, that are then appended to the URI.