### PR TITLE
Change BigIP to BIG-IP #264

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -5,9 +5,9 @@ f5-common-python
 
 Introduction
 ------------
-F5 Networks BIG-IP python SDK. This project implements an SDK for the iControl
-REST interface for the BigIP. Users of this library can create, edit, update,
-and delete configuration objects on a BigIP device.
+This project implements an SDK for the iControl REST interface for the BIG-IP.
+Users of this library can create, edit, update, and delete configuration objects
+on a BIG-IP device.
 
 Submodules
 ~~~~~~~~~~

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -4,9 +4,9 @@ F5 Python SDK Documentation
 
 Introduction
 ------------
-This project implements an object model based SDK for the F5 Networks BigIP
+This project implements an object model based SDK for the F5 Networks BIG-IP
 iControl REST interface. Users of this library can create, edit, update, and
-delete configuration objects on a BigIP device.  For more information on the
+delete configuration objects on a BIG-IP device.  For more information on the
 basic principals that the SDK uses see the :doc:`userguide/index`.
 
 Quick Start

--- a/docs/userguide/basics.rst
+++ b/docs/userguide/basics.rst
@@ -96,7 +96,7 @@ Methods
 | |load|    | GET           | | obtains the state of an existing resource on the device; sets   |
 |           |               | | the Resource attributes to match that state                     |
 +-----------+---------------+-------------------------------------------------------------------+
-| |exists|  | GET           | | checks for the existence of a named object on the BigIP         |
+| |exists|  | GET           | | checks for the existence of a named object on the BIG-IP        |
 +-----------+---------------+-------------------------------------------------------------------+
 
 .. note::

--- a/docs/userguide/ltm_pools_members_code_example.rst
+++ b/docs/userguide/ltm_pools_members_code_example.rst
@@ -70,7 +70,7 @@ Coding Example
         if pool_1.members_s.members.exists(partition='Common', name='m1:80'):
         raise Exception("Object should have been deleted")
 
-        # We are done with this pool so remove it from bigip
+        # We are done with this pool so remove it from BIG-IP
         pool_1.delete()
 
         # Make sure it is gone

--- a/f5/bigip/cm/__init__.py
+++ b/f5/bigip/cm/__init__.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-"""BigIP cluster module
+"""BIG-IP cluster module
 
 REST URI
     ``http://localhost/mgmt/tm/cm/``
@@ -32,7 +32,7 @@ from f5.bigip.resource import OrganizingCollection
 
 
 class Cm(OrganizingCollection):
