### PR TITLE
Bugfix: The load operation can fail after a create is done, because load useskwargs and those kwargs may cause the BigIP get request to fail.

### DIFF
--- a/f5/bigip/sys/application.py
+++ b/f5/bigip/sys/application.py
@@ -97,6 +97,8 @@ class Service(Resource):
         self._meta_data['required_refresh_parameters'].update(('partition',))
         self._meta_data['required_json_kind'] =\
             'tm:sys:application:service:servicestate'
+        self._meta_data['disallowed_load_parameters'] = \
+            set(['template', 'trafficGroup'])
 
     def _create(self, **kwargs):
         '''Create service on device and create accompanying Python object.
@@ -119,9 +121,6 @@ class Service(Resource):
             # drop in Common as the partition in kwargs.
             if 'partition' not in kwargs:
                 kwargs['partition'] = 'Common'
-            # 'template' kwarg should not be used in the call to load becuase
-            # the BigIP will return an error if it's present
-            kwargs.pop('template')
 
             # If response was created successfully, do a local_update.
             # If not, call to overridden _load method via load
@@ -154,6 +153,10 @@ class Service(Resource):
         :params kwargs: keyword arguments for talking to the device
         :returns: populated Service object
         '''
+        # Some kwargs should be popped before we do a load
+        for key in self._meta_data['disallowed_load_parameters']:
+            if key in kwargs:
+                kwargs.pop(key)
 
         self._check_load_parameters(**kwargs)
         name = kwargs.pop('name')

--- a/test/functional/sys/test_sys_application.py
+++ b/test/functional/sys/test_sys_application.py
@@ -60,7 +60,7 @@ def setup_template_test(request, bigip, name, partition):
     )
 
 
-def setup_service_test(request, bigip, name, partition, template_name):
+def setup_service_test(request, bigip, name, partition, template_name, tgroup):
     def teardown():
         delete_resource(test_service)
         delete_resource(test_template)
@@ -76,7 +76,10 @@ def setup_service_test(request, bigip, name, partition, template_name):
     )
     test_service = None
     test_service = service_s.service.create(
-        name=name, partition=partition, template=template_name
+        name=name,
+        partition=partition,
+        template=template_name,
+        trafficGroup=tgroup
     )
     return service_s, test_service
 
@@ -141,7 +144,8 @@ class TestServiceCollection(object):
             bigip,
             'test_service',
             'Common',
-            'test_template'
+            'test_template',
+            '/Common/traffic-group-local-only'
         )
 
         all_services = serv_s.get_collection()
@@ -159,7 +163,8 @@ class TestService(object):
             bigip,
             'test_service',
             'Common',
-            'test_template'
+            'test_template',
+            '/Common/traffic-group-local-only'
         )
         # Make sure the uri is what we expect
         assert bigip._meta_data['uri'] + 'sys/application/service/~Common' \


### PR DESCRIPTION
@zancas 

Issues: Issue #233

Problem: Load for a service will fail after create is called because all kwargs are passed from create to load

Analysis: Decided to make a resource meta_data property called 'disallowed_load_parameters' that will be stripped from kwargs passed into load if they are present.

Tests: Added the trafficGroup to one of the functional tests to ensure this does not fail on a real BigIP. Still testing at 100%