### PR TITLE
The application service resource needs to evict certain kwargs before load is called

### DIFF
--- a/f5/bigip/resource.py
+++ b/f5/bigip/resource.py
@@ -460,7 +460,7 @@ class Resource(ResourceBase):
         # Creation fails without these.
         self._meta_data['required_creation_parameters'] = set(('name',))
         # Refresh fails without these.
-        self._meta_data['required_refresh_parameters'] = set(('name',))
+        self._meta_data['required_load_parameters'] = set(('name',))
         # You can't have more than one of the attrs in any of these sets.
         self._meta_data['exclusive_attributes'] = []
         # You can't set these attributes, only 'read' them.
@@ -630,7 +630,7 @@ class Resource(ResourceBase):
         '''
         key_set = set(kwargs.keys())
         required_minus_received =\
-            self._meta_data['required_refresh_parameters'] - key_set
+            self._meta_data['required_load_parameters'] - key_set
         if required_minus_received != set():
             error_message = 'Missing required params: %r'\
                 % required_minus_received

--- a/f5/bigip/sys/application.py
+++ b/f5/bigip/sys/application.py
@@ -94,7 +94,7 @@ class Service(Resource):
         self._meta_data['required_creation_parameters'].update(
             ('template', 'partition')
         )
-        self._meta_data['required_refresh_parameters'].update(('partition',))
+        self._meta_data['required_load_parameters'].update(('partition',))
         self._meta_data['required_json_kind'] =\
             'tm:sys:application:service:servicestate'
         self._meta_data['disallowed_load_parameters'] = \
@@ -121,7 +121,12 @@ class Service(Resource):
             # drop in Common as the partition in kwargs.
             if 'partition' not in kwargs:
                 kwargs['partition'] = 'Common'
-
+            # Pop all but the necessary load kwargs from the kwargs given to
+            # create. Otherwise, load may fail.
+            kwargs_copy = kwargs.copy()
+            for key in kwargs_copy:
+                if key not in self._meta_data['required_load_parameters']:
+                    kwargs.pop(key)
             # If response was created successfully, do a local_update.
             # If not, call to overridden _load method via load
             self.load(**kwargs)
@@ -241,6 +246,6 @@ class Template(Resource):
     def __init__(self, template_s):
         super(Template, self).__init__(template_s)
         self._meta_data['required_creation_parameters'].update(('partition',))
-        self._meta_data['required_refresh_parameters'].update(('partition',))
+        self._meta_data['required_load_parameters'].update(('partition',))
         self._meta_data['required_json_kind'] =\
             'tm:sys:application:template:templatestate'

--- a/f5/bigip/sys/failover.py
+++ b/f5/bigip/sys/failover.py
@@ -47,7 +47,7 @@ class Failover(UnnamedResourceMixin, Resource):
     def __init__(self, sys):
         super(Failover, self).__init__(sys)
         endpoint = self.__class__.__name__.lower()
-        self._meta_data['required_refresh_parameters'] = set()
+        self._meta_data['required_load_parameters'] = set()
         self._meta_data['required_json_kind'] =\
             'tm:sys:failover:failoverstats'
         self._meta_data['uri'] =\

--- a/f5/bigip/sys/folder.py
+++ b/f5/bigip/sys/folder.py
@@ -56,7 +56,7 @@ class Folder(Resource):
         super(Folder, self).__init__(folder_s)
         self._meta_data['required_json_kind'] = 'tm:sys:folder:folderstate'
         # refresh() and load() require partition, not name
-        self._meta_data['required_refresh_parameters'] = set()
+        self._meta_data['required_load_parameters'] = set()
         self._meta_data['required_creation_parameters'].update(('subPath',))
 
     def _create_subpath_uri(self, kwargs):

--- a/f5/bigip/sys/global_settings.py
+++ b/f5/bigip/sys/global_settings.py
@@ -43,7 +43,7 @@ class Global_Settings(UnnamedResourceMixin, Resource):
     def __init__(self, sys):
         super(Global_Settings, self).__init__(sys)
         endpoint = self.__class__.__name__.lower().replace('_', '-')
-        self._meta_data['required_refresh_parameters'] = set()
+        self._meta_data['required_load_parameters'] = set()
         self._meta_data['required_json_kind'] =\
             'tm:sys:global-settings:global-settingsstate'
         self._meta_data['uri'] =\

--- a/f5/bigip/sys/ntp.py
+++ b/f5/bigip/sys/ntp.py
@@ -41,7 +41,7 @@ class Ntp(UnnamedResourceMixin, Resource):
     def __init__(self, sys):
         super(Ntp, self).__init__(sys)
         endpoint = self.__class__.__name__.lower()
-        self._meta_data['required_refresh_parameters'] = set()
+        self._meta_data['required_load_parameters'] = set()
         self._meta_data['required_json_kind'] = 'tm:sys:ntp:ntpstate'
         self._meta_data['uri'] =\
             self._meta_data['container']._meta_data['uri'] + endpoint + '/'

--- a/f5/bigip/sys/performance.py
+++ b/f5/bigip/sys/performance.py
@@ -54,7 +54,7 @@ class All_Stats(UnnamedResourceMixin, Resource):
     """BIG-IP system performace stats unnamed resource"""
     def __init__(self, performance):
         super(All_Stats, self).__init__(performance)
-        self._meta_data['required_refresh_parameters'] = set()
+        self._meta_data['required_load_parameters'] = set()
         self._meta_data['required_json_kind'] =\
             'tm:sys:performance:all-stats:all-statsstats'
         self._meta_data['uri'] =\

--- a/f5/bigip/test/test_resource.py
+++ b/f5/bigip/test/test_resource.py
@@ -280,7 +280,7 @@ class TestCollection_get_collection(object):
 class TestResource_load(object):
     def test_missing_required_params(self):
         r = Resource(mock.MagicMock())
-        r._meta_data['required_refresh_parameters'] = set(['IMPOSSIBLE'])
+        r._meta_data['required_load_parameters'] = set(['IMPOSSIBLE'])
         with pytest.raises(MissingRequiredReadParameter) as MRREIO:
             r.load(partition='Common', name='test_load')
         assert MRREIO.value.message ==\


### PR DESCRIPTION
@zancas 

Issues: Fixes: Issue #275

Problem: When an application service is created, kwargs may be given
that are used to create the service, but those same kwargs are passed to
load. These may cause the load to fail. So we must evict all but the
required_load_parameters from the kwargs given to create just before the
load is called.

Analysis: Modified required_refresh_parameters to be
required_load_parameters in all concrete classes that use them and the
base resource class.

Tests: All unit tests pass, but two functional tests fail:
sys/test_ntp.py::TestGlobal_Setting::test_RUL
test_requests_params.py::test_get_dollar_filtered_collection