### PR TITLE
Db objects now support update

### DIFF
--- a/f5/bigip/sys/db.py
+++ b/f5/bigip/sys/db.py
@@ -58,15 +58,6 @@ class Db(Resource):
             "DB resources doesn't support create, only load and refresh"
         )
 
-    def update(self, **kwargs):
-        '''Update is not supported for db resources.
-
-        :raises: UnsupportedOperation
-        '''
-        raise UnsupportedOperation(
-            "DB resources doesn't support update, only load and refresh"
-        )
-
     def delete(self, **kwargs):
         '''Delete is not supported for db resources.
 

--- a/f5/bigip/sys/test/test_db.py
+++ b/f5/bigip/sys/test/test_db.py
@@ -32,12 +32,6 @@ class TestDb(object):
         with pytest.raises(UnsupportedOperation):
             db.create()
 
-    def test_update_raises(self):
-        dbs = fake_dbs()
-        db = dbs.db
-        with pytest.raises(UnsupportedOperation):
-            db.update()
-
     def test_delete_raises(self):
         dbs = fake_dbs()
         db = dbs.db

--- a/test/functional/sys/test_db.py
+++ b/test/functional/sys/test_db.py
@@ -20,3 +20,10 @@ class TestDb(object):
         assert db.value == 'true'
         db.refresh()
         assert db.value == 'true'
+
+    def test_update(self, bigip):
+        db1 = bigip.sys.dbs.db.load(name='iptunnel.configsync')
+        db1.update(value='enable')
+        assert db1.value == 'enable'
+        db1.update(value='disable')
+        assert db1.value == 'disable'


### PR DESCRIPTION
@jlongstaf 
Issues:
Fixes #251

Problem: We had not previously implemented update for Db objects, but they are
supported.

Analysis: Implemented and tested.

Tests: sys/test_db::TestDb::test_update