### PR TITLE
docstring for inherited methods are incorrect #227

### DIFF
--- a/docs/apidoc/f5.bigip.cm.rst
+++ b/docs/apidoc/f5.bigip.cm.rst
@@ -1,24 +1,25 @@
 f5.bigip.cm
 ===========
 
-Submodule List
---------------
-.. currentmodule:: f5.bigip.cm
-
-.. autosummary::
-
-    device
-    device_group
-    traffic_group
-
 Module Contents
 ---------------
 
 .. automodule:: f5.bigip.cm
     :members:
 
-Submodule Details
------------------
+    Submodule List
+    ~~~~~~~~~~~~~~
+    .. currentmodule:: f5.bigip.cm
+
+    .. autosummary::
+
+        device
+        device_group
+        traffic_group
+
+
+Submodules
+----------
 
 device
 ~~~~~~

--- a/docs/apidoc/f5.bigip.ltm.rst
+++ b/docs/apidoc/f5.bigip.ltm.rst
@@ -1,28 +1,28 @@
 f5.bigip.ltm
 ============
 
-Submodule List
---------------
-.. currentmodule:: f5.bigip.ltm
-
-.. autosummary::
-
-    monitor
-    nat
-    node
-    policy
-    pool
-    rule
-    snat
-    ssl
-    virtual
-
-
 Module Contents
 ---------------
 
 .. automodule:: f5.bigip.ltm
    :members:
+
+    Submodule List
+    ~~~~~~~~~~~~~~
+    .. currentmodule:: f5.bigip.ltm
+
+    .. autosummary::
+
+        monitor
+        nat
+        node
+        policy
+        pool
+        rule
+        snat
+        ssl
+        virtual
+
 
 Submodules
 ----------
@@ -124,7 +124,7 @@ nat
     :members:
 
     node Collections and Resources
-    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     .. py:currentmodule:: f5.bigip.ltm.nat
 
     .. autosummary::
@@ -139,7 +139,7 @@ node
     :members:
 
     node Collections and Resources
-    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     .. py:currentmodule:: f5.bigip.ltm.node
 
     .. autosummary::

--- a/docs/apidoc/f5.bigip.net.rst
+++ b/docs/apidoc/f5.bigip.net.rst
@@ -1,24 +1,24 @@
 f5.bigip.net
 ============
 
-Submodule List
---------------
-.. py:currentmodule:: f5.bigip.net
-
-.. autosummary::
-
-    arp
-    interface
-    route
-    selfip
-    tunnels
-    vlan
-
 Module Conents
 --------------
 
 .. automodule:: f5.bigip.net
     :members:
+
+    Submodule List
+    ~~~~~~~~~~~~~~
+    .. py:currentmodule:: f5.bigip.net
+
+    .. autosummary::
+
+        arp
+        interface
+        route
+        selfip
+        tunnels
+        vlan
 
 
 Submodules

--- a/docs/apidoc/f5.bigip.rst
+++ b/docs/apidoc/f5.bigip.rst
@@ -1,12 +1,5 @@
 f5.bigip
 ========
-.. toctree::
-    :maxdepth: 3
-
-    f5.bigip.cm
-    f5.bigip.ltm
-    f5.bigip.net
-    f5.bigip.sys
 
 f5.bigip module
 ---------------
@@ -14,14 +7,80 @@ f5.bigip module
 .. automodule:: f5.bigip
     :members:
 
-f5.bigip.mixins module
-----------------------
+    Organizing Collection Modules
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    .. py:currentmodule:: f5.bigip
+
+    .. autosummary::
+
+        cm
+        ltm
+        net
+        sys
+
+
+    Resource Base Classes
+    ~~~~~~~~~~~~~~~~~~~~~
+
+    .. py:currentmodule:: f5.bigip
+
+    .. autosummary::
+
+        resource.ResourceBase
+        resource.OrganizingCollection
+        resource.Collection
+        resource.Resource
+
+    Resource Exceptions
+    ~~~~~~~~~~~~~~~~~~~
+
+    .. py:currentmodule:: f5.bigip
+
+    .. autosummary::
+
+        resource.KindTypeMismatch
+        resource.DeviceProvidesIncompatibleKey
+        resource.InvalidResource
+        resource.MissingRequiredCreationParameter
+        resource.MissingRequiredReadParameter
+        resource.UnregisteredKind
+        resource.GenerationMismatch
+        resource.InvalidForceType
+        resource.URICreationCollision
+        resource.UnsupportedOperation
+
+    Mixins
+    ~~~~~~
+
+    .. py:currentmodule:: f5.bigip
+
+    .. autosummary::
+
+        mixins.ToDictMixin
+        mixins.LazyAttributesMixin
+        mixins.ExclusiveAttributesMixin
+        mixins.UnnamedResourceMixin
+        mixins.LazyAttributesRequired
+
+
+.. toctree::
+    :maxdepth: 3
+    :hidden:
+
+    f5.bigip.cm
+    f5.bigip.ltm
+    f5.bigip.net
+    f5.bigip.sys
+
+resource module
+---------------
+
+.. automodule:: f5.bigip.resource
+    :members:
+
+mixins module
+-------------
 
 .. automodule:: f5.bigip.mixins
     :members:
 
