### PR TITLE
Implement toggle_standby fix docs for route_domain

### DIFF
--- a/docs/apidoc/f5.bigip.net.rst
+++ b/docs/apidoc/f5.bigip.net.rst
@@ -14,12 +14,13 @@ Module Conents
     .. autosummary::
 
         arp
+        fdb
         interface
         route
+        route_domain
         selfip
         tunnels
         vlan
-        fdb
 
 
 Submodules

--- a/test/functional/sys/test_failover.py
+++ b/test/functional/sys/test_failover.py
@@ -13,6 +13,8 @@
 # limitations under the License.
 #
 
+from pprint import pprint as pp
+
 
 class TestFailover(object):
     def test_failover_LR(self, bigip):
@@ -28,3 +30,17 @@ class TestFailover(object):
         assert f.apiRawValues['apiAnonymous'].startswith('Failover active')
         f.refresh()
         assert f.apiRawValues['apiAnonymous'].startswith('Failover active')
+
+    def test_toggle_standby(self, bigip):
+        f = bigip.sys.failover
+        f.toggle_standby(trafficgroup="traffic-group-1", state=None)
+        assert f.standby is None
+        assert f.command == u"run"
+        pp(f.raw)
+        f.toggle_standby(trafficgroup="traffic-group-1", state=True)
+        assert f.standby is True
+        assert f.command == u"run"
+        pp('************')
+        f.refresh()
+        pp(f.raw)
+        assert 'Failover active' in f.apiRawValues['apiAnonymous']


### PR DESCRIPTION
@swormke
Issues:
Fixes #216

Problem: The Failover class needs to support traffic group standby state
toggling.

Analysis: Implement method toggle_standby.  The original method name "standby"
collided with a value (sometimes) returned by the device.

Tests: sys/test_failover::TestFailover::test_toggle_standby