### PR TITLE
Feature.iapp parser double quote braces

### DIFF
--- a/f5/common/iapp_parser.py
+++ b/f5/common/iapp_parser.py
@@ -51,6 +51,9 @@ class IappParser(object):
     def _get_section_end_index(self, section, section_start):
         '''Get end of section's content.
 
+        In the loop to match braces, we must not count curly braces that are
+        within a doubly quoted string.
+
         :param section: string name of section
         :param section_start: integer index of section's beginning
         :return: integer index of section's end
@@ -58,11 +61,16 @@ class IappParser(object):
         '''
 
         brace_count = 0
-
+        in_quote = False
         for index, char in enumerate(self.template_str[section_start:]):
-            if char == u'{':
+            if char == '"' and not in_quote:
+                in_quote = True
+            elif char == '"' and in_quote:
+                in_quote = False
+
+            if char == u'{' and not in_quote:
                 brace_count += 1
-            elif char == u'}':
+            elif char == u'}' and not in_quote:
                 brace_count -= 1
 
             if brace_count is 0:

--- a/f5/common/test/test_iapp_parser.py
+++ b/f5/common/test/test_iapp_parser.py
@@ -39,6 +39,27 @@ good_templ = '''sys application template good_templ {
   requires-modules { ltm }
 }'''
 
+brace_in_quote_templ = '''sys application template good_templ {
+  actions {
+    definition {
+      html-help {
+        # HTML Help for "" the template
+      }
+      implementation {
+        # TMSH"{}{{}}}}}""{{{{}}"implementation code
+      }
+      presentation {
+        # APL"{}{}{{{{{{" presentation language
+      }
+      role-acl { hello test }
+      run-as <user context>
+    }
+  }
+  description <template description>
+  partition <partition name>
+  requires-modules { ltm }
+}'''
+
 no_desc_templ = '''sys application template good_templ {
   actions {
     definition {
@@ -261,6 +282,21 @@ good_templ_dict = {
     }
 }
 
+brace_in_quote_templ_dict = {
+    u'name': u'good_templ',
+    u'description': u'<template description>',
+    u'partition': u'<partition name>',
+    u'requiresModules': [u'ltm'],
+    'actions': {
+        'definition': {
+            u'htmlHelp': u'# HTML Help for "" the template',
+            u'roleAcl': [u'hello', u'test'],
+            u'implementation': u'# TMSH"{}{{}}}}}""{{{{}}"implementation code',
+            u'presentation': u'# APL"{}{}{{{{{{" presentation language'
+        }
+    }
+}
+
 no_help_templ_dict = {
     u'name': u'good_templ',
     u'description': u'<template description>',
@@ -374,6 +410,11 @@ def test_get_template_name_bad_name_error():
 def test_parse_template():
     prsr = ip.IappParser(good_templ)
     assert prsr.parse_template() == good_templ_dict
+
+
+def test_parse_template_brace_in_quote():
+    prsr = ip.IappParser(brace_in_quote_templ)
+    assert prsr.parse_template() == brace_in_quote_templ_dict
 
 
 def test_parse_template_no_section_found(TemplateSectionSetup):


### PR DESCRIPTION
@zancas 

#### What's this change do?
Adds functionality to ignore curly braces inside double quotes if those are present in an iapp template.

#### Any background context?
This stemmed from an issue of parsing an iapp template with a curly braces in a double quoted string like so: ```implementation { ... ... ... { } { hello test } hello quoted curly brace "}" ... }```

#### Where should the reviewer start?
New test, then look at the code changes