### PR TITLE
Fixed toctree substitution errors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,6 +47,8 @@ test/*/logs/*
 
 # Docs
 docs/_build
+venv/*
+docs/venv/*
 
 # iControl REST logs
 logs

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ install:
     - pip install hacking pytest pytest-cov
     - pip install -r requirements.test.txt
 script:
-    - flake8 .
+    - flake8 --exclude=docs .
     - py.test --cov --ignore=test/
     - python setup.py sdist
     - cd docs

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -76,21 +76,17 @@ release = VERSION
 
 # links to sections
 rst_epilog = """
-.. |Organizing Collection Section| replace:: :ref:`Organizing Collection
-<organizing_collection_section>`
+.. |Organizing Collection Section| replace:: :ref:`Organizing Collection <organizing_collection_section>`
 
 .. |Collection Section| replace:: :ref:`Collection <collection_section>`
 
 .. |Resource Section| replace:: :ref:`Resource <resource_section>`
 
-.. |Subcollection Section| replace:: :ref:`Subcollection
-<subcollection_section>`
+.. |Subcollection Section| replace:: :ref:`Subcollection <subcollection_section>`
 
-.. |Subcollection Resource Section| replace:: :ref:`Subcollection Resource
-<subcollection_resource_section>`
+.. |Subcollection Resource Section| replace:: :ref:`Subcollection Resource <subcollection_resource_section>`
 
-.. |Organizing Collection| replace::
-:class:`~f5.bigip.resource.OrganizingCollection>`
+.. |Organizing Collection| replace:: :class:`~f5.bigip.resource.OrganizingCollection`
 
 .. |Collection| replace:: :class:`~f5.bigip.resource.Collection`
 
@@ -98,8 +94,7 @@ rst_epilog = """
 
 .. |Subcollection| replace:: :class:`~f5.bigip.resource.Subcollection`
 
-.. |Subcollection Resource| replace::
-:class:`~f5.bigip.resource.SubcollectionResource`
+.. |Subcollection Resource| replace:: :class:`~f5.bigip.resource.SubcollectionResource`
 
 .. |create| replace:: :meth:`~f5.bigip.resource.Resource.create`
 


### PR DESCRIPTION
Fixes: #258 
@swormke 

#### What's this change do?
removed line wrap from conf.py to fix substitutions; 
added docs to exclude list for flake8; 
added venv/* to .gitignore

#### Where should the reviewer start?
- make sure the build passes
- make the docs locally and verify that the toc doesn't contain `|Organizing Collection Section|`, `|Subcollection Section|`, and `|Subcollection Resource Section|`.

#### Any background context?