### PR TITLE
PathElement abstract class for nonREST URI element

### DIFF
--- a/f5/bigip/__init__.py
+++ b/f5/bigip/__init__.py
@@ -19,10 +19,11 @@ from f5.bigip.cm import Cm
 from f5.bigip.ltm import Ltm
 from f5.bigip.net import Net
 from f5.bigip.resource import OrganizingCollection
+from f5.bigip.shared import Shared
 from f5.bigip.sys import Sys
 from icontrol.session import iControlRESTSession
 
-allowed_lazy_attributes = [Cm, Ltm, Net, Sys]
+allowed_lazy_attributes = [Cm, Ltm, Net, Shared, Sys]
 
 
 class BigIP(OrganizingCollection):

--- a/f5/bigip/shared/__init__.py
+++ b/f5/bigip/shared/__init__.py
@@ -1,0 +1,8 @@
+from f5.bigip.resource import PathElement
+from f5.bigip.shared.licensing import Licensing
+
+
+class Shared(PathElement):
+    def __init__(self, bigip):
+        super(Shared, self).__init__(bigip)
+        self._meta_data['allowed_lazy_attributes'] = [Licensing]

--- a/f5/bigip/shared/licensing.py
+++ b/f5/bigip/shared/licensing.py
@@ -1,0 +1,6 @@
+from f5.bigip.resource import PathElement
+
+
+class Licensing(PathElement):
+    def __init__(self, shared):
+        super(Licensing, self).__init__(shared)

--- a/f5/bigip/test/test___init__.py
+++ b/f5/bigip/test/test___init__.py
@@ -19,6 +19,7 @@ from f5.bigip import BigIP
 
 from f5.bigip.ltm import Ltm
 from f5.bigip.net import Net
+from f5.bigip.shared import Shared
 from f5.bigip.sys import Sys
 
 
@@ -34,6 +35,8 @@ def test___get__attr(FakeBigIP):
     assert isinstance(bigip_dot_ltm, Ltm)
     bigip_dot_net = FakeBigIP.net
     assert isinstance(bigip_dot_net, Net)
+    bigip_dot_shared = FakeBigIP.shared
+    assert isinstance(bigip_dot_shared, Shared)
     bigip_dot_sys = FakeBigIP.sys
     assert isinstance(bigip_dot_sys, Sys)
     with pytest.raises(AttributeError):

--- a/test/functional/shared/test___init__.py
+++ b/test/functional/shared/test___init__.py
@@ -1,0 +1,27 @@
+# Copyright 2016 F5 Networks Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from pprint import pprint as pp
+
+from f5.bigip import BigIP
+from f5.bigip.shared import Shared
+
+
+def test_shared(request, bigip):
+    s = bigip.shared
+    pp(s.raw)
+    assert isinstance(s._meta_data['container'], BigIP)
+    assert s._meta_data['allowed_lazy_attributes'][0].__name__ == "Licensing"
+    l = bigip.shared.licensing
+    pp(l.raw)
+    assert isinstance(l._meta_data['container'], Shared)


### PR DESCRIPTION
@pjbreaux
Issues:
Fixes #304

Problem: Some server provided path elements do not support HTTP operations

Analysis:  See for example the response to an HTTP GET against
'shared/licensing'

Tests: Current functional tests pass.
