### PR TITLE
Support for determining the state of a bigip device #302

### DIFF
--- a/docs/apidoc/f5.bigip.rst
+++ b/docs/apidoc/f5.bigip.rst
@@ -16,8 +16,8 @@ f5.bigip module
         cm
         ltm
         net
+        shared
         sys
-
 
     Resource Base Classes
     ~~~~~~~~~~~~~~~~~~~~~
@@ -30,6 +30,7 @@ f5.bigip module
         resource.OrganizingCollection
         resource.Collection
         resource.Resource
+        resource.PathElement
 
     Resource Exceptions
     ~~~~~~~~~~~~~~~~~~~
@@ -70,6 +71,7 @@ f5.bigip module
     f5.bigip.cm
     f5.bigip.ltm
     f5.bigip.net
+    f5.bigip.shared
     f5.bigip.sys
 
 resource module

--- a/docs/apidoc/f5.bigip.shared.rst
+++ b/docs/apidoc/f5.bigip.shared.rst
@@ -1,0 +1,33 @@
+f5.bigip.shared
+===============
+
+Module Contents
+---------------
+
+.. automodule:: f5.bigip.shared
+    :members:
+
+    Submodule List
+    ~~~~~~~~~~~~~~
+    .. currentmodule:: f5.bigip.shared
+
+    .. autosummary::
+
+        bigip_failover_state
+        licensing
+
+
+Submodules
+----------
+
+bigip_failover_state
+~~~~~~~~~~~~~~~~~~~~
+
+.. automodule:: f5.bigip.shared.bigip_failover_state
+    :members:
+
+licensing
+~~~~~~~~~
+
+.. automodule:: f5.bigip.shared.licensing
+    :members:

--- a/f5/bigip/mixins.py
+++ b/f5/bigip/mixins.py
@@ -158,3 +158,7 @@ class UnnamedResourceMixin(object):
         response = read_session.get(base_uri, **kwargs)
         self._local_update(response.json())
         return self
+
+    def _get_meta_data_uri(self):
+        endpoint = self.__class__.__name__.lower()
+        return self._meta_data['container']._meta_data['uri'] + endpoint + '/'

--- a/f5/bigip/resource.py
+++ b/f5/bigip/resource.py
@@ -144,6 +144,13 @@ class UnsupportedOperation(F5SDKError):
 
 
 class PathElement(LazyAttributeMixin):
+    """Base class to represent a URI path element that does not contain data.
+
+    The BIG-IP iControl REST API has URIs that are made up of path components
+    that do not return data when they are queried.  This class represents
+    those elements and does not support any of the CURDLE methods that
+    the other objects do.
+    """
     def __init__(self, container):
         self._meta_data = {'container': container,
                            'bigip': container._meta_data['bigip']}