-    """BigIP Cluster Organizing Collection."""
+    """BIG-IP Cluster Organizing Collection."""
     def __init__(self, bigip):
         super(Cm, self).__init__(bigip)
         self._meta_data['allowed_lazy_attributes'] = [

--- a/f5/bigip/cm/device.py
+++ b/f5/bigip/cm/device.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-"""BigIP cluster device submodule
+"""BIG-IP cluster device submodule
 
 REST URI
     ``http://localhost/mgmt/tm/cm/device/``
@@ -30,7 +30,7 @@ from f5.bigip.resource import Resource
 
 
 class Devices(Collection):
-    """BigIP cluster devices collection.
+    """BIG-IP cluster devices collection.
 
     """
     def __init__(self, cm):
@@ -41,7 +41,7 @@ class Devices(Collection):
 
 
 class Device(Resource):
-    """BigIP cluster device object.
+    """BIG-IP cluster device object.
 
     """
     def __init__(self, device_s):

--- a/f5/bigip/cm/device_group.py
+++ b/f5/bigip/cm/device_group.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 #
 
-"""BigIP cluster device-group submodule
+"""BIG-IP cluster device-group submodule
 
 REST URI
     ``http://localhost/mgmt/tm/cm/device-group``
@@ -30,7 +30,7 @@ from f5.bigip.resource import Resource
 
 
 class Device_Groups(Collection):
-    """BigIP cluster device-groups collection."""
+    """BIG-IP cluster device-groups collection."""
     def __init__(self, cm):
         super(Device_Groups, self).__init__(cm)
         endpoint = 'device-group'
@@ -42,7 +42,7 @@ class Device_Groups(Collection):
 
 
 class Device_Group(Resource):
-    """BigIP cluster device-group resource"""
+    """BIG-IP cluster device-group resource"""
     def __init__(self, device_groups):
         super(Device_Group, self).__init__(device_groups)
         self._meta_data['read_only_attributes'].append('type')
@@ -55,7 +55,7 @@ class Device_Group(Resource):
 
 
 class Devices_s(Collection):
-    """BigIP cluster devices-group devices subcollection."""
+    """BIG-IP cluster devices-group devices subcollection."""
     def __init__(self, device_group):
         super(Devices_s, self).__init__(device_group)
         self._meta_data['allowed_lazy_attributes'] = [Devices]
@@ -66,7 +66,7 @@ class Devices_s(Collection):
 
 
 class Devices(Resource):
-    """BigIP cluster devices-group devices subcollection resource."""
+    """BIG-IP cluster devices-group devices subcollection resource."""
     def __init__(self, devices_s):
         super(Devices, self).__init__(devices_s)
         self._meta_data['required_json_kind'] =\

--- a/f5/bigip/cm/traffic_group.py
+++ b/f5/bigip/cm/traffic_group.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 #
 
-"""BigIP cluster traffic-group submodule
+"""BIG-IP cluster traffic-group submodule
 
 REST URI
     ``http://localhost/mgmt/tm/cm/traffic-group``
@@ -30,7 +30,7 @@ from f5.bigip.resource import Resource
 
 
 class Traffic_Groups(Collection):
-    """BigIP cluster traffic-group collection"""
+    """BIG-IP cluster traffic-group collection"""
     def __init__(self, cm):
         super(Traffic_Groups, self).__init__(cm)
         endpoint = 'traffic-group'
@@ -42,7 +42,7 @@ class Traffic_Groups(Collection):
 
 
 class Traffic_Group(Resource):
-    """BigIP cluster traffic-group resource"""
+    """BIG-IP cluster traffic-group resource"""
     def __init__(self, traffic_groups):
         super(Traffic_Group, self).__init__(traffic_groups)
         self._meta_data['required_json_kind'] =\

--- a/f5/bigip/ltm/__init__.py
+++ b/f5/bigip/ltm/__init__.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 #
 
-"""BigIP Local Traffic Monitor (LTM) module.
+"""BIG-IP Local Traffic Monitor (LTM) module.
 
 REST URI
     ``http://localhost/mgmt/tm/ltm/``
@@ -38,7 +38,7 @@ from f5.bigip.resource import OrganizingCollection
 
 
 class Ltm(OrganizingCollection):
-    """BigIP Local Traffic Manager (LTM) organizing collection."""
+    """BIG-IP Local Traffic Manager (LTM) organizing collection."""
     def __init__(self, bigip):
         super(Ltm, self).__init__(bigip)
         self._meta_data['allowed_lazy_attributes'] = [

--- a/f5/bigip/ltm/monitor.py
+++ b/f5/bigip/ltm/monitor.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 #
 
-"""BigIP LTM monitor submodule.
+"""BIG-IP LTM monitor submodule.
 
 REST URI
     ``http://localhost/mgmt/tm/ltm/monitors/``
@@ -76,7 +76,7 @@ class Monitor(OrganizingCollection):
 
 
 class Https(Collection):
-    """BigIP Http monitor collection."""
+    """BIG-IP Http monitor collection."""
     def __init__(self, monitor):
         super(Https, self).__init__(monitor)
         self._meta_data['allowed_lazy_attributes'] = [Http]
@@ -105,7 +105,7 @@ class UpdateMonitorMixin(object):
 
 
 class Http(UpdateMonitorMixin, Resource):
-    """BigIP Http monitor resource."""
+    """BIG-IP Http monitor resource."""
     def __init__(self, https):
         super(Http, self).__init__(https)
         self._meta_data['required_json_kind'] =\
@@ -113,7 +113,7 @@ class Http(UpdateMonitorMixin, Resource):
 
 
 class Https_s(Collection):
-    """BigIP Https monitor collection."""
+    """BIG-IP Https monitor collection."""
     def __init__(self, monitor):
         super(Https_s, self).__init__(monitor)
         self._meta_data['allowed_lazy_attributes'] = [HttpS]
@@ -122,7 +122,7 @@ class Https_s(Collection):
 
 
 class HttpS(UpdateMonitorMixin, Resource):
-    """BigIP Https monitor resource."""
+    """BIG-IP Https monitor resource."""
     def __init__(self, https_s):
         super(HttpS, self).__init__(https_s)
         self._meta_data['required_json_kind'] =\
@@ -130,7 +130,7 @@ class HttpS(UpdateMonitorMixin, Resource):
 
 
 class Diameters(Collection):
-    """BigIP diameter monitor collection."""
+    """BIG-IP diameter monitor collection."""
     def __init__(self, monitor):
         super(Diameters, self).__init__(monitor)
         self._meta_data['allowed_lazy_attributes'] = [Diameter]
@@ -139,7 +139,7 @@ class Diameters(Collection):
 
 
 class Diameter(UpdateMonitorMixin, Resource):
-    """BigIP diameter monitor resource."""
+    """BIG-IP diameter monitor resource."""
     def __init__(self, diameters):
         super(Diameter, self).__init__(diameters)
         self._meta_data['required_json_kind'] =\
@@ -147,7 +147,7 @@ class Diameter(UpdateMonitorMixin, Resource):
 
 
 class Dns_s(Collection):
-    """BigIP Dns monitor collection."""
+    """BIG-IP Dns monitor collection."""
     def __init__(self, monitor):
         super(Dns_s, self).__init__(monitor)
         self._meta_data['allowed_lazy_attributes'] = [Dns]
@@ -156,7 +156,7 @@ class Dns_s(Collection):
 
 
 class Dns(UpdateMonitorMixin, Resource):
-    """BigIP Dns monitor resource."""
+    """BIG-IP Dns monitor resource."""
     def __init__(self, dns_s):
         super(Dns, self).__init__(dns_s)
         self._meta_data['required_json_kind'] =\
@@ -165,7 +165,7 @@ class Dns(UpdateMonitorMixin, Resource):
 
 
 class Externals(Collection):
-    """BigIP external monitor collection."""
+    """BIG-IP external monitor collection."""
     def __init__(self, monitor):
         super(Externals, self).__init__(monitor)
         self._meta_data['allowed_lazy_attributes'] = [External]
@@ -174,7 +174,7 @@ class Externals(Collection):
 
 
 class External(UpdateMonitorMixin, Resource):
-    """BigIP external monitor resrouce."""
+    """BIG-IP external monitor resrouce."""
     def __init__(self, externals):
         super(External, self).__init__(externals)
         self._meta_data['required_json_kind'] =\
@@ -182,7 +182,7 @@ class External(UpdateMonitorMixin, Resource):
 
 
 class Firepass_s(Collection):
-    """BigIP Fire Pass monitor collection."""
+    """BIG-IP Fire Pass monitor collection."""
     def __init__(self, monitor):
         super(Firepass_s, self).__init__(monitor)
         self._meta_data['allowed_lazy_attributes'] = [Firepass]
@@ -191,7 +191,7 @@ class Firepass_s(Collection):
 
 
 class Firepass(UpdateMonitorMixin, Resource):
-    """BigIP external monitor resource."""
+    """BIG-IP external monitor resource."""
     def __init__(self, firepass_s):
         super(Firepass, self).__init__(firepass_s)
         self._meta_data['required_json_kind'] =\
@@ -199,7 +199,7 @@ class Firepass(UpdateMonitorMixin, Resource):
 
 
 class Ftps(Collection):
-    """BigIP Ftp monitor collection."""
+    """BIG-IP Ftp monitor collection."""
     def __init__(self, monitor):
         super(Ftps, self).__init__(monitor)
         self._meta_data['allowed_lazy_attributes'] = [Ftp]
@@ -208,7 +208,7 @@ class Ftps(Collection):
 
 
 class Ftp(UpdateMonitorMixin, Resource):
-    """BigIP Ftp monitor resource."""
+    """BIG-IP Ftp monitor resource."""
     def __init__(self, ftps):
         super(Ftp, self).__init__(ftps)
         self._meta_data['required_json_kind'] =\
@@ -216,7 +216,7 @@ class Ftp(UpdateMonitorMixin, Resource):
 
 
 class Gateway_Icmps(Collection):
-    """BigIP Gateway Icmp monitor collection."""
+    """BIG-IP Gateway Icmp monitor collection."""
     def __init__(self, monitor):
         super(Gateway_Icmps, self).__init__(monitor)
         fixed = self._meta_data['uri'].replace('_', '-')
@@ -227,7 +227,7 @@ class Gateway_Icmps(Collection):
 
 
 class Gateway_Icmp(UpdateMonitorMixin, Resource):
-    """BigIP Gateway Icmp monitor resource."""
+    """BIG-IP Gateway Icmp monitor resource."""
     def __init__(self, gateway_icmps):
         super(Gateway_Icmp, self).__init__(gateway_icmps)
         self._meta_data['required_json_kind'] =\
@@ -235,7 +235,7 @@ class Gateway_Icmp(UpdateMonitorMixin, Resource):
 
 
 class Icmps(Collection):
-    """BigIP Icmp monitor collection."""
+    """BIG-IP Icmp monitor collection."""
     def __init__(self, monitor):
         super(Icmps, self).__init__(monitor)
         self._meta_data['allowed_lazy_attributes'] = [Icmp]
@@ -244,7 +244,7 @@ class Icmps(Collection):
 
 
 class Icmp(UpdateMonitorMixin, Resource):
-    """BigIP Icmp monitor resource."""
+    """BIG-IP Icmp monitor resource."""
     def __init__(self, icmps):
         super(Icmp, self).__init__(icmps)
         self._meta_data['required_json_kind'] =\
@@ -252,7 +252,7 @@ class Icmp(UpdateMonitorMixin, Resource):
 
 
 class Imaps(Collection):
-    """BigIP Imap monitor collection."""
+    """BIG-IP Imap monitor collection."""
     def __init__(self, monitor):
         super(Imaps, self).__init__(monitor)
         self._meta_data['allowed_lazy_attributes'] = [Imap]
@@ -261,7 +261,7 @@ class Imaps(Collection):
 
 
 class Imap(UpdateMonitorMixin, Resource):
-    """BigIP Imap monitor resource."""
+    """BIG-IP Imap monitor resource."""
     def __init__(self, imaps):
         super(Imap, self).__init__(imaps)
         self._meta_data['required_json_kind'] =\
@@ -269,7 +269,7 @@ class Imap(UpdateMonitorMixin, Resource):
 
 
 class Inbands(Collection):
-    """BigIP in band monitor collection."""
+    """BIG-IP in band monitor collection."""
     def __init__(self, monitor):
         super(Inbands, self).__init__(monitor)
         self._meta_data['allowed_lazy_attributes'] = [Inband]
@@ -278,7 +278,7 @@ class Inbands(Collection):
 
 
 class Inband(UpdateMonitorMixin, Resource):
-    """BigIP in band monitor resource."""
+    """BIG-IP in band monitor resource."""
     def __init__(self, inbands):
         super(Inband, self).__init__(inbands)
         self._meta_data['required_json_kind'] =\
@@ -286,7 +286,7 @@ class Inband(UpdateMonitorMixin, Resource):
 
 
 class Ldaps(Collection):
-    """BigIP Ldap monitor collection."""
+    """BIG-IP Ldap monitor collection."""
     def __init__(self, monitor):
         super(Ldaps, self).__init__(monitor)
         self._meta_data['allowed_lazy_attributes'] = [Ldap]
@@ -295,7 +295,7 @@ class Ldaps(Collection):
 
 
 class Ldap(UpdateMonitorMixin, Resource):
-    """BigIP Ldap monitor resource."""
+    """BIG-IP Ldap monitor resource."""
     def __init__(self, ldaps):
         super(Ldap, self).__init__(ldaps)
         self._meta_data['required_json_kind'] =\
@@ -303,7 +303,7 @@ class Ldap(UpdateMonitorMixin, Resource):
 
 
 class Module_Scores(Collection):
-    """BigIP module scores monitor collection."""
+    """BIG-IP module scores monitor collection."""
     def __init__(self, monitor):
         super(Module_Scores, self).__init__(monitor)
         fixed = self._meta_data['uri'].replace('_', '-')
@@ -314,7 +314,7 @@ class Module_Scores(Collection):
 
 
 class Module_Score(UpdateMonitorMixin, Resource):
-    """BigIP module scores monitor resource."""
+    """BIG-IP module scores monitor resource."""
     def __init__(self, gateway_icmps):
         super(Module_Score, self).__init__(gateway_icmps)
         self._meta_data['required_creation_parameters'].update(
@@ -324,7 +324,7 @@ class Module_Score(UpdateMonitorMixin, Resource):
 
 
 class Mysqls(Collection):
-    """BigIP MySQL monitor collection."""
+    """BIG-IP MySQL monitor collection."""
     def __init__(self, monitor):
         super(Mysqls, self).__init__(monitor)
         self._meta_data['allowed_lazy_attributes'] = [Mysql]
@@ -333,7 +333,7 @@ class Mysqls(Collection):
 
 
 class Mysql(UpdateMonitorMixin, Resource):
-    """BigIP MySQL monitor resource."""
+    """BIG-IP MySQL monitor resource."""
     def __init__(self, mysqls):
         super(Mysql, self).__init__(mysqls)
         self._meta_data['required_json_kind'] =\
@@ -341,7 +341,7 @@ class Mysql(UpdateMonitorMixin, Resource):
 
 
 class Mssqls(Collection):
-    """BigIP Mssql monitor collection."""
+    """BIG-IP Mssql monitor collection."""
     def __init__(self, monitor):
         super(Mssqls, self).__init__(monitor)
         self._meta_data['allowed_lazy_attributes'] = [Mssql]
@@ -350,7 +350,7 @@ class Mssqls(Collection):
 
 
 class Mssql(UpdateMonitorMixin, Resource):
-    """BigIP Mssql monitor resource."""
+    """BIG-IP Mssql monitor resource."""
     def __init__(self, mssqls):
         super(Mssql, self).__init__(mssqls)
         self._meta_data['required_json_kind'] =\
@@ -358,7 +358,7 @@ class Mssql(UpdateMonitorMixin, Resource):
 
 
 class Nntps(Collection):
-    """BigIP Nntps monitor collection."""
+    """BIG-IP Nntps monitor collection."""
     def __init__(self, monitor):
         super(Nntps, self).__init__(monitor)
         self._meta_data['allowed_lazy_attributes'] = [Nntp]
@@ -367,7 +367,7 @@ class Nntps(Collection):
 
 
 class Nntp(UpdateMonitorMixin, Resource):
-    """BigIP Nntps monitor resource."""
+    """BIG-IP Nntps monitor resource."""
     def __init__(self, nntps):
         super(Nntp, self).__init__(nntps)
         self._meta_data['required_json_kind'] =\
@@ -375,7 +375,7 @@ class Nntp(UpdateMonitorMixin, Resource):
 
 
 class Nones(Collection):
-    """BigIP None monitor collection."""
+    """BIG-IP None monitor collection."""
     def __init__(self, monitor):
         super(Nones, self).__init__(monitor)
         self._meta_data['allowed_lazy_attributes'] = [NONE]
@@ -384,7 +384,7 @@ class Nones(Collection):
 
 
 class NONE(UpdateMonitorMixin, Resource):
-    """BigIP None monitor resource."""
+    """BIG-IP None monitor resource."""
     def __init__(self, nones):
         super(NONE, self).__init__(nones)
         self._meta_data['required_json_kind'] =\
@@ -392,7 +392,7 @@ class NONE(UpdateMonitorMixin, Resource):
 
 
 class Oracles(Collection):
-    """BigIP Oracle monitor collection."""
+    """BIG-IP Oracle monitor collection."""
     def __init__(self, monitor):
         super(Oracles, self).__init__(monitor)
         self._meta_data['allowed_lazy_attributes'] = [Oracle]
@@ -401,7 +401,7 @@ class Oracles(Collection):
 
 
 class Oracle(UpdateMonitorMixin, Resource):
-    """BigIP Oracle monitor resource."""
+    """BIG-IP Oracle monitor resource."""
     def __init__(self, oracles):
         super(Oracle, self).__init__(oracles)
         self._meta_data['required_json_kind'] =\
@@ -409,7 +409,7 @@ class Oracle(UpdateMonitorMixin, Resource):
 
 
 class Pop3s(Collection):
-    """BigIP Pop3 monitor collection."""
+    """BIG-IP Pop3 monitor collection."""
     def __init__(self, monitor):
         super(Pop3s, self).__init__(monitor)
         self._meta_data['allowed_lazy_attributes'] = [Pop3]
@@ -418,7 +418,7 @@ class Pop3s(Collection):
 
 
 class Pop3(UpdateMonitorMixin, Resource):
-    """BigIP Pop3 monitor resource."""
+    """BIG-IP Pop3 monitor resource."""
     def __init__(self, pop3s):
         super(Pop3, self).__init__(pop3s)
         self._meta_data['required_json_kind'] =\
@@ -426,7 +426,7 @@ class Pop3(UpdateMonitorMixin, Resource):
 
 
 class Postgresqls(Collection):
-    """BigIP PostGRES SQL monitor collection."""
+    """BIG-IP PostGRES SQL monitor collection."""
     def __init__(self, monitor):
         super(Postgresqls, self).__init__(monitor)
         self._meta_data['allowed_lazy_attributes'] = [Postgresql]
@@ -435,7 +435,7 @@ class Postgresqls(Collection):
 
 
 class Postgresql(UpdateMonitorMixin, Resource):
-    """BigIP PostGRES SQL monitor resource."""
+    """BIG-IP PostGRES SQL monitor resource."""
     def __init__(self, postgresqls):
         super(Postgresql, self).__init__(postgresqls)
         self._meta_data['required_json_kind'] =\
@@ -443,7 +443,7 @@ class Postgresql(UpdateMonitorMixin, Resource):
 
 
 class Radius_s(Collection):
-    """BigIP radius monitor collection."""
+    """BIG-IP radius monitor collection."""
     def __init__(self, monitor):
         super(Radius_s, self).__init__(monitor)
         self._meta_data['allowed_lazy_attributes'] = [Radius]
@@ -452,7 +452,7 @@ class Radius_s(Collection):
 
 
 class Radius(UpdateMonitorMixin, Resource):
-    """BigIP radius monitor resource."""
+    """BIG-IP radius monitor resource."""
     def __init__(self, radius_s):
         super(Radius, self).__init__(radius_s)
         self._meta_data['required_json_kind'] =\
@@ -460,7 +460,7 @@ class Radius(UpdateMonitorMixin, Resource):
 
 
 class Radius_Accountings(Collection):
-    """BigIP radius accounting monitor collection."""
+    """BIG-IP radius accounting monitor collection."""
     def __init__(self, monitor):
         super(Radius_Accountings, self).__init__(monitor)
         fixed = self._meta_data['uri'].replace('_', '-')
@@ -472,7 +472,7 @@ class Radius_Accountings(Collection):
 
 
 class Radius_Accounting(UpdateMonitorMixin, Resource):
-    """BigIP radius accounting monitor resource."""
+    """BIG-IP radius accounting monitor resource."""
     def __init__(self, radius_accountings):
         super(Radius_Accounting, self).__init__(radius_accountings)
         self._meta_data['required_json_kind'] =\
@@ -480,7 +480,7 @@ class Radius_Accounting(UpdateMonitorMixin, Resource):
 
 
 class Real_Servers(Collection):
-    """BigIP real-server monitor collection."""
+    """BIG-IP real-server monitor collection."""
     def __init__(self, monitor):
         super(Real_Servers, self).__init__(monitor)
         fixed = self._meta_data['uri'].replace('_', '-')
@@ -491,7 +491,7 @@ class Real_Servers(Collection):
 
 
 class Real_Server(UpdateMonitorMixin, Resource):
-    """BigIP real-server monitor resource."""
+    """BIG-IP real-server monitor resource."""
     def __init__(self, real_servers):
         super(Real_Server, self).__init__(real_servers)
         self._meta_data['required_json_kind'] =\
@@ -522,7 +522,7 @@ class Real_Server(UpdateMonitorMixin, Resource):
 
 
 class Rpcs(Collection):
-    """BigIP Rpc monitor collection."""
+    """BIG-IP Rpc monitor collection."""
     def __init__(self, monitor):
         super(Rpcs, self).__init__(monitor)
         self._meta_data['allowed_lazy_attributes'] = [Rpc]
@@ -531,7 +531,7 @@ class Rpcs(Collection):
 
 
 class Rpc(UpdateMonitorMixin, Resource):
-    """BigIP Rpc monitor resource."""
+    """BIG-IP Rpc monitor resource."""
     def __init__(self, rpcs):
         super(Rpc, self).__init__(rpcs)
         self._meta_data['required_json_kind'] =\
@@ -539,7 +539,7 @@ class Rpc(UpdateMonitorMixin, Resource):
 
 
 class Sasps(Collection):
-    """BigIP Sasp monitor collection."""
+    """BIG-IP Sasp monitor collection."""
     def __init__(self, monitor):
         super(Sasps, self).__init__(monitor)
         self._meta_data['allowed_lazy_attributes'] = [Sasp]
@@ -548,7 +548,7 @@ class Sasps(Collection):
 
 
 class Sasp(UpdateMonitorMixin, Resource):
-    """BigIP Sasp monitor resource."""
+    """BIG-IP Sasp monitor resource."""
     def __init__(self, sasps):
         super(Sasp, self).__init__(sasps)
         self._meta_data['required_creation_parameters'].update(
@@ -558,7 +558,7 @@ class Sasp(UpdateMonitorMixin, Resource):
 
 
 class Scripteds(Collection):
-    """BigIP scripted monitor collection."""
+    """BIG-IP scripted monitor collection."""
     def __init__(self, monitor):
         super(Scripteds, self).__init__(monitor)
         self._meta_data['allowed_lazy_attributes'] = [Scripted]
@@ -567,7 +567,7 @@ class Scripteds(Collection):
 
 
 class Scripted(UpdateMonitorMixin, Resource):
-    """BigIP scripted monitor resource."""
+    """BIG-IP scripted monitor resource."""
     def __init__(self, scripteds):
         super(Scripted, self).__init__(scripteds)
         self._meta_data['required_json_kind'] =\
@@ -575,7 +575,7 @@ class Scripted(UpdateMonitorMixin, Resource):
 
 
 class Sips(Collection):
-    """BigIP Sip monitor collection."""
+    """BIG-IP Sip monitor collection."""
     def __init__(self, monitor):
         super(Sips, self).__init__(monitor)
         self._meta_data['allowed_lazy_attributes'] = [Sip]
@@ -584,7 +584,7 @@ class Sips(Collection):
 
 
 class Sip(UpdateMonitorMixin, Resource):
-    """BigIP Sip monitor resource."""
+    """BIG-IP Sip monitor resource."""
     def __init__(self, sips):
         super(Sip, self).__init__(sips)
         self._meta_data['required_json_kind'] =\
@@ -592,7 +592,7 @@ class Sip(UpdateMonitorMixin, Resource):
 
 
 class Smbs(Collection):
-    """BigIP Smb monitor collection."""
+    """BIG-IP Smb monitor collection."""
     def __init__(self, monitor):
         super(Smbs, self).__init__(monitor)
         self._meta_data['allowed_lazy_attributes'] = [Smb]
@@ -601,7 +601,7 @@ class Smbs(Collection):
 
 
 class Smb(UpdateMonitorMixin, Resource):
-    """BigIP Smb monitor resource."""
+    """BIG-IP Smb monitor resource."""
     def __init__(self, smbs):
         super(Smb, self).__init__(smbs)
         self._meta_data['required_json_kind'] =\
@@ -609,7 +609,7 @@ class Smb(UpdateMonitorMixin, Resource):
 
 
 class Smtps(Collection):
-    """BigIP Smtp monitor collection."""
+    """BIG-IP Smtp monitor collection."""
     def __init__(self, monitor):
         super(Smtps, self).__init__(monitor)
         self._meta_data['allowed_lazy_attributes'] = [Smtp]
@@ -618,7 +618,7 @@ class Smtps(Collection):
 
 
 class Smtp(UpdateMonitorMixin, Resource):
-    """BigIP Smtp monitor resource."""
+    """BIG-IP Smtp monitor resource."""
     def __init__(self, smtps):
         super(Smtp, self).__init__(smtps)
         self._meta_data['required_json_kind'] =\
@@ -626,7 +626,7 @@ class Smtp(UpdateMonitorMixin, Resource):
 
 
 class Snmp_Dcas(Collection):
-    """BigIP SNMP DCA monitor collection."""
+    """BIG-IP SNMP DCA monitor collection."""
     def __init__(self, monitor):
         super(Snmp_Dcas, self).__init__(monitor)
         fixed = self._meta_data['uri'].replace('_', '-')
@@ -637,7 +637,7 @@ class Snmp_Dcas(Collection):
 
 
 class Snmp_Dca(UpdateMonitorMixin, Resource):
-    """BigIP SNMP DCA monitor resource."""
+    """BIG-IP SNMP DCA monitor resource."""
     def __init__(self, snmp_dcas):
         super(Snmp_Dca, self).__init__(snmp_dcas)
         self._meta_data['required_json_kind'] =\
@@ -645,7 +645,7 @@ class Snmp_Dca(UpdateMonitorMixin, Resource):
 
 
 class Snmp_Dca_Bases(Collection):
-    """BigIP SNMP DCA bases monitor collection."""
+    """BIG-IP SNMP DCA bases monitor collection."""
     def __init__(self, monitor):
         super(Snmp_Dca_Bases, self).__init__(monitor)
         fixed = self._meta_data['uri'].replace('_', '-')
@@ -656,7 +656,7 @@ class Snmp_Dca_Bases(Collection):
 
 
 class Snmp_Dca_Base(UpdateMonitorMixin, Resource):
-    """BigIP SNMP DCA monitor resource."""
+    """BIG-IP SNMP DCA monitor resource."""
     def __init__(self, snmp_dca_bases):
         super(Snmp_Dca_Base, self).__init__(snmp_dca_bases)
         self._meta_data['required_json_kind'] =\
@@ -664,7 +664,7 @@ class Snmp_Dca_Base(UpdateMonitorMixin, Resource):
 
 
 class Soaps(Collection):
-    """BigIP Soap monitor collection."""
+    """BIG-IP Soap monitor collection."""
     def __init__(self, monitor):
         super(Soaps, self).__init__(monitor)
         self._meta_data['allowed_lazy_attributes'] = [Soap]
@@ -673,7 +673,7 @@ class Soaps(Collection):
 
 
 class Soap(UpdateMonitorMixin, Resource):
-    """BigIP Soap monitor resource."""
+    """BIG-IP Soap monitor resource."""
     def __init__(self, soaps):
         super(Soap, self).__init__(soaps)
         self._meta_data['required_json_kind'] =\
@@ -681,7 +681,7 @@ class Soap(UpdateMonitorMixin, Resource):
 
 
 class Tcps(Collection):
-    """BigIP Tcp monitor collection."""
+    """BIG-IP Tcp monitor collection."""
     def __init__(self, monitor):
         super(Tcps, self).__init__(monitor)
         self._meta_data['allowed_lazy_attributes'] = [Tcp]
@@ -690,7 +690,7 @@ class Tcps(Collection):
 
 
 class Tcp(UpdateMonitorMixin, Resource):
-    """BigIP Tcp monitor resource."""
+    """BIG-IP Tcp monitor resource."""
     def __init__(self, tcps):
         super(Tcp, self).__init__(tcps)
         self._meta_data['required_json_kind'] =\
@@ -698,7 +698,7 @@ class Tcp(UpdateMonitorMixin, Resource):
 
 
 class Tcp_Echos(Collection):
-    """BigIP Tcp echo monitor collection."""
+    """BIG-IP Tcp echo monitor collection."""
     def __init__(self, monitor):
         super(Tcp_Echos, self).__init__(monitor)
         fixed = self._meta_data['uri'].replace('_', '-')
@@ -709,7 +709,7 @@ class Tcp_Echos(Collection):
 
 
 class Tcp_Echo(UpdateMonitorMixin, Resource):
-    """BigIP Tcp echo monitor resource."""
+    """BIG-IP Tcp echo monitor resource."""
     def __init__(self, tcp_echos):
         super(Tcp_Echo, self).__init__(tcp_echos)
         self._meta_data['required_json_kind'] =\
@@ -717,7 +717,7 @@ class Tcp_Echo(UpdateMonitorMixin, Resource):
 
 
 class Tcp_Half_Opens(Collection):
-    """BigIP Tcp half open monitor collection."""
+    """BIG-IP Tcp half open monitor collection."""
     def __init__(self, monitor):
         super(Tcp_Half_Opens, self).__init__(monitor)
         fixed = self._meta_data['uri'].replace('_', '-')
@@ -728,7 +728,7 @@ class Tcp_Half_Opens(Collection):
 
 
 class Tcp_Half_Open(UpdateMonitorMixin, Resource):
-    """BigIP Tcp half open monitor resource."""
+    """BIG-IP Tcp half open monitor resource."""
     def __init__(self, tcp_half_opens):
         super(Tcp_Half_Open, self).__init__(tcp_half_opens)
         self._meta_data['required_json_kind'] =\
@@ -736,7 +736,7 @@ class Tcp_Half_Open(UpdateMonitorMixin, Resource):
 
 
 class Udps(Collection):
-    """BigIP Udp monitor collection."""
+    """BIG-IP Udp monitor collection."""
     def __init__(self, monitor):
         super(Udps, self).__init__(monitor)
         self._meta_data['allowed_lazy_attributes'] = [Udp]
@@ -745,7 +745,7 @@ class Udps(Collection):
 
 
 class Udp(UpdateMonitorMixin, Resource):
-    """BigIP Udp monitor resource."""
+    """BIG-IP Udp monitor resource."""
     def __init__(self, udps):
         super(Udp, self).__init__(udps)
         self._meta_data['required_json_kind'] =\
@@ -753,7 +753,7 @@ class Udp(UpdateMonitorMixin, Resource):
 
 
 class Virtual_Locations(Collection):
-    """BigIP virtual-locations monitor collection."""
+    """BIG-IP virtual-locations monitor collection."""
     def __init__(self, monitor):
         super(Virtual_Locations, self).__init__(monitor)
         fixed = self._meta_data['uri'].replace('_', '-')
@@ -765,7 +765,7 @@ class Virtual_Locations(Collection):
 
 
 class Virtual_Location(UpdateMonitorMixin, Resource):
-    """BigIP virtual-locations monitor resource."""
+    """BIG-IP virtual-locations monitor resource."""
     def __init__(self, virtual_locations):
         super(Virtual_Location, self).__init__(virtual_locations)
         self._meta_data['required_creation_parameters'].update(
@@ -775,7 +775,7 @@ class Virtual_Location(UpdateMonitorMixin, Resource):
 
 
 class Waps(Collection):
-    """BigIP Wap monitor collection."""
+    """BIG-IP Wap monitor collection."""
     def __init__(self, monitor):
         super(Waps, self).__init__(monitor)
         self._meta_data['allowed_lazy_attributes'] = [Wap]
@@ -784,7 +784,7 @@ class Waps(Collection):
 
 
 class Wap(UpdateMonitorMixin, Resource):
-    """BigIP Wap monitor resource."""
+    """BIG-IP Wap monitor resource."""
     def __init__(self, waps):
         super(Wap, self).__init__(waps)
         self._meta_data['required_json_kind'] =\
@@ -792,7 +792,7 @@ class Wap(UpdateMonitorMixin, Resource):
 
 
 class Wmis(Collection):
-    """BigIP Wmi monitor collection."""
+    """BIG-IP Wmi monitor collection."""
     def __init__(self, monitor):
         super(Wmis, self).__init__(monitor)
         self._meta_data['allowed_lazy_attributes'] = [Wmi]
@@ -801,7 +801,7 @@ class Wmis(Collection):
 
 
 class Wmi(UpdateMonitorMixin, Resource):
-    """BigIP Wmi monitor resource."""
+    """BIG-IP Wmi monitor resource."""
     def __init__(self, wmis):
         super(Wmi, self).__init__(wmis)
         self._meta_data['required_json_kind'] =\

--- a/f5/bigip/ltm/nat.py
+++ b/f5/bigip/ltm/nat.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-"""BigIP Local Traffic Manager (LTM) Nat module.
+"""BIG-IP Local Traffic Manager (LTM) Nat module.
 
 REST URI
     ``http://localhost/mgmt/tm/ltm/nat``
@@ -31,7 +31,7 @@ from f5.bigip.resource import Resource
 
 
 class Nats(Collection):
-    """BigIP LTM Nat collection object"""
+    """BIG-IP LTM Nat collection object"""
     def __init__(self, ltm):
         super(Nats, self).__init__(ltm)
         self._meta_data['allowed_lazy_attributes'] = [Nat]
@@ -40,7 +40,7 @@ class Nats(Collection):
 
 
 class Nat(Resource, ExclusiveAttributesMixin):
-    """BigIP LTM Nat collection resource"""
+    """BIG-IP LTM Nat collection resource"""
     def __init__(self, nat_s):
         super(Nat, self).__init__(nat_s)
         self._meta_data['required_creation_parameters'].update(
@@ -49,7 +49,7 @@ class Nat(Resource, ExclusiveAttributesMixin):
         self._meta_data['exclusive_attributes'].append(('enable', 'disable'))
 
     def create(self, **kwargs):
-        """Create the resource on the BigIP.
+        """Create the resource on the BIG-IP.
 
         Uses HTTP POST to the `collection` URI to create a resource associated
         with a new unique URI on the device.
@@ -73,7 +73,7 @@ class Nat(Resource, ExclusiveAttributesMixin):
 
         :param kwargs: All the key-values needed to create the resource
         :returns: ``self`` - A python object that represents the object's
-                  configuration and state on the BigIP.
+                  configuration and state on the BIG-IP.
 
         """
         itg = kwargs.get('inheritedTrafficGroup', None)

--- a/f5/bigip/ltm/node.py
+++ b/f5/bigip/ltm/node.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 #
 
-"""BigIP Local Traffic Manager (LTM) node module.
+"""BIG-IP Local Traffic Manager (LTM) node module.
 
 REST URI
     ``http://localhost/mgmt/tm/ltm/node``
@@ -30,7 +30,7 @@ from f5.bigip.resource import Resource
 
 
 class Nodes(Collection):
-    """BigIP LTM node collection"""
+    """BIG-IP LTM node collection"""
     def __init__(self, ltm):
         super(Nodes, self).__init__(ltm)
         self._meta_data['allowed_lazy_attributes'] = [Node]
@@ -39,7 +39,7 @@ class Nodes(Collection):
 
 
 class Node(Resource):
-    """BigIP LTM node resource"""
+    """BIG-IP LTM node resource"""
     def __init__(self, nodes):
         super(Node, self).__init__(nodes)
         self._meta_data['required_json_kind'] = 'tm:ltm:node:nodestate'

--- a/f5/bigip/ltm/policy.py
+++ b/f5/bigip/ltm/policy.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 #
 
-"""BigIP Local Traffic Manager (LTM) policy module.
+"""BIG-IP Local Traffic Manager (LTM) policy module.
 
 REST URI
     ``http://localhost/mgmt/tm/ltm/policy``
@@ -30,7 +30,7 @@ from f5.bigip.resource import Resource
 
 
 class Policys(Collection):
-    """BigIP LTM policy collection."""
+    """BIG-IP LTM policy collection."""
     def __init__(self, ltm):
         super(Policys, self).__init__(ltm)
         self._meta_data['allowed_lazy_attributes'] = [Policy]
@@ -39,7 +39,7 @@ class Policys(Collection):
 
 
 class Policy(Resource):
-    """BigIP LTM policy resource."""
+    """BIG-IP LTM policy resource."""
     def __init__(self, policy_s):
         super(Policy, self).__init__(policy_s)
         self._meta_data['required_json_kind'] = 'tm:ltm:policy:policystate'
@@ -49,7 +49,7 @@ class Policy(Resource):
 
 
 class Rules_s(Collection):
-    """BigIP LTM policy rules sub-collection."""
+    """BIG-IP LTM policy rules sub-collection."""
     def __init__(self, policy):
         super(Rules_s, self).__init__(policy)
         self._meta_data['attribute_registry'] =\
@@ -60,7 +60,7 @@ class Rules_s(Collection):
 
 
 class Rules(Resource):
-    """BigIP LTM policy rules sub-collection resource."""
+    """BIG-IP LTM policy rules sub-collection resource."""
     def __init__(self, rules_s):
         super(Rules, self).__init__(rules_s)
         self._meta_data['required_json_kind'] =\
@@ -73,7 +73,7 @@ class Rules(Resource):
 
 
 class Actions_s(Collection):
-    """BigIP LTM policy actions sub-collection."""
+    """BIG-IP LTM policy actions sub-collection."""
     def __init__(self, rules):
         super(Actions_s, self).__init__(rules)
         self._meta_data['required_json_kind'] =\
@@ -84,7 +84,7 @@ class Actions_s(Collection):
 
 
 class Actions(Resource):
-    """BigIP LTM policy actions sub-collection resource."""
+    """BIG-IP LTM policy actions sub-collection resource."""
     def __init__(self, actions_s):
         super(Actions, self).__init__(actions_s)
         self._meta_data['required_json_kind'] =\
@@ -92,7 +92,7 @@ class Actions(Resource):
 
 
 class Conditions_s(Collection):
-    """BigIP LTM policy conditions sub-collection."""
+    """BIG-IP LTM policy conditions sub-collection."""
     def __init__(self, rules):
         super(Conditions_s, self).__init__(rules)
         self._meta_data['required_json_kind'] =\
@@ -103,7 +103,7 @@ class Conditions_s(Collection):
 
 
 class Conditions(Resource):
-    """BigIP LTM policy conditions sub-collection resource."""
+    """BIG-IP LTM policy conditions sub-collection resource."""
     def __init__(self, conditions_s):
         super(Conditions, self).__init__(conditions_s)
         self._meta_data['required_json_kind'] =\

--- a/f5/bigip/ltm/pool.py
+++ b/f5/bigip/ltm/pool.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 #
 
-"""BigIP Local Traffic Manager (LTM) pool module.
+"""BIG-IP Local Traffic Manager (LTM) pool module.
 
 REST URI
     ``http://localhost/mgmt/tm/ltm/pool``
@@ -35,7 +35,7 @@ class MemberStateAlwaysRequiredOnUpdate(F5SDKError):
 
 
 class Pools(Collection):
-    """BigIP LTM pool collection"""
+    """BIG-IP LTM pool collection"""
     def __init__(self, ltm):
         super(Pools, self).__init__(ltm)
         self._meta_data['allowed_lazy_attributes'] = [Pool]
@@ -44,7 +44,7 @@ class Pools(Collection):
 
 
 class Pool(Resource):
-    """BigIP LTM pool resource"""
+    """BIG-IP LTM pool resource"""
     def __init__(self, pool_s):
         super(Pool, self).__init__(pool_s)
         self._meta_data['required_json_kind'] = 'tm:ltm:pool:poolstate'
@@ -54,7 +54,7 @@ class Pool(Resource):
 
 
 class Members_s(Collection):
-    """BigIP LTM pool members sub-collection"""
+    """BIG-IP LTM pool members sub-collection"""
     def __init__(self, pool):
         super(Members_s, self).__init__(pool)
         self._meta_data['allowed_lazy_attributes'] = [Members]
@@ -65,7 +65,7 @@ class Members_s(Collection):
 
 
 class Members(Resource):
-    """BigIP LTM pool members sub-collection resource"""
+    """BIG-IP LTM pool members sub-collection resource"""
     def __init__(self, members_s):
         super(Members, self).__init__(members_s)
         self._meta_data['required_json_kind'] =\

--- a/f5/bigip/ltm/rule.py
+++ b/f5/bigip/ltm/rule.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 #
 
-"""BigIP Local Traffic Manager (LTM) rule module.
+"""BIG-IP Local Traffic Manager (LTM) rule module.
 
 REST URI
     ``http://localhost/mgmt/tm/ltm/rule``
@@ -30,7 +30,7 @@ from f5.bigip.resource import Resource
 
 
 class Rules(Collection):
-    """BigIP LTM rule collection"""
+    """BIG-IP LTM rule collection"""
     def __init__(self, ltm):
         super(Rules, self).__init__(ltm)
         self._meta_data['allowed_lazy_attributes'] = [Rule]
@@ -39,7 +39,7 @@ class Rules(Collection):
 
 
 class Rule(Resource):
-    """BigIP LTM rule resource"""
+    """BIG-IP LTM rule resource"""
     def __init__(self, rule_s):
         super(Rule, self).__init__(rule_s)
         self._meta_data['required_json_kind'] = 'tm:ltm:rule:rulestate'

--- a/f5/bigip/ltm/snat.py
+++ b/f5/bigip/ltm/snat.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 #
 
-"""BigIP Local Traffic Manager (LTM) Snat module.
+"""BIG-IP Local Traffic Manager (LTM) Snat module.
 
 REST URI
     ``http://localhost/mgmt/tm/ltm/snat``
@@ -35,7 +35,7 @@ class RequireOneOf(MissingRequiredCreationParameter):
 
 
 class Snats(Collection):
-    """BigIP LTM Snat collection"""
+    """BIG-IP LTM Snat collection"""
     def __init__(self, ltm):
         super(Snats, self).__init__(ltm)
         self._meta_data['allowed_lazy_attributes'] = [Snat]
@@ -44,7 +44,7 @@ class Snats(Collection):
 
 
 class Snat(Resource):
-    """BigIP LTM Snat resource"""
+    """BIG-IP LTM Snat resource"""
     def __init__(self, snat_s):
         '''This represents a Snat.
 
@@ -57,7 +57,7 @@ class Snat(Resource):
             ('partition', 'origins'))
 
     def create(self, **kwargs):
-        """Call this to create a new snat on the BigIP.
+        """Call this to create a new snat on the BIG-IP.
 
         Uses HTTP POST to 'containing' URI to create a service associated with
         a new URI on the device.
@@ -68,7 +68,7 @@ class Snat(Resource):
         Object.selfLink, the actual uri used by REST operations on the object
         is Object._meta_data['uri'].  The _meta_data['uri'] is the same as
         Object.selfLink with the substring 'localhost' replaced with the value
-        of Object._meta_data['bigip']._meta_data['hostname'], and without
+        of Object._meta_data['BIG-IP']._meta_data['hostname'], and without
         query args, or hash fragments.
 
         The following is done prior to the POST

--- a/f5/bigip/ltm/virtual.py
+++ b/f5/bigip/ltm/virtual.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 #
 
-"""BigIP Local Traffic Manager (LTM) virtual module.
+"""BIG-IP Local Traffic Manager (LTM) virtual module.
 
 REST URI
     ``http://localhost/mgmt/tm/ltm/virtual``
@@ -30,7 +30,7 @@ from f5.bigip.resource import Resource
 
 
 class Virtuals(Collection):
-    """BigIP LTM virtual collection"""
+    """BIG-IP LTM virtual collection"""
     def __init__(self, ltm):
         super(Virtuals, self).__init__(ltm)
         self._meta_data['allowed_lazy_attributes'] = [Virtual]
@@ -39,7 +39,7 @@ class Virtuals(Collection):
 
 
 class Virtual(Resource):
-    """BigIP LTM virtual resource"""
+    """BIG-IP LTM virtual resource"""
     def __init__(self, virtual_s):
         super(Virtual, self).__init__(virtual_s)
         self._meta_data['required_json_kind'] = 'tm:ltm:virtual:virtualstate'

--- a/f5/bigip/net/__init__.py
+++ b/f5/bigip/net/__init__.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 #
 
-"""BigIP net module
+"""BIG-IP net module
 
 REST URI
     ``http://localhost/mgmt/tm/net/``

--- a/f5/bigip/net/arp.py
+++ b/f5/bigip/net/arp.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 #
 
-"""BigIP Network ARP module.
+"""BIG-IP Network ARP module.
 
 REST URI
     ``http://localhost/mgmt/tm/net/arp``
@@ -30,7 +30,7 @@ from f5.bigip.resource import Resource
 
 
 class Arps(Collection):
-    """BigIP network ARP collection"""
+    """BIG-IP network ARP collection"""
     def __init__(self, net):
         super(Arps, self).__init__(net)
         self._meta_data['allowed_lazy_attributes'] = [Arp]
@@ -40,7 +40,7 @@ class Arps(Collection):
 
 
 class Arp(Resource):
-    """BigIP network ARP resource"""
+    """BIG-IP network ARP resource"""
     def __init__(self, arp_s):
         super(Arp, self).__init__(arp_s)
         self._meta_data['required_json_kind'] = 'tm:net:arp:arpstate'

--- a/f5/bigip/net/interface.py
+++ b/f5/bigip/net/interface.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 #
 
-"""BigIP Network interface module.
+"""BIG-IP Network interface module.
 
 REST URI
     ``http://localhost/mgmt/tm/net/interface``
@@ -32,7 +32,7 @@ from f5.bigip.resource import UnsupportedOperation
 
 
 class Interfaces(Collection):
-    """BigIP network interface collection"""
+    """BIG-IP network interface collection"""
     def __init__(self, net):
         super(Interfaces, self).__init__(net)
         self._meta_data['allowed_lazy_attributes'] = [Interface]
@@ -42,7 +42,7 @@ class Interfaces(Collection):
 
 
 class Interface(Resource, ExclusiveAttributesMixin):
-    """BigIP network interface collection"""
+    """BIG-IP network interface collection"""
     def __init__(self, interface_s):
         super(Interface, self).__init__(interface_s)
         self._meta_data['required_json_kind'] =\
@@ -52,7 +52,7 @@ class Interface(Resource, ExclusiveAttributesMixin):
     def create(self, **kwargs):
         """Create is not supported for interfaces.
 
-        :raises: :exc:`~f5.bigip.resource.UnsupportedOperation`
+        :raises: :exc:`~f5.BIG-IP.resource.UnsupportedOperation`
         """
         raise UnsupportedOperation(
             "BigIP interfaces cannot be created by users")
@@ -60,7 +60,7 @@ class Interface(Resource, ExclusiveAttributesMixin):
     def delete(self):
         """Delete is not supported for interfaces.
 
-        :raises: :exc:`~f5.bigip.resource.UnsupportedOperation`
+        :raises: :exc:`~f5.BIG-IP.resource.UnsupportedOperation`
         """
         raise UnsupportedOperation(
             "BigIP interfaces cannot be deleted by users")

--- a/f5/bigip/net/route.py
+++ b/f5/bigip/net/route.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 #
 
-"""BigIP Network route module.
+"""BIG-IP Network route module.
 
 REST URI
     ``http://localhost/mgmt/tm/net/route``
@@ -32,7 +32,7 @@ from f5.bigip.resource import Resource
 
 
 class Routes(Collection):
-    """BigIP network route collection"""
+    """BIG-IP network route collection"""
     def __init__(self, net):
         super(Routes, self).__init__(net)
         self._meta_data['allowed_lazy_attributes'] = [Route]
@@ -42,7 +42,7 @@ class Routes(Collection):
 
 
 class Route(Resource, ExclusiveAttributesMixin):
-    """BigIP network route resource"""
+    """BIG-IP network route resource"""
     def __init__(self, route_s):
         super(Route, self).__init__(route_s)
         self._meta_data['required_json_kind'] = 'tm:net:route:routestate'
@@ -53,7 +53,7 @@ class Route(Resource, ExclusiveAttributesMixin):
             ('blackhole', 'gw', 'tmInterface', 'pool'))
 
     def create(self, **kwargs):
-        '''Create a Route on the BigIP and the associated python object.
+        '''Create a Route on the BIG-IP and the associated python object.
 
         One of the following gateways is required when creating the route
         objects: ``blackhole``, ``gw``, ``tmInterface``, ``pool``.

--- a/f5/bigip/net/selfip.py
+++ b/f5/bigip/net/selfip.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 #
 
-"""BigIP Network self-ip module.
+"""BIG-IP Network self-ip module.
 
 .. note::
 
@@ -35,7 +35,7 @@ from f5.bigip.resource import Resource
 
 
 class Selfips(Collection):
-    """BigIP network Self-IP collection
+    """BIG-IP network Self-IP collection
 
     .. note::
 
@@ -54,11 +54,11 @@ class Selfips(Collection):
 
 
 class Selfip(Resource):
-    '''BigIP Self-IP resource
+    '''BIG-IP Self-IP resource
 
     Use this object to create, refresh, update, delete, and load self ip
-    configuration on the BIGIP.  This requires that a
-    :class:`~f5.bigip.network.vlan.VLAN` object be present on the system and
+    configuration on the BIG-IP.  This requires that a
+    :class:`~f5.BIG-IP.network.vlan.VLAN` object be present on the system and
     that object's :attrib:`fullPath` be used as the VLAN name.
 
     The address that is used for create is a *<ipaddress>/<netmask>*.  For

--- a/f5/bigip/net/tunnels.py
+++ b/f5/bigip/net/tunnels.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 #
 
-"""BigIP Network tunnels module.
+"""BIG-IP Network tunnels module.
 
 REST URI
     ``http://localhost/mgmt/tm/net/tunnels``
@@ -30,7 +30,7 @@ from f5.bigip.resource import Resource
 
 
 class Tunnels_s(Collection):
-    """BigIP network tunnels collection"""
+    """BIG-IP network tunnels collection"""
     def __init__(self, net):
         super(Tunnels_s, self).__init__(net)
         self._meta_data['allowed_lazy_attributes'] = [
@@ -41,7 +41,7 @@ class Tunnels_s(Collection):
 
 
 class Tunnels(Collection):
-    """BigIP network tunnels resource (collection for GRE, Tunnel, VXLANs"""
+    """BIG-IP network tunnels resource (collection for GRE, Tunnel, VXLANs"""
     def __init__(self, tunnels_s):
         super(Tunnels, self).__init__(tunnels_s)
         self._meta_data['allowed_lazy_attributes'] = [Gres, Tunnel, Vxlans]
@@ -50,7 +50,7 @@ class Tunnels(Collection):
 
 
 class Tunnel(Resource):
-    """BigIP tunnels tunnel resource"""
+    """BIG-IP tunnels tunnel resource"""
     def __init__(self, tunnels):
         super(Tunnel, self).__init__(tunnels)
         self._meta_data['required_creation_parameters'].update(('partition',))
@@ -59,7 +59,7 @@ class Tunnel(Resource):
 
 
 class Gres(Collection):
-    """BigIP tunnels GRE sub-collection"""
+    """BIG-IP tunnels GRE sub-collection"""
     def __init__(self, tunnels_s):
         super(Gres, self).__init__(tunnels_s)
         self._meta_data['allowed_lazy_attributes'] = [Gre]
@@ -68,7 +68,7 @@ class Gres(Collection):
 
 
 class Gre(Resource):
-    """BigIP tunnels GRE sub-collection resource"""
+    """BIG-IP tunnels GRE sub-collection resource"""
     def __init__(self, gres):
         super(Gre, self).__init__(gres)
         self._meta_data['required_creation_parameters'].update(('partition',))
@@ -77,7 +77,7 @@ class Gre(Resource):
 
 
 class Vxlans(Collection):
-    """BigIP tunnels VXLAN sub-collection"""
+    """BIG-IP tunnels VXLAN sub-collection"""
     def __init__(self, tunnels_s):
         super(Vxlans, self).__init__(tunnels_s)
         self._meta_data['allowed_lazy_attributes'] = [Vxlan]
@@ -86,7 +86,7 @@ class Vxlans(Collection):
 
 
 class Vxlan(Resource):
-    """BigIP tunnels VXLAN sub-collection resource"""
+    """BIG-IP tunnels VXLAN sub-collection resource"""
     def __init__(self, vxlans):
         super(Vxlan, self).__init__(vxlans)
         self._meta_data['required_creation_parameters'].update(('partition',))

--- a/f5/bigip/net/vlan.py
+++ b/f5/bigip/net/vlan.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 #
 
-"""BigIP Network vlan module.
+"""BIG-IP Network vlan module.
 
 REST URI
     ``http://localhost/mgmt/tm/net/vlan``
@@ -31,7 +31,7 @@ from f5.bigip.resource import Resource
 
 
 class Vlans(Collection):
-    """BigIP network Vlan collection."""
+    """BIG-IP network Vlan collection."""
     def __init__(self, net):
         super(Vlans, self).__init__(net)
         self._meta_data['allowed_lazy_attributes'] = [Vlan]
@@ -40,7 +40,7 @@ class Vlans(Collection):
 
 
 class Vlan(Resource):
-    """BigIP network Vlan resource."""
+    """BIG-IP network Vlan resource."""
     def __init__(self, vlan_s):
         super(Vlan, self).__init__(vlan_s)
         self._meta_data['required_json_kind'] = 'tm:net:vlan:vlanstate'
@@ -49,11 +49,11 @@ class Vlan(Resource):
 
 
 class Interfaces_s(Collection):
-    '''BigIP network Vlan interface collection.
+    '''BIG-IP network Vlan interface collection.
 
     .. note::
         Not to be confused with ``tm/mgmt/net/interface``.  This is object
-        is actually called ``interfaces`` with an ``s`` by the BIGIP's REST
+        is actually called ``interfaces`` with an ``s`` by the BIG-IP's REST
         API.
     '''
     def __init__(self, vlan):
@@ -64,7 +64,7 @@ class Interfaces_s(Collection):
 
 
 class Interfaces(Resource, ExclusiveAttributesMixin):
-    """BigIP network Vlan interface resource."""
+    """BIG-IP network Vlan interface resource."""
     def __init__(self, interfaces_s):
         super(Interfaces, self).__init__(interfaces_s)
         # Vlan intefaces objects do not have a partition

--- a/f5/bigip/resource.py
+++ b/f5/bigip/resource.py
@@ -31,14 +31,14 @@ Examples:
  * Expression:     pool_a = pools1.create(partition="Common", name="foo")
  * URI Returned:   https://a/mgmt/tm/ltm/pool/~Common~foo
 
-There are different types of resources published by the BigIP REST Server, they
-are represented by the classes in this module.
+There are different types of resources published by the BIG-IP REST Server,
+they are represented by the classes in this module.
 
 We refer to a server-provided resource as a "service".  Thus far all URI
 referenced resources are "services" in this sense.
 
 We use methods named Create, Refresh, Update, Load, and Delete to manipulate
-BigIP device services.
+BIG-IP device services.
 
 Methods:
 
@@ -60,8 +60,8 @@ Available Classes:
       constructor to match its call in LazyAttributeMixin.__getattr__. The
       expected behavior is that all resource subclasses depend on this
       constructor to correctly set their self._meta_data['uri'].
-      All ResourceBase objects (except BigIPs) have a container (BigIPs contain
-      themselves).  The container is the object the ResourceBase is an
+      All ResourceBase objects (except BIG-IPs) have a container (BIG-IPs
+      contain themselves).  The container is the object the ResourceBase is an
       attribute of.
     * OrganizingCollection -- These resources support lists of "reference"
       "links". These are json blobs without a Python class representation.
@@ -124,7 +124,7 @@ class UnregisteredKind(F5SDKError):
 
 
 class GenerationMismatch(F5SDKError):
-    """The server reported BigIP is not the expacted value."""
+    """The server reported BIG-IP is not the expacted value."""
     pass
 
 
@@ -144,9 +144,9 @@ class UnsupportedOperation(F5SDKError):
 
 
 class ResourceBase(LazyAttributeMixin, ToDictMixin):
-    """Base class for all BigIP iControl REST API endpoints.
+    """Base class for all BIG-IP iControl REST API endpoints.
 
-    The BigIP is represented by an object that converts device published uri's
+    The BIG-IP is represented by an object that converts device published uri's
     into Python objects.  Each uri maps to a Python object. The mechanism for
     instantiating these objects is the __getattr__ Special Function in the
     LazyAttributeMixin.  When a registered attribute is `dot` referenced, on
@@ -168,7 +168,7 @@ class ResourceBase(LazyAttributeMixin, ToDictMixin):
     Critically this enforces a convention relating device published uris to
     API objects, in a hierarchy similar to the uri paths.  I.E. the uri
     corresponding to a ``Nats`` object is ``mgmt/tm/ltm/nat/``. If you
-    query the bigip's uri (e.g. print(bigip._meta_data['uri']) ), you'll see
+    query the BIG-IP's uri (e.g. print(bigip._meta_data['uri']) ), you'll see
     that it ends in:
     ``/mgmt/tm/``, if you query the ``ltm`` object's uri
     (e.g. print(bigip.ltm._meta_data['uri']) ) you'll see it ends in
@@ -194,7 +194,7 @@ class ResourceBase(LazyAttributeMixin, ToDictMixin):
 
         Since all ResourceBases sub-types must support the `refresh` method, it
         is defined here, in the base class.
-        NOTE: The BigIP uri 'mgmt/tm/' uniquely passes itself to this
+        NOTE: The BIG-IP uri 'mgmt/tm/' uniquely passes itself to this
         constructor as the "container".
 
         :param container: instance is an attribute of a ResourceBase container
@@ -327,9 +327,9 @@ class OrganizingCollection(ResourceBase):
       resources on the device.
     """
     def __init__(self, bigip):
-        """Call this to construct an OC. It should be an attribute of BigIP.
+        """Call this to construct an OC. It should be an attribute of BIG-IP.
 
-        :param bigip: all OCs are attributes of a BigIP instance
+        :param bigip: all OCs are attributes of a BIG-IP instance
         """
         super(OrganizingCollection, self).__init__(bigip)
         base_uri = self.__class__.__name__.lower() + '/'
@@ -554,7 +554,7 @@ class Resource(ResourceBase):
         return self
 
     def create(self, **kwargs):
-        """Create the resource on the BigIP.
+        """Create the resource on the BIG-IP.
 
         Uses HTTP POST to the `collection` URI to create a resource associated
         with a new unique URI on the device.
@@ -578,7 +578,7 @@ class Resource(ResourceBase):
         be passed to the underlying requests.session.post method where it will
         be handled according to that API. THIS IS HOW TO PASS QUERY-ARGS!
         :returns: ``self`` - A python object that represents the object's
-                  configuration and state on the BigIP.
+                  configuration and state on the BIG-IP.
 
         """
         self._create(**kwargs)
@@ -605,7 +605,7 @@ class Resource(ResourceBase):
     def load(self, **kwargs):
         """Load an already configured service into this instance.
 
-        This method uses HTTP GET to obtain a resource from the BigIP.
+        This method uses HTTP GET to obtain a resource from the BIG-IP.
 
         ..
             The URI of the target service is constructed from the instance's
@@ -643,8 +643,8 @@ class Resource(ResourceBase):
         session = self._meta_data['bigip']._meta_data['icr_session']
         read_only = self._meta_data.get('read_only_attributes', [])
 
-        # Get the current state of the object on BigIP and check the generation
-        # Use pop here because we don't want force in the data_dict
+        # Get the current state of the object on BIG-IP and check the
+        # generation Use pop here because we don't want force in the data_dict
         force = self._check_force_arg(kwargs.pop('force', False))
         if not force:
             self._check_generation()
@@ -655,7 +655,7 @@ class Resource(ResourceBase):
 
         # Need to remove any of the Collection objects from self.__dict__
         # because these are subCollections and _meta_data and
-        # other non-BIGIP attrs are not removed from the subCollections
+        # other non-BIG-IP attrs are not removed from the subCollections
         # See issue #146 for details
         for key, value in self.__dict__.items():
             if isinstance(value, Collection):
@@ -664,7 +664,7 @@ class Resource(ResourceBase):
 
         # Remove any read-only attributes from our data_dict before we update
         # the data dict with the attributes.  If they pass in read-only attrs
-        # in the method call we are going to let BIGIP let them know about it
+        # in the method call we are going to let BIG-IP let them know about it
         # when it fails
         for attr in read_only:
             data_dict.pop(attr, '')
@@ -675,9 +675,9 @@ class Resource(ResourceBase):
         self._local_update(response.json())
 
     def update(self, **kwargs):
-        """Update the configuration of the resource on the BigIP.
+        """Update the configuration of the resource on the BIG-IP.
 
-        This method uses HTTP PUT alter the resource state on the BigIP.
+        This method uses HTTP PUT alter the resource state on the BIG-IP.
 
         The attributes of the instance will be packaged as a dictionary.  That
         dictionary will be updated with kwargs.  It is then submitted as JSON
@@ -711,9 +711,9 @@ class Resource(ResourceBase):
             self.__dict__ = {'deleted': True}
 
     def delete(self, **kwargs):
-        """Delete the resource on the BigIP.
+        """Delete the resource on the BIG-IP.
 
-        Uses HTTP DELETE to delete the resource on the BigIP.
+        Uses HTTP DELETE to delete the resource on the BIG-IP.
 
         After this method is called, and status_code 200 response is received
         ``instance.__dict__`` is replace with ``{'deleted': True}``
@@ -728,7 +728,7 @@ class Resource(ResourceBase):
         # Need to implement correct teardown here.
 
     def exists(self, **kwargs):
-        """Check for the existence of the named object on the BigIP
+        """Check for the existence of the named object on the BIG-IP
 
         Sends an HTTP GET to the URI of the named object and if it fails with
         a :exc:~requests.HTTPError` exception it checks the exception for
@@ -742,7 +742,7 @@ class Resource(ResourceBase):
         NOTE: If kwargs has a 'requests_params' key the corresponding dict will
         be passed to the underlying requests.session.get method where it will
         be handled according to that API. THIS IS HOW TO PASS QUERY-ARGS!
-        :returns: bool -- The objects exists on BigIP or not.
+        :returns: bool -- The objects exists on BIG-IP or not.
         :raises: :exc:`requests.HTTPError`, Any HTTP error that was not status
                  code 404.
         """
@@ -767,7 +767,7 @@ class Resource(ResourceBase):
         return force
 
     def _check_generation(self):
-        '''Check that the generation on the BigIP matches the object
+        '''Check that the generation on the BIG-IP matches the object
 
         This will do a get to the objects URI and check that the generation
         returned in the JSON matches the one the object currently has.  If it

--- a/f5/bigip/sys/__init__.py
+++ b/f5/bigip/sys/__init__.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 #
 
-"""BigIP System (sys) module
+"""BIG-IP System (sys) module
 
 REST URI
     ``http://localhost/mgmt/tm/sys/``

--- a/f5/bigip/sys/application.py
+++ b/f5/bigip/sys/application.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 #
 
-"""BigIP iApp (application) module
+"""BIG-IP iApp (application) module
 
 REST URI
     ``http://localhost/mgmt/sys/application/``
@@ -33,7 +33,7 @@ from requests import HTTPError
 
 
 class Applications(Collection):
-    """BigIP iApp collection."""
+    """BIG-IP iApp collection."""
     def __init__(self, sys):
         super(Applications, self).__init__(sys)
         self._meta_data['allowed_lazy_attributes'] = [
@@ -45,7 +45,7 @@ class Applications(Collection):
 
 
 class Aplscripts(Collection):
-    """BigIP iApp script collection."""
+    """BIG-IP iApp script collection."""
     def __init__(self, application):
         super(Aplscripts, self).__init__(application)
         self._meta_data['allowed_lazy_attributes'] = [Aplscript]
@@ -54,7 +54,7 @@ class Aplscripts(Collection):
 
 
 class Aplscript(Resource):
-    """BigIP iApp script resource."""
+    """BIG-IP iApp script resource."""
     def __init__(self, apl_script_s):
         super(Aplscript, self).__init__(apl_script_s)
         self._meta_data['required_json_kind'] =\
@@ -62,7 +62,7 @@ class Aplscript(Resource):
 
 
 class Customstats(Collection):
-    """BigIP iApp custom stats sub-collection."""
+    """BIG-IP iApp custom stats sub-collection."""
     def __init__(self, application):
         super(Customstats, self).__init__(application)
         self._meta_data['allowed_lazy_attributes'] = [Customstat]
@@ -71,7 +71,7 @@ class Customstats(Collection):
 
 
 class Customstat(Resource):
-    """BigIP iApp custom stats sub-collection resource."""
+    """BIG-IP iApp custom stats sub-collection resource."""
     def __init__(self, custom_stat_s):
         super(Customstat, self).__init__(custom_stat_s)
         self._meta_data['required_json_kind'] =\
@@ -79,7 +79,7 @@ class Customstat(Resource):
 
 
 class Services(Collection):
-    """BigIP iApp service sub-collection."""
+    """BIG-IP iApp service sub-collection."""
     def __init__(self, application):
         super(Services, self).__init__(application)
         self._meta_data['allowed_lazy_attributes'] = [Service]
@@ -88,7 +88,7 @@ class Services(Collection):
 
 
 class Service(Resource):
-    """BigIP iApp service sub-collection resource"""
+    """BIG-IP iApp service sub-collection resource"""
     def __init__(self, service_s):
         super(Service, self).__init__(service_s)
         self._meta_data['required_creation_parameters'].update(
@@ -116,7 +116,7 @@ class Service(Resource):
                     "retrieved" not in ex.response.text:
                 raise
 
-            # BigIP will create in Common partition if none is given.
+            # BIG-IP will create in Common partition if none is given.
             # In order to create the uri properly in this class's load,
             # drop in Common as the partition in kwargs.
             if 'partition' not in kwargs:
@@ -148,7 +148,7 @@ class Service(Resource):
         return self._update(**kwargs)
 
     def _load(self, **kwargs):
-        '''Load python Service object with response JSON from BigIP.
+        '''Load python Service object with response JSON from BIG-IP.
 
         :params kwargs: keyword arguments for talking to the device
         :returns: populated Service object
@@ -185,7 +185,7 @@ class Service(Resource):
         return '%s~%s~%s.app~%s' % (base_uri, partition, name, name)
 
     def exists(self, **kwargs):
-        '''Check for the existence of the named object on the BigIP
+        '''Check for the existence of the named object on the BIG-IP
 
         Override of resource.Resource exists() to build proper URI unique to
         service resources.
@@ -202,7 +202,7 @@ class Service(Resource):
         NOTE: If kwargs has a 'requests_params' key the corresponding dict will
         be passed to the underlying requests.session.get method where it will
         be handled according to that API. THIS IS HOW TO PASS QUERY-ARGS!
-        :returns: bool -- The objects exists on BigIP or not.
+        :returns: bool -- The objects exists on BIG-IP or not.
         :raises: :exc:`requests.HTTPError`, Any HTTP error that was not status
                  code 404.
         '''
@@ -228,7 +228,7 @@ class Service(Resource):
 
 
 class Templates(Collection):
-    """BigIP iApp template sub-collection"""
+    """BIG-IP iApp template sub-collection"""
     def __init__(self, application):
         super(Templates, self).__init__(application)
         self._meta_data['allowed_lazy_attributes'] = [Template]
@@ -237,7 +237,7 @@ class Templates(Collection):
 
 
 class Template(Resource):
-    """BigIP iApp template sub-collection resource"""
+    """BIG-IP iApp template sub-collection resource"""
     def __init__(self, template_s):
         super(Template, self).__init__(template_s)
         self._meta_data['required_creation_parameters'].update(('partition',))

--- a/f5/bigip/sys/db.py
+++ b/f5/bigip/sys/db.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 #
 
-"""BigIP db module
+"""BIG-IP db module
 
 REST URI
     ``http://localhost/mgmt/sys/db/``
@@ -31,7 +31,7 @@ from f5.bigip.resource import UnsupportedOperation
 
 
 class Dbs(Collection):
-    """BigIP db collection"""
+    """BIG-IP db collection"""
     def __init__(self, sys):
         super(Dbs, self).__init__(sys)
         self._meta_data['allowed_lazy_attributes'] = [Db]
@@ -40,7 +40,7 @@ class Dbs(Collection):
 
 
 class Db(Resource):
-    """BigIP db resource
+    """BIG-IP db resource
 
     .. note::
         db objects are read-only.

--- a/f5/bigip/sys/failover.py
+++ b/f5/bigip/sys/failover.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-"""BigIP system failover module
+"""BIG-IP system failover module
 
 REST URI
     ``http://localhost/mgmt/tm/sys/failover``
@@ -29,7 +29,7 @@ from f5.bigip.resource import Resource
 
 
 class Failover(UnnamedResourceMixin, Resource):
-    '''BigIP Failover stats and state change.
+    '''BIG-IP Failover stats and state change.
 
     The failover object only supports load, update, and refresh because it is
      an unnamed resource.

--- a/f5/bigip/sys/folder.py
+++ b/f5/bigip/sys/folder.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 #
 
-"""BigIP system folder (partition) module
+"""BIG-IP system folder (partition) module
 
 REST URI
     ``http://localhost/mgmt/tm/sys/folder``
@@ -31,7 +31,7 @@ from requests.exceptions import HTTPError
 
 
 class Folders(Collection):
-    """BigIP system folder collection.
+    """BIG-IP system folder collection.
 
     These are what we refer to as ``partition`` in the SDK.
     """
@@ -44,7 +44,7 @@ class Folders(Collection):
 
 class Folder(Resource):
     def __init__(self, folder_s):
-        '''BigIP system folder resource.
+        '''BIG-IP system folder resource.
 
         Folder objects are the same as the partition so we need to deal with
         them slightly differently than other Resources.  For example when
@@ -103,7 +103,7 @@ class Folder(Resource):
         return self._update(**kwargs)
 
     def exists(self, **kwargs):
-        """Check for the existence of the named object on the BigIP
+        """Check for the existence of the named object on the BIG-IP
 
         Tries to `load()` the object and if it fails checks the exception
         for 404.  If the `load()` is successful it returns `True` if the
@@ -115,7 +115,7 @@ class Folder(Resource):
         NOTE: If kwargs has a 'requests_params' key the corresponding dict will
         be passed to the underlying requests.session.get method where it will
         be handled according to that API. THIS IS HOW TO PASS QUERY-ARGS!
-        :returns: bool -- The objects exists on BigIP or not.
+        :returns: bool -- The objects exists on BIG-IP or not.
         :raises: :exc:`requests.HTTPError`, Any HTTP error that was not status
             code 404.
         """

--- a/f5/bigip/sys/global_settings.py
+++ b/f5/bigip/sys/global_settings.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 #
 
-"""BigIP system global-settings module
+"""BIG-IP system global-settings module
 
 REST URI
     ``http://localhost/mgmt/tm/sys/global-settings``
@@ -30,7 +30,7 @@ from f5.bigip.resource import Resource
 
 
 class Global_Settings(UnnamedResourceMixin, Resource):
-    """BigIP system global-settings resource
+    """BIG-IP system global-settings resource
 
     The global_settings object only supports load and update because it is an
     unnamed resource.

--- a/f5/bigip/sys/ntp.py
+++ b/f5/bigip/sys/ntp.py
@@ -13,7 +13,7 @@
 #   limitations under the License.
 #
 
-"""BigIP system ntp module
+"""BIG-IP system ntp module
 
 REST URI
     ``http://localhost/mgmt/tm/sys/ntp``
@@ -31,7 +31,7 @@ from f5.bigip.resource import Resource
 
 
 class Ntp(UnnamedResourceMixin, Resource):
-    """BigIP system NTP unnamed resource
+    """BIG-IP system NTP unnamed resource
 
         .. note::
 
@@ -51,7 +51,7 @@ class Ntp(UnnamedResourceMixin, Resource):
 
 
 class Restricts(Collection):
-    """BigIP system NTP restrict sub-collection"""
+    """BIG-IP system NTP restrict sub-collection"""
     def __init__(self, ntp):
         super(Restricts, self).__init__(ntp)
         self._meta_data['allowed_lazy_attributes'] = [Restrict]
@@ -62,7 +62,7 @@ class Restricts(Collection):
 
 
 class Restrict(Resource):
-    """BigIP system NTP restrict sub-collection resource"""
+    """BIG-IP system NTP restrict sub-collection resource"""
     def __init__(self, restricts):
         super(Restrict, self).__init__(restricts)
         self._meta_data['required_json_kind'] =\

--- a/f5/bigip/sys/performance.py
+++ b/f5/bigip/sys/performance.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 #
 
-"""BigIP system peformance stats module.
+"""BIG-IP system peformance stats module.
 
 REST URI
     ``http://localhost/mgmt/tm/sys/performance``
@@ -32,7 +32,7 @@ from f5.bigip.resource import UnsupportedOperation
 
 
 class Performance(Collection):
-    """BigIP system performace stats collection"""
+    """BIG-IP system performace stats collection"""
     def __init__(self, sys):
         super(Performance, self).__init__(sys)
         self._meta_data['allowed_lazy_attributes'] = [All_Stats]
@@ -40,9 +40,9 @@ class Performance(Collection):
             self._meta_data['container']._meta_data['uri'] + "performance/"
 
     def get_collection(self):
-        '''Performance collections are not proper BigIP collection objects.
+        '''Performance collections are not proper BIG-IP collection objects.
 
-        :raises: :exc:`~f5.bigip.resource.UnsupportedOperation`
+        :raises: :exc:`~f5.BIG-IP.resource.UnsupportedOperation`
         '''
         raise UnsupportedOperation(
             "The iControl REST URI mgmt/sys/performance/ does not respond " +
@@ -51,7 +51,7 @@ class Performance(Collection):
 
 
 class All_Stats(UnnamedResourceMixin, Resource):
-    """BigIP system performace stats unnamed resource"""
+    """BIG-IP system performace stats unnamed resource"""
     def __init__(self, performance):
         super(All_Stats, self).__init__(performance)
         self._meta_data['required_refresh_parameters'] = set()
@@ -63,7 +63,7 @@ class All_Stats(UnnamedResourceMixin, Resource):
     def update(self, **kwargs):
         '''Update is not supported for statistics.
 
-        :raises: :exc:`~f5.bigip.resource.UnsupportedOperation`
+        :raises: :exc:`~f5.BIG-IP.resource.UnsupportedOperation`
         '''
         raise UnsupportedOperation(
             'Stats do not support create, only load and refresh')

--- a/f5/bigip/test/big_ip_mock.py
+++ b/f5/bigip/test/big_ip_mock.py
@@ -17,12 +17,12 @@ import mock
 
 
 class BigIPMock(object):
-    """Mock BigIP object
+    """Mock BIG-IP object
 
-    Mocks a BigIP object by substituting a mock icr_session object which
+    Mocks a BIG-IP object by substituting a mock icr_session object which
     returns a user created mock response object. To use, create a mock response
     object which will get returned by any icr_session HTTP method, then create
-    an interface object, passing in this BigIPMock object.
+    an interface object, passing in this BIG-IPMock object.
 
     Example:
 
@@ -30,11 +30,12 @@ class BigIPMock(object):
         # read_json_file() is used to get mock JSON, but you can always pass
         # in a JSON string, or create a dictionary object and convert to JSON
         # using json.loads().
-        response = BigIPMock.create_mock_response(
-          200, BigIPMock.read_json_file("f5/bigip/interfaces/test/pool.json"))
+        response = BIG-IPMock.create_mock_response(
+          200, BIG-IPMock.read_json_file("f5/BIG-IP/interfaces/test/pool.json")
+        )
 
-        # Create BigIP object, passing in mocked response object
-        big_ip = BigIPMock(response)
+        # Create BIG-IP object, passing in mocked response object
+        big_ip = BIG-IPMock(response)
 
         # Create interface object
         test_pool = Pool(big_ip)
@@ -45,7 +46,7 @@ class BigIPMock(object):
     """
 
     def __init__(self, response=mock.Mock()):
-        """Initializes BigIPMock object.
+        """Initializes BIG-IPMock object.
 
         :param response: Mock response object to return from icr_session calls.
         :return:
@@ -63,7 +64,7 @@ class BigIPMock(object):
 
         This mocked icr_session substitutes basic request library
         methods (get, put, post, etc.) with a method that simply
-        returns a mocked response object. Set the response on the BigIPMock
+        returns a mocked response object. Set the response on the BIG-IPMock
         object before calling one of the icr_session methods.
 
         :rtype object: mock session object.


### PR DESCRIPTION
@zancas @jputrino 
Issues:
Fixes #264

Problem:
We need to make sure that BIG-IP is spelled correctly according
to F5 corporate branding.

Analysis:
* Change docs and doc strings to ensure that all are BIG-IP

Tests:
* Made docs
* Flake8