-f5.bigip.resource module
-------------------------
-
-.. automodule:: f5.bigip.resource
-    :members:

--- a/docs/apidoc/f5.bigip.sys.rst
+++ b/docs/apidoc/f5.bigip.sys.rst
@@ -1,25 +1,25 @@
 f5.bigip.sys
 ============
 
-Submodule List
---------------
-.. py:currentmodule:: f5.bigip.sys
-
-.. autosummary::
-
-   application
-   db
-   failover
-   folder
-   global_settings
-   ntp
-   performance
-
 Module Contents
 ---------------
 
 .. automodule:: f5.bigip.sys
     :members:
+
+    Submodule List
+    ~~~~~~~~~~~~~~
+    .. py:currentmodule:: f5.bigip.sys
+
+    .. autosummary::
+
+       application
+       db
+       failover
+       folder
+       global_settings
+       ntp
+       performance
 
 Submodules
 ----------

--- a/f5/bigip/ltm/nat.py
+++ b/f5/bigip/ltm/nat.py
@@ -47,15 +47,33 @@ class NAT(Resource):
         self._meta_data['required_json_kind'] = 'tm:ltm:nat:natstate'
 
     def create(self, **kwargs):
-        # If you do a create with inheritedTrafficGroup set to 'false' you
-        # must also have a trafficGroup.  This pattern generalizes like so:
-        # If the presence of a param implies an additional required param, then
-        # simply self._meta_data['required_creation_params'].update(IMPLIED),
-        # before the call to self._create(**kwargs), wherein req params are
-        # checked.
-        # We refer to this property as "implied-required parameters" because
-        # the presence of one parameter, or parameter value (e.g.
-        # inheritedTrafficGroup), implies that another parameter is required.
+        """Create the resource on the BigIP.
+
+        Uses HTTP POST to the `collection` URI to create a resource associated
+        with a new unique URI on the device.
+
+        ..
+            If you do a create with inheritedTrafficGroup set to 'false' you
+            must also have a trafficGroup.  This pattern generalizes like so:
+            If the presence of a param implies an additional required param,
+            then simply
+            self._meta_data['required_creation_params'].update(IMPLIED),
+            before the call to self._create(**kwargs), wherein req params are
+            checked.
+
+            We refer to this property as "implied-required parameters" because
+            the presence of one parameter, or parameter value (e.g.
+            inheritedTrafficGroup), implies that another parameter is required.
+
+        .. note::
+            If you are creating with ``inheritedTrafficGroup` set to
+            :obj:`False` you just also have a `trafficGroup`.
+
+        :param kwargs: All the key-values needed to create the resource
+        :returns: ``self`` - A python object that represents the object's
+                  configuration and state on the BigIP.
+
+        """
         itg = kwargs.get('inheritedTrafficGroup', None)
         if itg and itg == 'false':
             self._meta_data['required_creation_parameters'].\

--- a/f5/bigip/mixins.py
+++ b/f5/bigip/mixins.py
@@ -16,6 +16,7 @@
 
 
 class ToDictMixin(object):
+    """Convert an object's attributes to a dictionary"""
     traversed = {}
     Containers = tuple, list, set, frozenset, dict
 
@@ -53,10 +54,12 @@ class ToDictMixin(object):
 
 
 class LazyAttributesRequired(Exception):
+    """Raised when a object accesses a lazy attribute that is not listed"""
     pass
 
 
 class LazyAttributeMixin(object):
+    """Allow attributes to be created lazily based on the allowed values"""
     def __getattr__(self, name):
         # ensure this object supports lazy attrs.
         cls_name = self.__class__.__name__
@@ -93,6 +96,7 @@ class LazyAttributeMixin(object):
 
 
 class ExclusiveAttributesMixin(object):
+    """Overrides ``__setattr__`` to remove exclusive attrs from the object."""
     def __setattr__(self, key, value):
         '''Remove any of the existing exclusive attrs from the object
 


### PR DESCRIPTION
@zancas @pjbreaux @jputrino 
Issues:
Fixes #227

Problem:
The methods in the base class were not written in a general
form so when they show up on RTD in the subclasses they are
not appropriate for users.

Analysis:
* Make them more generic
* Format the f5.bigip.rst file to be better organized.

Tests:
* Built docs
* Flake8