### PR TITLE
If an object already has a _meta_data['uri']

### DIFF
--- a/f5/bigip/resource.py
+++ b/f5/bigip/resource.py
@@ -497,11 +497,6 @@ class Resource(ResourceBase):
         :param selfLinkuri: the server provided selfLink (contains localhost)
         :raises: URICreationCollision
         """
-        if 'uri' in self._meta_data:
-            error = "There was an attempt to assign a new uri to this "\
-                    "resource, the _meta_data['uri'] is %s and it should"\
-                    " not be changed." % (self._meta_data['uri'])
-            raise URICreationCollision(error)
         # hostname local alias
         hostname = self._meta_data['bigip']._meta_data['hostname']
 
@@ -521,6 +516,11 @@ class Resource(ResourceBase):
 
     def _create(self, **kwargs):
         """wrapped by `create` override that in subclasses to customize"""
+        if 'uri' in self._meta_data:
+            error = "There was an attempt to assign a new uri to this "\
+                    "resource, the _meta_data['uri'] is %s and it should"\
+                    " not be changed." % (self._meta_data['uri'])
+            raise URICreationCollision(error)
         requests_params = self._handle_requests_params(kwargs)
         key_set = set(kwargs.keys())
         required_minus_received =\
@@ -585,6 +585,11 @@ class Resource(ResourceBase):
 
     def _load(self, **kwargs):
         """wrapped with load, override that in a subclass to customize"""
+        if 'uri' in self._meta_data:
+            error = "There was an attempt to assign a new uri to this "\
+                    "resource, the _meta_data['uri'] is %s and it should"\
+                    " not be changed." % (self._meta_data['uri'])
+            raise URICreationCollision(error)
         requests_params = self._handle_requests_params(kwargs)
         self._check_load_parameters(**kwargs)
         kwargs['uri_as_parts'] = True

--- a/f5/bigip/sys/test/test_sys_application.py
+++ b/f5/bigip/sys/test/test_sys_application.py
@@ -168,7 +168,7 @@ class TestServiceCreate(object):
     def test_create_uri_collision(self, FakeService):
         FakeService._meta_data = {'uri': 'already_defined'}
         with pytest.raises(URICreationCollision) as ex:
-            FakeService._activate_URI('FAKEURI')
+            FakeService.create(fakeuri='FAKEURI')
         assert "There was an attempt to assign a new uri to this resource, " \
             "the _meta_data['uri'] is already_defined and it should not be " \
             "changed." in ex.value.message

--- a/f5/bigip/test/test_resource.py
+++ b/f5/bigip/test/test_resource.py
@@ -102,7 +102,6 @@ class TestResourcecreate(object):
         r = Resource(mock.MagicMock())
         r._meta_data['bigip']._meta_data['icr_session'].post.return_value =\
             MockResponse({u"kind": u"tm:"})
-        r._meta_data['uri'] = 'URI'
         r._meta_data['required_json_kind'] = 'INCORRECT!'
         with pytest.raises(KindTypeMismatch) as KTMmEIO:
             r.create(partition="Common", name="test_create")
@@ -139,11 +138,11 @@ def test__activate_URI():
     assert r._meta_data['allowed_lazy_attributes'] == [u"SPAM"]
 
 
-def test__activate_URI_with_Collision():
+def test__create_with_Collision():
     r = Resource(mock.MagicMock())
     r._meta_data['uri'] = 'URI'
     with pytest.raises(URICreationCollision) as UCCEIO:
-        r._activate_URI('URI')
+        r.create(uri='URI')
     assert UCCEIO.value.message ==\
         "There was an attempt to assign a new uri to this resource,"\
         " the _meta_data['uri'] is URI and it should not be changed."


### PR DESCRIPTION
@b225ccc 
create and load will no longer talk to the device
Fixes #237

Problem: A loaded/created object shouldn't talk to the device.

Analysis: Telling the device to create a resource that you, the
client object, are already aware of, doesn't make sense and wastes
resources.

Tests: Updated Unittests, see the diff.