--- a/f5/bigip/shared/bigip_failover_state.py
+++ b/f5/bigip/shared/bigip_failover_state.py
@@ -1,0 +1,58 @@
+# Copyright 2016 F5 Networks Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+"""BIG-IP shared failover state module
+
+REST URI
+    ``http://localhost/mgmt/tm/shared/bigip-failover-state``
+
+GUI Path
+    N/A
+
+REST Kind
+    ``tm:shared:licensing:*``
+"""
+
+from f5.bigip.mixins import UnnamedResourceMixin
+from f5.bigip.resource import Resource
+
+
+class Bigip_Failover_State(UnnamedResourceMixin, Resource):
+    """BIG-IP failover state information
+
+    Failover state objects only support the
+    :meth:`~f5.bigip.resource.Resource.load` method because they cannot be
+    modified via the API.
+
+    .. note::
+
+        This is an unnamed resource so it has not ~Partition~Name pattern
+        at the end of its URI.
+    """
+
+    def __init__(self, shared):
+        super(Bigip_Failover_State, self).__init__(shared)
+        self._meta_data['required_load_parameters'] = set()
+        self._meta_data['required_json_kind'] = ''
+        uri = self._get_meta_data_uri()
+        self._meta_data['uri'] = uri.replace('_', '-')
+
+    def update(self, **kwargs):
+        '''Update is not supported for BIG-IP failover state.
+
+        :raises: UnsupportedOperation
+        '''
+        raise self.UnsupportedMethod(
+            "%s does not support the update method" % self.__class__.__name__
+        )

--- a/f5/bigip/shared/licensing.py
+++ b/f5/bigip/shared/licensing.py
@@ -1,6 +1,114 @@
+# Copyright 2016 F5 Networks Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+"""BIG-IP system failover module
+
+REST URI
+    ``http://localhost/mgmt/tm/shared/license``
+
+GUI Path
+    ``System --> License``
+
+REST Kind
+    ``tm:shared:licensing:*``
+"""
+
+from f5.bigip.mixins import UnnamedResourceMixin
 from f5.bigip.resource import PathElement
+from f5.bigip.resource import Resource
 
 
 class Licensing(PathElement):
+    """BIG-IP licensing stats and states.
+
+    Licensing objects themselves do not support any methods and are just
+    containers for lower level objects.
+
+    .. note::
+
+        This is an unnamed resource so it has not ~Partition~Name pattern
+        at the end of its URI.
+    """
     def __init__(self, shared):
         super(Licensing, self).__init__(shared)
+        self._meta_data['allowed_lazy_attributes'] = [
+            Activation,
+            Registration,
+        ]
+        self._meta_data['attribute_registry'] = {
+            'tm:shared:licensing:activation:activatelicenseresponse':
+                Activation,
+            'tm:shared:licensing:registration:registrationlicenseresponse':
+                Registration,
+        }
+
+
+class Activation(UnnamedResourceMixin, Resource):
+    """BIG-IP license activation status
+
+    Activation state objects only support the
+    :meth:`~f5.bigip.resource.Resource.load` method because they cannot be
+    modified via the API.
+
+    .. note::
+
+        This is an unnamed resource so it has not ~Partition~Name pattern
+        at the end of its URI.
+    """
+
+    def __init__(self, licensing):
+        super(Activation, self).__init__(licensing)
+        self._meta_data['required_load_parameters'] = set()
+        self._meta_data['required_json_kind'] =\
+            'tm:shared:licensing:activation:activatelicenseresponse'
+        self._meta_data['uri'] = self._get_meta_data_uri()
+
+    def update(self, **kwargs):
+        '''Update is not supported for License Activation
+
+        :raises: UnsupportedOperation
+        '''
+        raise self.UnsupportedMethod(
+            "%s does not support the update method" % self.__class__.__name__
+        )
+
+
+class Registration(UnnamedResourceMixin, Resource):
+    """BIG-IP license registration status
+
+    Registration state objects only support the
+    :meth:`~f5.bigip.resource.Resource.load` method because they cannot be
+    modified via the API.
+
+    .. note::
+
+        This is an unnamed resource so it has not ~Partition~Name pattern
+        at the end of its URI.
+    """
+
+    def __init__(self, licensing):
+        super(Registration, self).__init__(licensing)
+        self._meta_data['required_load_parameters'] = set()
+        self._meta_data['required_json_kind'] =\
+            'tm:shared:licensing:activation:activatelicenseresponse'
+        self._meta_data['uri'] = self._get_meta_data_uri()
+
+    def update(self, **kwargs):
+        '''Update is not supported for License Registration
+
+        :raises: UnsupportedOperation
+        '''
+        raise self.UnsupportedMethod(
+            "%s does not support the update method" % self.__class__.__name__
+        )

--- a/test/functional/shared/test_bigip_failover_state.py
+++ b/test/functional/shared/test_bigip_failover_state.py
@@ -11,29 +11,17 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-#
 
-"""BIG-IP Shared (shared) module
+import pytest
 
-REST URI
-    ``http://localhost/mgmt/tm/shared/``
-
-GUI Path
-    ``System``
-
-REST Kind
-    N/A -- HTTP GET returns an error
-"""
-
-from f5.bigip.resource import PathElement
-from f5.bigip.shared.bigip_failover_state import Bigip_Failover_State
-from f5.bigip.shared.licensing import Licensing
+from f5.bigip.mixins import UnnamedResourceMixin
 
 
-class Shared(PathElement):
-    def __init__(self, bigip):
-        super(Shared, self).__init__(bigip)
-        self._meta_data['allowed_lazy_attributes'] = [
-            Licensing,
-            Bigip_Failover_State,
-        ]
+class TestBigIPFailoverState(object):
+    def test_load(self, request, bigip):
+        a = bigip.shared.bigip_failover_state.load()
+        assert hasattr(a, 'generation')
+
+    def test_update(self, request, bigip):
+        with pytest.raises(UnnamedResourceMixin.UnsupportedMethod):
+            bigip.shared.bigip_failover_state.update()

--- a/test/functional/shared/test_licensing.py
+++ b/test/functional/shared/test_licensing.py
@@ -1,0 +1,37 @@
+# Copyright 2016 F5 Networks Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pytest
+
+from f5.bigip.mixins import UnnamedResourceMixin
+
+
+class TestActivation(object):
+    def test_load(self, request, bigip):
+        a = bigip.shared.licensing.activation.load()
+        assert hasattr(a, 'generation')
+
+    def test_update(self, request, bigip):
+        with pytest.raises(UnnamedResourceMixin.UnsupportedMethod):
+            bigip.shared.licensing.activation.update()
+
+
+class TestRegistration(object):
+    def test_load(self, request, bigip):
+        reg = bigip.shared.licensing.registration.load()
+        assert hasattr(reg, 'generation')
+
+    def test_update(self, request, bigip):
+        with pytest.raises(UnnamedResourceMixin.UnsupportedMethod):
+            bigip.shared.licensing.registration.update()


### PR DESCRIPTION
@zancas @pjbreaux @wojteck0806
Issues:
Fixes #302

Problem:
A user of this sdk should be able to determine if the BigIP is licensed and active or not.

Analysis:
- Added the objects that represent the paths described by @wojtek0806
- Added tests for the new objects
- Added docs for the new objects and the new PathElement

Tests:
- Flake8
- UnitTests
- Functional Tests
