### PR TITLE
Update SUPPORT statements in file and documentation #277

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -118,9 +118,6 @@ Copyright
 ---------
 Copyright 2014-2016 F5 Networks Inc.
 
-Support
--------
-See `Support <SUPPORT.md>`__
 
 License
 -------

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -1,5 +1,0 @@
-Maintenance and support of the unmodified F5 code is provided only to customers
-who have an existing support contract, purchased separately subject to F5’s
-support policies available at http://www.f5.com/about/guidelines-policies/ and 
-http://askf5.com.  F5 will not provide maintenance and support services of
-modified F5 code or code that does not have an existing support contract.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -70,14 +70,6 @@ Copyright
 ---------
 Copyright 2014-2016 F5 Networks Inc.
 
-Support
--------
-Maintenance and support of the unmodified F5 code is provided only to customers
-who have an existing support contract, purchased separately subject to F5’s
-support policies available at http://www.f5.com/about/guidelines-policies/ and
-http://askf5.com.  F5 will not provide maintenance and support services of
-modified F5 code or code that does not have an existing support contract.
-
 License
 -------
 Apache V2.0


### PR DESCRIPTION
@jputrino 
Issues:
Fixes #277

Problem:
This package is not included in the official F5 support statement
unless a problem or issue is found via its use by a higher level
supported application like F5Networks/f5-openstack-agent.

Analysis:
- Removed the SUPPORT file
- Removed the support sections from the readme and index page for docs

Tests:
