### PR TITLE
Issues: Attribute registry values need to be class names, not strings

### DIFF
--- a/f5/bigip/ltm/persistence.py
+++ b/f5/bigip/ltm/persistence.py
@@ -54,9 +54,9 @@ class Source_Addrs(Collection):
         '''Auto generated constructor.'''
         super(Source_Addrs, self).__init__(persistence)
         # self._meta_data['allowed_lazy_attributes'] = [Source_Addr]
-        self._meta_data['attribute_registry'] =\
-            {u'tm:ltm:persistence:source-addr:source-addrstate':
-             u'Source_Addr'}
+        # self._meta_data['attribute_registry'] =\
+        #     {u'tm:ltm:persistence:source-addr:source-addrstate':
+        #      Source_Addr}
         self._meta_data['template_generated'] = True
 
 
@@ -66,8 +66,8 @@ class Hashs(Collection):
         '''Auto generated constructor.'''
         super(Hashs, self).__init__(persistence)
         # self._meta_data['allowed_lazy_attributes'] = [Hash]
-        self._meta_data['attribute_registry'] =\
-            {u'tm:ltm:persistence:hash:hashstate': u'Hash'}
+        # self._meta_data['attribute_registry'] =\
+        #     {u'tm:ltm:persistence:hash:hashstate': Hash}
         self._meta_data['template_generated'] = True
 
 
@@ -77,8 +77,8 @@ class Sips(Collection):
         '''Auto generated constructor.'''
         super(Sips, self).__init__(persistence)
         # self._meta_data['allowed_lazy_attributes'] = [Sip]
-        self._meta_data['attribute_registry'] =\
-            {u'tm:ltm:persistence:sip:sipstate': u'Sip'}
+        # self._meta_data['attribute_registry'] =\
+        #     {u'tm:ltm:persistence:sip:sipstate': Sip}
         self._meta_data['template_generated'] = True
 
 
@@ -88,8 +88,8 @@ class Ssls(Collection):
         '''Auto generated constructor.'''
         super(Ssls, self).__init__(persistence)
         # self._meta_data['allowed_lazy_attributes'] = [Ssl]
-        self._meta_data['attribute_registry'] =\
-            {u'tm:ltm:persistence:ssl:sslstate': u'Ssl'}
+        # self._meta_data['attribute_registry'] =\
+        #     {u'tm:ltm:persistence:ssl:sslstate': Ssl}
         self._meta_data['template_generated'] = True
 
 
@@ -111,8 +111,8 @@ class Dest_Addrs(Collection):
         '''Auto generated constructor.'''
         super(Dest_Addrs, self).__init__(persistence)
         # self._meta_data['allowed_lazy_attributes'] = [Dest_Addr]
-        self._meta_data['attribute_registry'] =\
-            {u'tm:ltm:persistence:dest-addr:dest-addrstate': u'Dest_Addr'}
+        # self._meta_data['attribute_registry'] =\
+        #     {u'tm:ltm:persistence:dest-addr:dest-addrstate': Dest_Addr}
         self._meta_data['template_generated'] = True
 
 
@@ -122,8 +122,8 @@ class Msrdps(Collection):
         '''Auto generated constructor.'''
         super(Msrdps, self).__init__(persistence)
         # self._meta_data['allowed_lazy_attributes'] = [Msrdp]
-        self._meta_data['attribute_registry'] =\
-            {u'tm:ltm:persistence:msrdp:msrdpstate': u'Msrdp'}
+        # self._meta_data['attribute_registry'] =\
+        #     {u'tm:ltm:persistence:msrdp:msrdpstate': Msrdp}
         self._meta_data['template_generated'] = True
 
 
@@ -133,8 +133,8 @@ class Cookies(Collection):
         '''Auto generated constructor.'''
         super(Cookies, self).__init__(persistence)
         self._meta_data['allowed_lazy_attributes'] = [Cookie]
-        self._meta_data['attribute_registry'] =\
-            {u'tm:ltm:persistence:cookie:cookiestate': u'Cookie'}
+        # self._meta_data['attribute_registry'] =\
+        #     {u'tm:ltm:persistence:cookie:cookiestate': Cookie}
         self._meta_data['template_generated'] = True
 
 
@@ -156,8 +156,8 @@ class Universals(Collection):
         '''Auto generated constructor.'''
         super(Universals, self).__init__(persistence)
         self._meta_data['allowed_lazy_attributes'] = [Universal]
-        self._meta_data['attribute_registry'] =\
-            {u'tm:ltm:persistence:universal:universalstate': u'Universal'}
+        # self._meta_data['attribute_registry'] =\
+        #     {u'tm:ltm:persistence:universal:universalstate': Universal}
         self._meta_data['template_generated'] = True
 
 

--- a/f5/bigip/net/fdb.py
+++ b/f5/bigip/net/fdb.py
@@ -37,7 +37,7 @@ class Fdbs(Collection):
         super(Fdbs, self).__init__(net)
         # self._meta_data['allowed_lazy_attributes'] = [Fdb]
         # self._meta_data['attribute_registry'] =\
-        #    {u'tm:net:fdb:fdbstate': u'Fdb'}
+        #    {u'tm:net:fdb:fdbstate': Fdb}
         self._meta_data['template_generated'] = True
 
 
@@ -60,7 +60,7 @@ class Tunnels(Collection):
         super(Tunnels, self).__init__(fdb)
         self._meta_data['allowed_lazy_attributes'] = [Tunnel]
         self._meta_data['attribute_registry'] =\
-            {u'tm:net:fdb:tunnel:tunnelstate': u'Tunnel'}
+            {u'tm:net:fdb:tunnel:tunnelstate': Tunnel}
         self._meta_data['template_generated'] = True
 
 
@@ -71,5 +71,5 @@ class Vlans(Collection):
         super(Vlans, self).__init__(fdb)
         # self._meta_data['allowed_lazy_attributes'] = [Vlan]
         # self._meta_data['attribute_registry'] =\
-        #     {u'tm:net:fdb:vlan:vlanstate': u'Vlan'}
+        #     {u'tm:net:fdb:vlan:vlanstate': Vlan}
         self._meta_data['template_generated'] = True

--- a/f5/bigip/net/route_domain.py
+++ b/f5/bigip/net/route_domain.py
@@ -37,7 +37,7 @@ class Route_Domains(Collection):
         super(Route_Domains, self).__init__(net)
         self._meta_data['allowed_lazy_attributes'] = [Route_Domain]
         self._meta_data['attribute_registry'] =\
-            {u'tm:net:route-domain:route-domainstate': u'Route_Domain'}
+            {u'tm:net:route-domain:route-domainstate': Route_Domain}
         self._meta_data['template_generated'] = True
         self._meta_data['uri'] = self._meta_data['uri'].replace('_', '-')
 


### PR DESCRIPTION
Fixes #296

Problem: Invoking get_collection() method on a resource collection throws a traceback

Analysis: Generator for new resource collections class sets the value for attribute to a string.

Tests: py.test functional tests no longer fail.
