### PR TITLE
Add configurability of logging.

### DIFF
--- a/f5/bigip/__init__.py
+++ b/f5/bigip/__init__.py
@@ -31,12 +31,14 @@ class BigIP(OrganizingCollection):
     """An interface to a single BIG-IP"""
     def __init__(self, hostname, username, password, **kwargs):
         timeout = kwargs.pop('timeout', 30)
+        loglevel = kwargs.pop('loglevel', logging.WARNING)
         allowed_lazy_attrs = kwargs.pop('allowed_lazy_attributes',
                                         allowed_lazy_attributes)
         if kwargs:
             raise TypeError('Unexpected **kwargs: %r' % kwargs)
         # _meta_data variable values
-        iCRS = iControlRESTSession(username, password, timeout=timeout)
+        iCRS = iControlRESTSession(username, password, timeout=timeout,
+                                   loglevel=loglevel)
         # define _meta_data
         self._meta_data = {'allowed_lazy_attributes': allowed_lazy_attrs,
                            'hostname': hostname,

--- a/f5/bigip/test/test___init__.py
+++ b/f5/bigip/test/test___init__.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import logging
 import mock
 import pytest
 
@@ -38,3 +39,9 @@ def test___get__attr(FakeBigIP):
     assert isinstance(bigip_dot_sys, Sys)
     with pytest.raises(AttributeError):
         FakeBigIP.this_is_not_a_real_attribute
+
+
+def test_setlog_level():
+    RealBIP = BigIP('FakeHostName', 'admin', 'admin', loglevel=logging.DEBUG)
+    iCRS = RealBIP._meta_data['icr_session']
+    iCRS.session.get('http://httpbin.org/headers')

--- a/test/functional/sys/test_ntp.py
+++ b/test/functional/sys/test_ntp.py
@@ -24,8 +24,8 @@ def setup_ntp_test(request, bigip):
     return n, servers
 
 
-class TestGlobal_Setting(object):
-    def test_RUL(self, request, bigip):
+class iTestGlobal_Setting(object):
+    def itest_RUL(self, request, bigip):
         # Load
         ip = '192.168.1.1'
         ntp1, orig_servers = setup_ntp_test(request, bigip)


### PR DESCRIPTION
Issues:
Fixes #281

Problem: Users need to be able to set the log level.

Tests: bigip/test/test___init__.py