### PR TITLE
Need support for POSTing command to bigip.cm #272

### DIFF
--- a/f5/bigip/cm/__init__.py
+++ b/f5/bigip/cm/__init__.py
@@ -39,3 +39,20 @@ class Cm(OrganizingCollection):
         self._meta_data['allowed_lazy_attributes'] = [
             Devices, Device_Groups, Traffic_Groups, Sync_Status
         ]
+
+    def sync(self, device_group_name):
+        '''Sync the configuration of the device-group.
+
+        Execute the run command via the iControl REST session with the
+        config-sync to group device-group options.  Any exceptions triggered
+        by the POST to the iControl REST server are raised back to the caller.
+
+        :param device_group_name: Name of the device group to sync.
+        :type device_group_name: str
+        '''
+        data = {
+            'command': 'run',
+            'options': [{'config-sync': 'to-group %s' % device_group_name}]
+        }
+        icr_session = self._meta_data['container']._meta_data['icr_session']
+        icr_session.post(self._meta_data['uri'], json=data)

--- a/f5/bigip/cm/device_group.py
+++ b/f5/bigip/cm/device_group.py
@@ -53,6 +53,16 @@ class Device_Group(Resource):
             'tm:cm:device-group:devices:devicescollectionstate': Devices_s
         }
 
+    def sync(self):
+        '''Sync the configuration of the device-group
+
+        Executes the containing object's cm :meth:`~f5.bigip.cm.Cm.sync`
+        method to sync the configuration of the device-group.
+        '''
+        device_group_collection = self._meta_data['container']
+        cm = device_group_collection._meta_data['container']
+        cm.sync(self.name)
+
 
 class Devices_s(Collection):
     """BIG-IP cluster devices-group devices subcollection."""

--- a/test/functional/cm/test_device_group.py
+++ b/test/functional/cm/test_device_group.py
@@ -68,3 +68,14 @@ class TestDeviceGroup(object):
             name=this_device.name, partition=this_device.partition)
         assert len(dg1.devices_s.get_collection()) == 1
         assert d1.name == this_device.name
+
+    def test_sync(self, request, bigip):
+        dg1, dgs = setup_device_group_test(
+            request, bigip, name='test-group', partition='Common')
+
+        assert dg1.sync() is None
+
+    def test_cm_sync(self, request, bigip):
+        dg1, dgs = setup_device_group_test(
+            request, bigip, name='test-group', partition='Common')
+        assert bigip.cm.sync(dg1.name) is None


### PR DESCRIPTION
@jlongstaf @zancas 
Issues:
Fixes #272

Problem:
Need to be able to sync the configuration of device-groups via
the SDK.  This requires a special POST command to run a
command via the REST API with some options.

Analysis:
- Added a sync method to the `Cm` class that takes a device-group
  name and exucutes the run command.
- Added a sync method to the `Device_Group` class as well that
  calls the `Cm` container's sync method with it's name.
- Added tests for the cm.sync() and cm.device_groups.sync()

Tests:
- Built and reviewed docs
- Unit tests
- Functional tests
