### PR TITLE
Application Services Service must override exists() to build proper uri

### DIFF
--- a/test/functional/sys/test_sys_application.py
+++ b/test/functional/sys/test_sys_application.py
@@ -81,7 +81,7 @@ def setup_service_test(request, bigip, name, partition, template_name):
     return service_s, test_service
 
 
-def curdl_check(collection, resource, resource_name, **kwargs):
+def curdle_check(collection, resource, resource_name, **kwargs):
     name = kwargs['name']
     assert resource.name == name
     second_resource = getattr(collection, resource_name).load(**kwargs)
@@ -96,6 +96,8 @@ def curdl_check(collection, resource, resource_name, **kwargs):
 
     second_resource.refresh()
     assert second_resource.generation == resource.generation
+
+    assert getattr(collection, resource_name).exists(**kwargs) is True
 
 
 class TestApplication(object):
@@ -123,7 +125,7 @@ class TestTemplate(object):
             'test_template',
             'Common'
         )
-        curdl_check(
+        curdle_check(
             templ_s,
             test_templ,
             'template',
@@ -162,7 +164,7 @@ class TestService(object):
         # Make sure the uri is what we expect
         assert bigip._meta_data['uri'] + 'sys/application/service/~Common' \
             '~test_service.app~test_service' in test_serv._meta_data['uri']
-        curdl_check(
+        curdle_check(
             serv_s,
             test_serv,
             'service',


### PR DESCRIPTION
@zancas 

#### What's this change do?
Override resource's exists() in application services service to build the uri for exists()

#### Any background context?
The uri for a service seems to be unique on the BigIP. Therefore the exists method in the resource base class does not build the proper uri for this resource.

There are new methods here, one public, one private. Wondering about how docs should be handled?

#### Where should the reviewer start?
Unit tests, then functional, then code changes