### PR TITLE
Branding compliance updates and bug fix

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,7 +28,7 @@ Creating issues is good, creating good issues is even better. By filing meaningf
 TODO: What do we want in our bug reports and an example?
 
 ### Feature Requests and Enhancements
-TODO: What do we want in our bug reports and an example?
+TODO: What do we want in our feature requests and an example?
 
 ## Pull Requests
 If you are submitting a pull request you need to make sure that you have done a few things first.
@@ -38,7 +38,7 @@ If you are submitting a pull request you need to make sure that you have done a 
 _The Hat_ because your request fails unit tests.
 * A reasonable set of unit tests is required, and the approver of the pull request is expecting to review them along with the product code.
 * Functional tests are nice-to-have but not required to complete a pull request. Note that not having functional tests will make your pull request end up in an integration branch and be held out of the main develop branch until someone writes an appropriate set of tests.
-* Clean up your git history because no one wants to see 75 commits for one issue
+* Clean up your git history;  no one wants to see 75 commits for one issue.
 * Use our [commit template](.git-commit-template.txt).
 * Use our pull request template.
 
@@ -75,7 +75,8 @@ shell
  $ open htmlcov/index.html
 ```
 
-If you are running our functional tests, you will need a real BIG-IP to run them against. You can get one of those pretty easily in [Amazon EC2](https://aws.amazon.com/marketplace/pp/B00JL3UASY/ref=srh_res_product_title?ie=UTF8&sr=0-10&qid=1449332167461).
+If you are running our functional tests, you will need a real BIG-IP® to run
+ them against. You can get one of those pretty easily in [Amazon EC2](https://aws.amazon.com/marketplace/pp/B00JL3UASY/ref=srh_res_product_title?ie=UTF8&sr=0-10&qid=1449332167461).
 
 Here's an example of how to run functional tests.
 

--- a/README.rst
+++ b/README.rst
@@ -5,16 +5,16 @@ f5-common-python
 
 Introduction
 ------------
-This project implements an SDK for the iControl REST interface for the BIG-IP.
+This project implements an SDK for the iControl REST interface for BIG-IP®.
 Users of this library can create, edit, update, and delete configuration objects
-on a BIG-IP device.
+on a BIG-IP®.
 
 Submodules
 ~~~~~~~~~~
 
 bigip
 ^^^^^
-Python API for configuring objects on a BIG-IP device and gathering information
+Python API for configuring objects on a BIG-IP® device and gathering information
 from the device via the REST API.
 
 Installation
@@ -24,8 +24,11 @@ Installation
 
     $> pip install f5-sdk
 
-*NOTE:* If you are using a pre-release version you must use the ``--pre``
-option for the ``pip`` command.
+.. note::
+
+    If you are using a pre-release version you must use the ``--pre``
+    option for the ``pip`` command.
+
 
 Usage
 -----
@@ -107,7 +110,7 @@ the Unit Test section).
 
 .. code:: shell
 
-    flake8 ./
+    $ flake8 ./
 
 
 Contact

--- a/docs/apidoc/f5.bigip.sys.rst
+++ b/docs/apidoc/f5.bigip.sys.rst
@@ -129,8 +129,8 @@ performance
 .. automodule:: f5.bigip.sys.performance
     :members:
 
-    Performace Resources and Subcollections
-    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    Performance Resources and Subcollections
+    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     .. py:currentmodule:: f5.bigip.sys.performance
 
     .. autosummary::

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -4,9 +4,9 @@ F5 Python SDK Documentation
 
 Introduction
 ------------
-This project implements an object model based SDK for the F5 Networks BIG-IP
+This project implements an object model based SDK for the F5 Networks BIG-IP®
 iControl REST interface. Users of this library can create, edit, update, and
-delete configuration objects on a BIG-IP device.  For more information on the
+delete configuration objects on a BIG-IP® device.  For more information on the
 basic principals that the SDK uses see the :doc:`userguide/index`.
 
 Quick Start

--- a/docs/userguide/basics.rst
+++ b/docs/userguide/basics.rst
@@ -96,7 +96,7 @@ Methods
 | |load|    | GET           | | obtains the state of an existing resource on the device; sets   |
 |           |               | | the Resource attributes to match that state                     |
 +-----------+---------------+-------------------------------------------------------------------+
-| |exists|  | GET           | | checks for the existence of a named object on the BIG-IP®        |
+| |exists|  | GET           | | checks for the existence of a named object on the BIG-IP®       |
 +-----------+---------------+-------------------------------------------------------------------+
 
 .. note::

--- a/docs/userguide/basics.rst
+++ b/docs/userguide/basics.rst
@@ -96,7 +96,7 @@ Methods
 | |load|    | GET           | | obtains the state of an existing resource on the device; sets   |
 |           |               | | the Resource attributes to match that state                     |
 +-----------+---------------+-------------------------------------------------------------------+
-| |exists|  | GET           | | checks for the existence of a named object on the BIG-IP        |
+| |exists|  | GET           | | checks for the existence of a named object on the BIG-IP®        |
 +-----------+---------------+-------------------------------------------------------------------+
 
 .. note::

--- a/docs/userguide/endpoints/organizing_collection.rst
+++ b/docs/userguide/endpoints/organizing_collection.rst
@@ -5,9 +5,9 @@ Organizing Collection
 
 ``kind``: ``collectionstate``
 
-The `iControl REST User Guide <https://devcentral.f5.com/d/the-user-guide-for-the-icontrol-rest-interface-in-big-ip-version-1160>`_ defines an *organizing collection* as a URI that designates all of the ``tmsh`` subordinate modules and components in the specified module. Organizing collections, which appear directly under :mod:`f5.bigip`, correspond to the various modules available on the BIG-IP (for example, :mod:`f5.bigip.ltm`).
+The `iControl REST User Guide <https://devcentral.f5.com/d/the-user-guide-for-the-icontrol-rest-interface-in-big-ip-version-1160>`_ defines an *organizing collection* as a URI that designates all of the ``tmsh`` subordinate modules and components in the specified module. Organizing collections, which appear directly under :mod:`f5.bigip`, correspond to the various modules available on the BIG-IP® (for example, :mod:`f5.bigip.ltm`).
 
-The organizing collection names correspond to the items that appear in the drawers on the left-hand side of the BIG-IP configuration utility (the GUI). The module names are abbreviated in the REST API, but the mapping is otherwise pretty straightforward. For example, the SDK module :mod:`f5.bigip.sys` maps to the System drawer in the GUI.
+The organizing collection names correspond to the items that appear in the drawers on the left-hand side of the BIG-IP® configuration utility (the GUI). The module names are abbreviated in the REST API, but the mapping is otherwise pretty straightforward. For example, the SDK module :mod:`f5.bigip.sys` maps to the System drawer in the GUI.
 
 |Organizing Collection| objects do not have configuration parameters. As shown in the example below, the JSON blob received in response to an ``HTTP GET`` for an organizing collection object contains an ``items`` parameter with a list of references to |Collection| and |Resource| objects.
 

--- a/docs/userguide/endpoints/resource.rst
+++ b/docs/userguide/endpoints/resource.rst
@@ -14,7 +14,7 @@ A resource is a fully configurable object for which the CURDLE :ref:`methods <me
 * |load|
 * |exists|
 
-When using the SDK, you will notice that resources are instantiated via their :ref:`collection <collection_section>`. Once created or loaded, resources contain attributes that map to the JSON fields returned by the BIG-IP.
+When using the SDK, you will notice that resources are instantiated via their :ref:`collection <collection_section>`. Once created or loaded, resources contain attributes that map to the JSON fields returned by the BIG-IP®.
 
 .. topic:: Example
 

--- a/docs/userguide/index.rst
+++ b/docs/userguide/index.rst
@@ -2,7 +2,7 @@ User Guide
 ==========
 To get the most out of using our SDK, it's useful to understand the basic
 concepts and principals we used when we designed it. It is also important
-that you are familiar with the F5 BIG-IP and, at a minimum, how to configure BIG-IP
+that you are familiar with the F5 BIG-IP® and, at a minimum, how to configure BIG-IP®
 using the configuration utility (the GUI). More useful still would be if you are already familiar with the
 `iControl REST API <https://devcentral.f5.com/wiki/iControlREST.HomePage.ashx>`_.
 

--- a/docs/userguide/ltm_pools_members_code_example.rst
+++ b/docs/userguide/ltm_pools_members_code_example.rst
@@ -70,7 +70,7 @@ Coding Example
         if pool_1.members_s.members.exists(partition='Common', name='m1:80'):
         raise Exception("Object should have been deleted")
 
-        # We are done with this pool so remove it from BIG-IP
+        # We are done with this pool so remove it from BIG-IP®
         pool_1.delete()
 
         # Make sure it is gone

--- a/docs/userguide/object_path.rst
+++ b/docs/userguide/object_path.rst
@@ -11,7 +11,7 @@ The object classes used in the SDK directly correspond to the REST endpoints you
 
 4. The characters ``.`` and ``-`` are always replaced with ``_`` in the SDK.
 
-Because the REST API endpoints have a hierarchical structure, you need to load/create the highest-level objects before you can load lower-level ones. The example below shows how the pieces of the URI correspond to the REST endpoints/SDK classes. The first part of the URI is the IP address of your BIG-IP device.
+Because the REST API endpoints have a hierarchical structure, you need to load/create the highest-level objects before you can load lower-level ones. The example below shows how the pieces of the URI correspond to the REST endpoints/SDK classes. The first part of the URI is the IP address of your BIG-IP® device.
 
 .. include:: uri_code_breakdown.rst
 
@@ -32,12 +32,12 @@ In the sections below, we'll walk through the Python object paths using LTM pool
 
 |Organizing Collection Section|
 -------------------------------
-The ``mgmt/tm`` and ``ltm`` organizing collections define what area of the BIG-IP you're going to work with. The ``mgmt/tm`` organizing collection corresponds to the management plane of your BIG-IP device (TMOS). Loading ``ltm`` indicates that we're going to work with the BIG-IP's :guilabel:`Local Traffic` module.
+The ``mgmt/tm`` and ``ltm`` organizing collections define what area of the BIG-IP® you're going to work with. The ``mgmt/tm`` organizing collection corresponds to the management plane of your BIG-IP® device (TMOS). Loading ``ltm`` indicates that we're going to work with the BIG-IP®'s :guilabel:`Local Traffic` module.
 
 .. include:: endpoints/endpoint_table_tm.rst
 .. include:: endpoints/endpoint_table_ltm.rst
 
-.. topic:: Example: Connect to the BIG-IP and load the LTM module
+.. topic:: Example: Connect to the BIG-IP® and load the LTM module
 
     .. code-block:: python
 
@@ -57,7 +57,7 @@ The ``mgmt/tm`` and ``ltm`` organizing collections define what area of the BIG-I
 |Collection Section|
 --------------------
 
-Now that the higher-level organizing collections are loaded (in other words, we're signed in to the BIG-IP and accessed the LTM module), we can load the ``pool`` collection.
+Now that the higher-level organizing collections are loaded (in other words, we're signed in to the BIG-IP® and accessed the LTM module), we can load the ``pool`` collection.
 
 .. include:: endpoints/endpoint_table_ltm_pool.rst
 
@@ -79,14 +79,14 @@ Now that the higher-level organizing collections are loaded (in other words, we'
         pool2
         pool_1
 
-In the above example, we instantiated the class :class:`f5.bigip.ltm.pool.Pools`, then used the :meth:`f5.bigip.ltm.pool.Pools.get_collection()` method to fetch the collection (in other words, a list of the pool :ref:`resources <res_section>` configured on the BIG-IP).
+In the above example, we instantiated the class :class:`f5.bigip.ltm.pool.Pools`, then used the :meth:`f5.bigip.ltm.pool.Pools.get_collection()` method to fetch the collection (in other words, a list of the pool :ref:`resources <res_section>` configured on the BIG-IP®).
 
 
 .. _res_section:
 
 |Resource Section|
 ------------------
-In the SDK, we refer to a single instance of a configuration object as a resource. As shown in the previous sections, we are able to access the ``pool`` resources on the BIG-IP after loading the ``mgmt\tm\ltm`` organizing collections and the ``pools`` collection.
+In the SDK, we refer to a single instance of a configuration object as a resource. As shown in the previous sections, we are able to access the ``pool`` resources on the BIG-IP® after loading the ``mgmt\tm\ltm`` organizing collections and the ``pools`` collection.
 
 .. include:: endpoints/endpoint_table_ltm_pool_pools.rst
 
@@ -98,7 +98,7 @@ In the SDK, we refer to a single instance of a configuration object as a resourc
         pool = pools.pool.load(partition='Common', name='mypool')
 
 
-In the example above, we instantiated the class :class:`f5.bigip.ltm.pool.Pool` and loaded the :obj:`f5.bigip.ltm.pools.pool` object. The object is a python representation of the BIG-IP pool we loaded (in this case, ``Common/mypool``).
+In the example above, we instantiated the class :class:`f5.bigip.ltm.pool.Pool` and loaded the :obj:`f5.bigip.ltm.pools.pool` object. The object is a python representation of the BIG-IP® pool we loaded (in this case, ``Common/mypool``).
 
 .. tip::
 

--- a/f5/bigip/__init__.py
+++ b/f5/bigip/__init__.py
@@ -1,3 +1,5 @@
+# coding=utf-8
+#
 """Classes and functions for configuring BIG-IP"""
 # Copyright 2014 F5 Networks Inc.
 #

--- a/f5/bigip/cm/__init__.py
+++ b/f5/bigip/cm/__init__.py
@@ -1,4 +1,6 @@
-# Copyright 2016 F5 Networks Inc.
+# coding=utf-8
+#
+#  Copyright 2016 F5 Networks Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -12,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-"""BIG-IP cluster module
+"""BIG-IP® cluster module
 
 REST URI
     ``http://localhost/mgmt/tm/cm/``
@@ -33,7 +35,7 @@ from f5.bigip.resource import OrganizingCollection
 
 
 class Cm(OrganizingCollection):
-    """BIG-IP Cluster Organizing Collection."""
+    """BIG-IP® Cluster Organizing Collection."""
     def __init__(self, bigip):
         super(Cm, self).__init__(bigip)
         self._meta_data['allowed_lazy_attributes'] = [

--- a/f5/bigip/cm/device.py
+++ b/f5/bigip/cm/device.py
@@ -1,4 +1,6 @@
-# Copyright 2016 F5 Networks Inc.
+# coding=utf-8
+#
+#  Copyright 2016 F5 Networks Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -12,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-"""BIG-IP cluster device submodule
+"""BIG-IP® cluster device submodule
 
 REST URI
     ``http://localhost/mgmt/tm/cm/device/``
@@ -30,7 +32,7 @@ from f5.bigip.resource import Resource
 
 
 class Devices(Collection):
-    """BIG-IP cluster devices collection.
+    """BIG-IP® cluster devices collection.
 
     """
     def __init__(self, cm):
@@ -41,7 +43,7 @@ class Devices(Collection):
 
 
 class Device(Resource):
-    """BIG-IP cluster device object.
+    """BIG-IP® cluster device object.
 
     """
     def __init__(self, device_s):

--- a/f5/bigip/cm/device_group.py
+++ b/f5/bigip/cm/device_group.py
@@ -1,4 +1,6 @@
-# Copyright 2016 F5 Networks Inc.
+# coding=utf-8
+#
+#  Copyright 2016 F5 Networks Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -13,7 +15,7 @@
 # limitations under the License.
 #
 
-"""BIG-IP cluster device-group submodule
+"""BIG-IP® cluster device-group submodule
 
 REST URI
     ``http://localhost/mgmt/tm/cm/device-group``
@@ -30,7 +32,7 @@ from f5.bigip.resource import Resource
 
 
 class Device_Groups(Collection):
-    """BIG-IP cluster device-groups collection."""
+    """BIG-IP® cluster device-groups collection."""
     def __init__(self, cm):
         super(Device_Groups, self).__init__(cm)
         endpoint = 'device-group'
@@ -42,7 +44,7 @@ class Device_Groups(Collection):
 
 
 class Device_Group(Resource):
-    """BIG-IP cluster device-group resource"""
+    """BIG-IP® cluster device-group resource"""
     def __init__(self, device_groups):
         super(Device_Group, self).__init__(device_groups)
         self._meta_data['read_only_attributes'].append('type')
@@ -65,7 +67,7 @@ class Device_Group(Resource):
 
 
 class Devices_s(Collection):
-    """BIG-IP cluster devices-group devices subcollection."""
+    """BIG-IP® cluster devices-group devices subcollection."""
     def __init__(self, device_group):
         super(Devices_s, self).__init__(device_group)
         self._meta_data['allowed_lazy_attributes'] = [Devices]
@@ -76,7 +78,7 @@ class Devices_s(Collection):
 
 
 class Devices(Resource):
-    """BIG-IP cluster devices-group devices subcollection resource."""
+    """BIG-IP® cluster devices-group devices subcollection resource."""
     def __init__(self, devices_s):
         super(Devices, self).__init__(devices_s)
         self._meta_data['required_json_kind'] =\

--- a/f5/bigip/cm/sync_status.py
+++ b/f5/bigip/cm/sync_status.py
@@ -1,4 +1,6 @@
-# Copyright 2016 F5 Networks Inc.
+# coding=utf-8
+#
+#  Copyright 2016 F5 Networks Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/f5/bigip/cm/traffic_group.py
+++ b/f5/bigip/cm/traffic_group.py
@@ -1,4 +1,6 @@
-# Copyright 2016 F5 Networks Inc.
+# coding=utf-8
+#
+#  Copyright 2016 F5 Networks Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -13,7 +15,7 @@
 # limitations under the License.
 #
 
-"""BIG-IP cluster traffic-group submodule
+"""BIG-IP® cluster traffic-group submodule
 
 REST URI
     ``http://localhost/mgmt/tm/cm/traffic-group``
@@ -30,7 +32,7 @@ from f5.bigip.resource import Resource
 
 
 class Traffic_Groups(Collection):
-    """BIG-IP cluster traffic-group collection"""
+    """BIG-IP® cluster traffic-group collection"""
     def __init__(self, cm):
         super(Traffic_Groups, self).__init__(cm)
         endpoint = 'traffic-group'
@@ -42,7 +44,7 @@ class Traffic_Groups(Collection):
 
 
 class Traffic_Group(Resource):
-    """BIG-IP cluster traffic-group resource"""
+    """BIG-IP® cluster traffic-group resource"""
     def __init__(self, traffic_groups):
         super(Traffic_Group, self).__init__(traffic_groups)
         self._meta_data['required_json_kind'] =\

--- a/f5/bigip/ltm/__init__.py
+++ b/f5/bigip/ltm/__init__.py
@@ -1,3 +1,5 @@
+# coding=utf-8
+#
 # Copyright 2015-2016 F5 Networks Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -13,7 +15,7 @@
 # limitations under the License.
 #
 
-"""BIG-IP Local Traffic Monitor (LTM) module.
+"""BIG-IP® Local Traffic Manager™ (LTM®) module.
 
 REST URI
     ``http://localhost/mgmt/tm/ltm/``
@@ -41,7 +43,7 @@ from f5.bigip.resource import OrganizingCollection
 
 
 class Ltm(OrganizingCollection):
-    """BIG-IP Local Traffic Manager (LTM) organizing collection."""
+    """BIG-IP® Local Traffic Manager (LTM) organizing collection."""
     def __init__(self, bigip):
         super(Ltm, self).__init__(bigip)
         self._meta_data['allowed_lazy_attributes'] = [

--- a/f5/bigip/ltm/monitor.py
+++ b/f5/bigip/ltm/monitor.py
@@ -1,4 +1,6 @@
-# Copyright 2014-2016 F5 Networks Inc.
+# coding=utf-8
+#
+#  Copyright 2014-2016 F5 Networks Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -13,7 +15,7 @@
 # limitations under the License.
 #
 
-"""BIG-IP LTM monitor submodule.
+"""BIG-IP® LTM monitor submodule.
 
 REST URI
     ``http://localhost/mgmt/tm/ltm/monitors/``
@@ -76,7 +78,7 @@ class Monitor(OrganizingCollection):
 
 
 class Https(Collection):
-    """BIG-IP Http monitor collection."""
+    """BIG-IP® Http monitor collection."""
     def __init__(self, monitor):
         super(Https, self).__init__(monitor)
         self._meta_data['allowed_lazy_attributes'] = [Http]
@@ -105,7 +107,7 @@ class UpdateMonitorMixin(object):
 
 
 class Http(UpdateMonitorMixin, Resource):
-    """BIG-IP Http monitor resource."""
+    """BIG-IP® Http monitor resource."""
     def __init__(self, https):
         super(Http, self).__init__(https)
         self._meta_data['required_json_kind'] =\
@@ -113,7 +115,7 @@ class Http(UpdateMonitorMixin, Resource):
 
 
 class Https_s(Collection):
-    """BIG-IP Https monitor collection."""
+    """BIG-IP® Https monitor collection."""
     def __init__(self, monitor):
         super(Https_s, self).__init__(monitor)
         self._meta_data['allowed_lazy_attributes'] = [HttpS]
@@ -122,7 +124,7 @@ class Https_s(Collection):
 
 
 class HttpS(UpdateMonitorMixin, Resource):
-    """BIG-IP Https monitor resource."""
+    """BIG-IP® Https monitor resource."""
     def __init__(self, https_s):
         super(HttpS, self).__init__(https_s)
         self._meta_data['required_json_kind'] =\
@@ -130,7 +132,7 @@ class HttpS(UpdateMonitorMixin, Resource):
 
 
 class Diameters(Collection):
-    """BIG-IP diameter monitor collection."""
+    """BIG-IP® diameter monitor collection."""
     def __init__(self, monitor):
         super(Diameters, self).__init__(monitor)
         self._meta_data['allowed_lazy_attributes'] = [Diameter]
@@ -139,7 +141,7 @@ class Diameters(Collection):
 
 
 class Diameter(UpdateMonitorMixin, Resource):
-    """BIG-IP diameter monitor resource."""
+    """BIG-IP® diameter monitor resource."""
     def __init__(self, diameters):
         super(Diameter, self).__init__(diameters)
         self._meta_data['required_json_kind'] =\
@@ -147,7 +149,7 @@ class Diameter(UpdateMonitorMixin, Resource):
 
 
 class Dns_s(Collection):
-    """BIG-IP Dns monitor collection."""
+    """BIG-IP® Dns monitor collection."""
     def __init__(self, monitor):
         super(Dns_s, self).__init__(monitor)
         self._meta_data['allowed_lazy_attributes'] = [Dns]
@@ -156,7 +158,7 @@ class Dns_s(Collection):
 
 
 class Dns(UpdateMonitorMixin, Resource):
-    """BIG-IP Dns monitor resource."""
+    """BIG-IP® Dns monitor resource."""
     def __init__(self, dns_s):
         super(Dns, self).__init__(dns_s)
         self._meta_data['required_json_kind'] =\
@@ -165,7 +167,7 @@ class Dns(UpdateMonitorMixin, Resource):
 
 
 class Externals(Collection):
-    """BIG-IP external monitor collection."""
+    """BIG-IP® external monitor collection."""
     def __init__(self, monitor):
         super(Externals, self).__init__(monitor)
         self._meta_data['allowed_lazy_attributes'] = [External]
@@ -174,7 +176,7 @@ class Externals(Collection):
 
 
 class External(UpdateMonitorMixin, Resource):
-    """BIG-IP external monitor resrouce."""
+    """BIG-IP® external monitor resrouce."""
     def __init__(self, externals):
         super(External, self).__init__(externals)
         self._meta_data['required_json_kind'] =\
@@ -182,7 +184,7 @@ class External(UpdateMonitorMixin, Resource):
 
 
 class Firepass_s(Collection):
-    """BIG-IP Fire Pass monitor collection."""
+    """BIG-IP® Fire Pass monitor collection."""
     def __init__(self, monitor):
         super(Firepass_s, self).__init__(monitor)
         self._meta_data['allowed_lazy_attributes'] = [Firepass]
@@ -191,7 +193,7 @@ class Firepass_s(Collection):
 
 
 class Firepass(UpdateMonitorMixin, Resource):
-    """BIG-IP external monitor resource."""
+    """BIG-IP® external monitor resource."""
     def __init__(self, firepass_s):
         super(Firepass, self).__init__(firepass_s)
         self._meta_data['required_json_kind'] =\
@@ -199,7 +201,7 @@ class Firepass(UpdateMonitorMixin, Resource):
 
 
 class Ftps(Collection):
-    """BIG-IP Ftp monitor collection."""
+    """BIG-IP® Ftp monitor collection."""
     def __init__(self, monitor):
         super(Ftps, self).__init__(monitor)
         self._meta_data['allowed_lazy_attributes'] = [Ftp]
@@ -208,7 +210,7 @@ class Ftps(Collection):
 
 
 class Ftp(UpdateMonitorMixin, Resource):
-    """BIG-IP Ftp monitor resource."""
+    """BIG-IP® Ftp monitor resource."""
     def __init__(self, ftps):
         super(Ftp, self).__init__(ftps)
         self._meta_data['required_json_kind'] =\
@@ -216,7 +218,7 @@ class Ftp(UpdateMonitorMixin, Resource):
 
 
 class Gateway_Icmps(Collection):
-    """BIG-IP Gateway Icmp monitor collection."""
+    """BIG-IP® Gateway Icmp monitor collection."""
     def __init__(self, monitor):
         super(Gateway_Icmps, self).__init__(monitor)
         fixed = self._meta_data['uri'].replace('_', '-')
@@ -227,7 +229,7 @@ class Gateway_Icmps(Collection):
 
 
 class Gateway_Icmp(UpdateMonitorMixin, Resource):
-    """BIG-IP Gateway Icmp monitor resource."""
+    """BIG-IP® Gateway Icmp monitor resource."""
     def __init__(self, gateway_icmps):
         super(Gateway_Icmp, self).__init__(gateway_icmps)
         self._meta_data['required_json_kind'] =\
@@ -235,7 +237,7 @@ class Gateway_Icmp(UpdateMonitorMixin, Resource):
 
 
 class Icmps(Collection):
-    """BIG-IP Icmp monitor collection."""
+    """BIG-IP® Icmp monitor collection."""
     def __init__(self, monitor):
         super(Icmps, self).__init__(monitor)
         self._meta_data['allowed_lazy_attributes'] = [Icmp]
@@ -244,7 +246,7 @@ class Icmps(Collection):
 
 
 class Icmp(UpdateMonitorMixin, Resource):
-    """BIG-IP Icmp monitor resource."""
+    """BIG-IP® Icmp monitor resource."""
     def __init__(self, icmps):
         super(Icmp, self).__init__(icmps)
         self._meta_data['required_json_kind'] =\
@@ -252,7 +254,7 @@ class Icmp(UpdateMonitorMixin, Resource):
 
 
 class Imaps(Collection):
-    """BIG-IP Imap monitor collection."""
+    """BIG-IP® Imap monitor collection."""
     def __init__(self, monitor):
         super(Imaps, self).__init__(monitor)
         self._meta_data['allowed_lazy_attributes'] = [Imap]
@@ -261,7 +263,7 @@ class Imaps(Collection):
 
 
 class Imap(UpdateMonitorMixin, Resource):
-    """BIG-IP Imap monitor resource."""
+    """BIG-IP® Imap monitor resource."""
     def __init__(self, imaps):
         super(Imap, self).__init__(imaps)
         self._meta_data['required_json_kind'] =\
@@ -269,7 +271,7 @@ class Imap(UpdateMonitorMixin, Resource):
 
 
 class Inbands(Collection):
-    """BIG-IP in band monitor collection."""
+    """BIG-IP® in band monitor collection."""
     def __init__(self, monitor):
         super(Inbands, self).__init__(monitor)
         self._meta_data['allowed_lazy_attributes'] = [Inband]
@@ -278,7 +280,7 @@ class Inbands(Collection):
 
 
 class Inband(UpdateMonitorMixin, Resource):
-    """BIG-IP in band monitor resource."""
+    """BIG-IP® in band monitor resource."""
     def __init__(self, inbands):
         super(Inband, self).__init__(inbands)
         self._meta_data['required_json_kind'] =\
@@ -286,7 +288,7 @@ class Inband(UpdateMonitorMixin, Resource):
 
 
 class Ldaps(Collection):
-    """BIG-IP Ldap monitor collection."""
+    """BIG-IP® Ldap monitor collection."""
     def __init__(self, monitor):
         super(Ldaps, self).__init__(monitor)
         self._meta_data['allowed_lazy_attributes'] = [Ldap]
@@ -295,7 +297,7 @@ class Ldaps(Collection):
 
 
 class Ldap(UpdateMonitorMixin, Resource):
-    """BIG-IP Ldap monitor resource."""
+    """BIG-IP® Ldap monitor resource."""
     def __init__(self, ldaps):
         super(Ldap, self).__init__(ldaps)
         self._meta_data['required_json_kind'] =\
@@ -303,7 +305,7 @@ class Ldap(UpdateMonitorMixin, Resource):
 
 
 class Module_Scores(Collection):
-    """BIG-IP module scores monitor collection."""
+    """BIG-IP® module scores monitor collection."""
     def __init__(self, monitor):
         super(Module_Scores, self).__init__(monitor)
         fixed = self._meta_data['uri'].replace('_', '-')
@@ -314,7 +316,7 @@ class Module_Scores(Collection):
 
 
 class Module_Score(UpdateMonitorMixin, Resource):
-    """BIG-IP module scores monitor resource."""
+    """BIG-IP® module scores monitor resource."""
     def __init__(self, gateway_icmps):
         super(Module_Score, self).__init__(gateway_icmps)
         self._meta_data['required_creation_parameters'].update(
@@ -324,7 +326,7 @@ class Module_Score(UpdateMonitorMixin, Resource):
 
 
 class Mysqls(Collection):
-    """BIG-IP MySQL monitor collection."""
+    """BIG-IP® MySQL monitor collection."""
     def __init__(self, monitor):
         super(Mysqls, self).__init__(monitor)
         self._meta_data['allowed_lazy_attributes'] = [Mysql]
@@ -333,7 +335,7 @@ class Mysqls(Collection):
 
 
 class Mysql(UpdateMonitorMixin, Resource):
-    """BIG-IP MySQL monitor resource."""
+    """BIG-IP® MySQL monitor resource."""
     def __init__(self, mysqls):
         super(Mysql, self).__init__(mysqls)
         self._meta_data['required_json_kind'] =\
@@ -341,7 +343,7 @@ class Mysql(UpdateMonitorMixin, Resource):
 
 
 class Mssqls(Collection):
-    """BIG-IP Mssql monitor collection."""
+    """BIG-IP® Mssql monitor collection."""
     def __init__(self, monitor):
         super(Mssqls, self).__init__(monitor)
         self._meta_data['allowed_lazy_attributes'] = [Mssql]
@@ -350,7 +352,7 @@ class Mssqls(Collection):
 
 
 class Mssql(UpdateMonitorMixin, Resource):
-    """BIG-IP Mssql monitor resource."""
+    """BIG-IP® Mssql monitor resource."""
     def __init__(self, mssqls):
         super(Mssql, self).__init__(mssqls)
         self._meta_data['required_json_kind'] =\
@@ -358,7 +360,7 @@ class Mssql(UpdateMonitorMixin, Resource):
 
 
 class Nntps(Collection):
-    """BIG-IP Nntps monitor collection."""
+    """BIG-IP® Nntps monitor collection."""
     def __init__(self, monitor):
         super(Nntps, self).__init__(monitor)
         self._meta_data['allowed_lazy_attributes'] = [Nntp]
@@ -367,7 +369,7 @@ class Nntps(Collection):
 
 
 class Nntp(UpdateMonitorMixin, Resource):
-    """BIG-IP Nntps monitor resource."""
+    """BIG-IP® Nntps monitor resource."""
     def __init__(self, nntps):
         super(Nntp, self).__init__(nntps)
         self._meta_data['required_json_kind'] =\
@@ -375,7 +377,7 @@ class Nntp(UpdateMonitorMixin, Resource):
 
 
 class Nones(Collection):
-    """BIG-IP None monitor collection."""
+    """BIG-IP® None monitor collection."""
     def __init__(self, monitor):
         super(Nones, self).__init__(monitor)
         self._meta_data['allowed_lazy_attributes'] = [NONE]
@@ -384,7 +386,7 @@ class Nones(Collection):
 
 
 class NONE(UpdateMonitorMixin, Resource):
-    """BIG-IP None monitor resource."""
+    """BIG-IP® None monitor resource."""
     def __init__(self, nones):
         super(NONE, self).__init__(nones)
         self._meta_data['required_json_kind'] =\
@@ -392,7 +394,7 @@ class NONE(UpdateMonitorMixin, Resource):
 
 
 class Oracles(Collection):
-    """BIG-IP Oracle monitor collection."""
+    """BIG-IP® Oracle monitor collection."""
     def __init__(self, monitor):
         super(Oracles, self).__init__(monitor)
         self._meta_data['allowed_lazy_attributes'] = [Oracle]
@@ -401,7 +403,7 @@ class Oracles(Collection):
 
 
 class Oracle(UpdateMonitorMixin, Resource):
-    """BIG-IP Oracle monitor resource."""
+    """BIG-IP® Oracle monitor resource."""
     def __init__(self, oracles):
         super(Oracle, self).__init__(oracles)
         self._meta_data['required_json_kind'] =\
@@ -409,7 +411,7 @@ class Oracle(UpdateMonitorMixin, Resource):
 
 
 class Pop3s(Collection):
-    """BIG-IP Pop3 monitor collection."""
+    """BIG-IP® Pop3 monitor collection."""
     def __init__(self, monitor):
         super(Pop3s, self).__init__(monitor)
         self._meta_data['allowed_lazy_attributes'] = [Pop3]
@@ -418,7 +420,7 @@ class Pop3s(Collection):
 
 
 class Pop3(UpdateMonitorMixin, Resource):
-    """BIG-IP Pop3 monitor resource."""
+    """BIG-IP® Pop3 monitor resource."""
     def __init__(self, pop3s):
         super(Pop3, self).__init__(pop3s)
         self._meta_data['required_json_kind'] =\
@@ -426,7 +428,7 @@ class Pop3(UpdateMonitorMixin, Resource):
 
 
 class Postgresqls(Collection):
-    """BIG-IP PostGRES SQL monitor collection."""
+    """BIG-IP® PostGRES SQL monitor collection."""
     def __init__(self, monitor):
         super(Postgresqls, self).__init__(monitor)
         self._meta_data['allowed_lazy_attributes'] = [Postgresql]
@@ -435,7 +437,7 @@ class Postgresqls(Collection):
 
 
 class Postgresql(UpdateMonitorMixin, Resource):
-    """BIG-IP PostGRES SQL monitor resource."""
+    """BIG-IP® PostGRES SQL monitor resource."""
     def __init__(self, postgresqls):
         super(Postgresql, self).__init__(postgresqls)
         self._meta_data['required_json_kind'] =\
@@ -443,7 +445,7 @@ class Postgresql(UpdateMonitorMixin, Resource):
 
 
 class Radius_s(Collection):
-    """BIG-IP radius monitor collection."""
+    """BIG-IP® radius monitor collection."""
     def __init__(self, monitor):
         super(Radius_s, self).__init__(monitor)
         self._meta_data['allowed_lazy_attributes'] = [Radius]
@@ -452,7 +454,7 @@ class Radius_s(Collection):
 
 
 class Radius(UpdateMonitorMixin, Resource):
-    """BIG-IP radius monitor resource."""
+    """BIG-IP® radius monitor resource."""
     def __init__(self, radius_s):
         super(Radius, self).__init__(radius_s)
         self._meta_data['required_json_kind'] =\
@@ -460,7 +462,7 @@ class Radius(UpdateMonitorMixin, Resource):
 
 
 class Radius_Accountings(Collection):
-    """BIG-IP radius accounting monitor collection."""
+    """BIG-IP® radius accounting monitor collection."""
     def __init__(self, monitor):
         super(Radius_Accountings, self).__init__(monitor)
         fixed = self._meta_data['uri'].replace('_', '-')
@@ -472,7 +474,7 @@ class Radius_Accountings(Collection):
 
 
 class Radius_Accounting(UpdateMonitorMixin, Resource):
-    """BIG-IP radius accounting monitor resource."""
+    """BIG-IP® radius accounting monitor resource."""
     def __init__(self, radius_accountings):
         super(Radius_Accounting, self).__init__(radius_accountings)
         self._meta_data['required_json_kind'] =\
@@ -480,7 +482,7 @@ class Radius_Accounting(UpdateMonitorMixin, Resource):
 
 
 class Real_Servers(Collection):
-    """BIG-IP real-server monitor collection."""
+    """BIG-IP® real-server monitor collection."""
     def __init__(self, monitor):
         super(Real_Servers, self).__init__(monitor)
         fixed = self._meta_data['uri'].replace('_', '-')
@@ -491,7 +493,7 @@ class Real_Servers(Collection):
 
 
 class Real_Server(UpdateMonitorMixin, Resource):
-    """BIG-IP real-server monitor resource."""
+    """BIG-IP® real-server monitor resource."""
     def __init__(self, real_servers):
         super(Real_Server, self).__init__(real_servers)
         self._meta_data['required_json_kind'] =\
@@ -522,7 +524,7 @@ class Real_Server(UpdateMonitorMixin, Resource):
 
 
 class Rpcs(Collection):
-    """BIG-IP Rpc monitor collection."""
+    """BIG-IP® Rpc monitor collection."""
     def __init__(self, monitor):
         super(Rpcs, self).__init__(monitor)
         self._meta_data['allowed_lazy_attributes'] = [Rpc]
@@ -531,7 +533,7 @@ class Rpcs(Collection):
 
 
 class Rpc(UpdateMonitorMixin, Resource):
-    """BIG-IP Rpc monitor resource."""
+    """BIG-IP® Rpc monitor resource."""
     def __init__(self, rpcs):
         super(Rpc, self).__init__(rpcs)
         self._meta_data['required_json_kind'] =\
@@ -539,7 +541,7 @@ class Rpc(UpdateMonitorMixin, Resource):
 
 
 class Sasps(Collection):
-    """BIG-IP Sasp monitor collection."""
+    """BIG-IP® Sasp monitor collection."""
     def __init__(self, monitor):
         super(Sasps, self).__init__(monitor)
         self._meta_data['allowed_lazy_attributes'] = [Sasp]
@@ -548,7 +550,7 @@ class Sasps(Collection):
 
 
 class Sasp(UpdateMonitorMixin, Resource):
-    """BIG-IP Sasp monitor resource."""
+    """BIG-IP® Sasp monitor resource."""
     def __init__(self, sasps):
         super(Sasp, self).__init__(sasps)
         self._meta_data['required_creation_parameters'].update(
@@ -558,7 +560,7 @@ class Sasp(UpdateMonitorMixin, Resource):
 
 
 class Scripteds(Collection):
-    """BIG-IP scripted monitor collection."""
+    """BIG-IP® scripted monitor collection."""
     def __init__(self, monitor):
         super(Scripteds, self).__init__(monitor)
         self._meta_data['allowed_lazy_attributes'] = [Scripted]
@@ -567,7 +569,7 @@ class Scripteds(Collection):
 
 
 class Scripted(UpdateMonitorMixin, Resource):
-    """BIG-IP scripted monitor resource."""
+    """BIG-IP® scripted monitor resource."""
     def __init__(self, scripteds):
         super(Scripted, self).__init__(scripteds)
         self._meta_data['required_json_kind'] =\
@@ -575,7 +577,7 @@ class Scripted(UpdateMonitorMixin, Resource):
 
 
 class Sips(Collection):
-    """BIG-IP Sip monitor collection."""
+    """BIG-IP® Sip monitor collection."""
     def __init__(self, monitor):
         super(Sips, self).__init__(monitor)
         self._meta_data['allowed_lazy_attributes'] = [Sip]
@@ -584,7 +586,7 @@ class Sips(Collection):
 
 
 class Sip(UpdateMonitorMixin, Resource):
-    """BIG-IP Sip monitor resource."""
+    """BIG-IP® Sip monitor resource."""
     def __init__(self, sips):
         super(Sip, self).__init__(sips)
         self._meta_data['required_json_kind'] =\
@@ -592,7 +594,7 @@ class Sip(UpdateMonitorMixin, Resource):
 
 
 class Smbs(Collection):
-    """BIG-IP Smb monitor collection."""
+    """BIG-IP® Smb monitor collection."""
     def __init__(self, monitor):
         super(Smbs, self).__init__(monitor)
         self._meta_data['allowed_lazy_attributes'] = [Smb]
@@ -601,7 +603,7 @@ class Smbs(Collection):
 
 
 class Smb(UpdateMonitorMixin, Resource):
-    """BIG-IP Smb monitor resource."""
+    """BIG-IP® Smb monitor resource."""
     def __init__(self, smbs):
         super(Smb, self).__init__(smbs)
         self._meta_data['required_json_kind'] =\
@@ -609,7 +611,7 @@ class Smb(UpdateMonitorMixin, Resource):
 
 
 class Smtps(Collection):
-    """BIG-IP Smtp monitor collection."""
+    """BIG-IP® Smtp monitor collection."""
     def __init__(self, monitor):
         super(Smtps, self).__init__(monitor)
         self._meta_data['allowed_lazy_attributes'] = [Smtp]
@@ -618,7 +620,7 @@ class Smtps(Collection):
 
 
 class Smtp(UpdateMonitorMixin, Resource):
-    """BIG-IP Smtp monitor resource."""
+    """BIG-IP® Smtp monitor resource."""
     def __init__(self, smtps):
         super(Smtp, self).__init__(smtps)
         self._meta_data['required_json_kind'] =\
@@ -626,7 +628,7 @@ class Smtp(UpdateMonitorMixin, Resource):
 
 
 class Snmp_Dcas(Collection):
-    """BIG-IP SNMP DCA monitor collection."""
+    """BIG-IP® SNMP DCA monitor collection."""
     def __init__(self, monitor):
         super(Snmp_Dcas, self).__init__(monitor)
         fixed = self._meta_data['uri'].replace('_', '-')
@@ -637,7 +639,7 @@ class Snmp_Dcas(Collection):
 
 
 class Snmp_Dca(UpdateMonitorMixin, Resource):
-    """BIG-IP SNMP DCA monitor resource."""
+    """BIG-IP® SNMP DCA monitor resource."""
     def __init__(self, snmp_dcas):
         super(Snmp_Dca, self).__init__(snmp_dcas)
         self._meta_data['required_json_kind'] =\
@@ -645,7 +647,7 @@ class Snmp_Dca(UpdateMonitorMixin, Resource):
 
 
 class Snmp_Dca_Bases(Collection):
-    """BIG-IP SNMP DCA bases monitor collection."""
+    """BIG-IP® SNMP DCA bases monitor collection."""
     def __init__(self, monitor):
         super(Snmp_Dca_Bases, self).__init__(monitor)
         fixed = self._meta_data['uri'].replace('_', '-')
@@ -656,7 +658,7 @@ class Snmp_Dca_Bases(Collection):
 
 
 class Snmp_Dca_Base(UpdateMonitorMixin, Resource):
-    """BIG-IP SNMP DCA monitor resource."""
+    """BIG-IP® SNMP DCA monitor resource."""
     def __init__(self, snmp_dca_bases):
         super(Snmp_Dca_Base, self).__init__(snmp_dca_bases)
         self._meta_data['required_json_kind'] =\
@@ -664,7 +666,7 @@ class Snmp_Dca_Base(UpdateMonitorMixin, Resource):
 
 
 class Soaps(Collection):
-    """BIG-IP Soap monitor collection."""
+    """BIG-IP® Soap monitor collection."""
     def __init__(self, monitor):
         super(Soaps, self).__init__(monitor)
         self._meta_data['allowed_lazy_attributes'] = [Soap]
@@ -673,7 +675,7 @@ class Soaps(Collection):
 
 
 class Soap(UpdateMonitorMixin, Resource):
-    """BIG-IP Soap monitor resource."""
+    """BIG-IP® Soap monitor resource."""
     def __init__(self, soaps):
         super(Soap, self).__init__(soaps)
         self._meta_data['required_json_kind'] =\
@@ -681,7 +683,7 @@ class Soap(UpdateMonitorMixin, Resource):
 
 
 class Tcps(Collection):
-    """BIG-IP Tcp monitor collection."""
+    """BIG-IP® Tcp monitor collection."""
     def __init__(self, monitor):
         super(Tcps, self).__init__(monitor)
         self._meta_data['allowed_lazy_attributes'] = [Tcp]
@@ -690,7 +692,7 @@ class Tcps(Collection):
 
 
 class Tcp(UpdateMonitorMixin, Resource):
-    """BIG-IP Tcp monitor resource."""
+    """BIG-IP® Tcp monitor resource."""
     def __init__(self, tcps):
         super(Tcp, self).__init__(tcps)
         self._meta_data['required_json_kind'] =\
@@ -698,7 +700,7 @@ class Tcp(UpdateMonitorMixin, Resource):
 
 
 class Tcp_Echos(Collection):
-    """BIG-IP Tcp echo monitor collection."""
+    """BIG-IP® Tcp echo monitor collection."""
     def __init__(self, monitor):
         super(Tcp_Echos, self).__init__(monitor)
         fixed = self._meta_data['uri'].replace('_', '-')
@@ -709,7 +711,7 @@ class Tcp_Echos(Collection):
 
 
 class Tcp_Echo(UpdateMonitorMixin, Resource):
-    """BIG-IP Tcp echo monitor resource."""
+    """BIG-IP® Tcp echo monitor resource."""
     def __init__(self, tcp_echos):
         super(Tcp_Echo, self).__init__(tcp_echos)
         self._meta_data['required_json_kind'] =\
@@ -717,7 +719,7 @@ class Tcp_Echo(UpdateMonitorMixin, Resource):
 
 
 class Tcp_Half_Opens(Collection):
-    """BIG-IP Tcp half open monitor collection."""
+    """BIG-IP® Tcp half open monitor collection."""
     def __init__(self, monitor):
         super(Tcp_Half_Opens, self).__init__(monitor)
         fixed = self._meta_data['uri'].replace('_', '-')
@@ -728,7 +730,7 @@ class Tcp_Half_Opens(Collection):
 
 
 class Tcp_Half_Open(UpdateMonitorMixin, Resource):
-    """BIG-IP Tcp half open monitor resource."""
+    """BIG-IP® Tcp half open monitor resource."""
     def __init__(self, tcp_half_opens):
         super(Tcp_Half_Open, self).__init__(tcp_half_opens)
         self._meta_data['required_json_kind'] =\
@@ -736,7 +738,7 @@ class Tcp_Half_Open(UpdateMonitorMixin, Resource):
 
 
 class Udps(Collection):
-    """BIG-IP Udp monitor collection."""
+    """BIG-IP® Udp monitor collection."""
     def __init__(self, monitor):
         super(Udps, self).__init__(monitor)
         self._meta_data['allowed_lazy_attributes'] = [Udp]
@@ -745,7 +747,7 @@ class Udps(Collection):
 
 
 class Udp(UpdateMonitorMixin, Resource):
-    """BIG-IP Udp monitor resource."""
+    """BIG-IP® Udp monitor resource."""
     def __init__(self, udps):
         super(Udp, self).__init__(udps)
         self._meta_data['required_json_kind'] =\
@@ -753,7 +755,7 @@ class Udp(UpdateMonitorMixin, Resource):
 
 
 class Virtual_Locations(Collection):
-    """BIG-IP virtual-locations monitor collection."""
+    """BIG-IP® virtual-locations monitor collection."""
     def __init__(self, monitor):
         super(Virtual_Locations, self).__init__(monitor)
         fixed = self._meta_data['uri'].replace('_', '-')
@@ -765,7 +767,7 @@ class Virtual_Locations(Collection):
 
 
 class Virtual_Location(UpdateMonitorMixin, Resource):
-    """BIG-IP virtual-locations monitor resource."""
+    """BIG-IP® virtual-locations monitor resource."""
     def __init__(self, virtual_locations):
         super(Virtual_Location, self).__init__(virtual_locations)
         self._meta_data['required_creation_parameters'].update(
@@ -775,7 +777,7 @@ class Virtual_Location(UpdateMonitorMixin, Resource):
 
 
 class Waps(Collection):
-    """BIG-IP Wap monitor collection."""
+    """BIG-IP® Wap monitor collection."""
     def __init__(self, monitor):
         super(Waps, self).__init__(monitor)
         self._meta_data['allowed_lazy_attributes'] = [Wap]
@@ -784,7 +786,7 @@ class Waps(Collection):
 
 
 class Wap(UpdateMonitorMixin, Resource):
-    """BIG-IP Wap monitor resource."""
+    """BIG-IP® Wap monitor resource."""
     def __init__(self, waps):
         super(Wap, self).__init__(waps)
         self._meta_data['required_json_kind'] =\
@@ -792,7 +794,7 @@ class Wap(UpdateMonitorMixin, Resource):
 
 
 class Wmis(Collection):
-    """BIG-IP Wmi monitor collection."""
+    """BIG-IP® Wmi monitor collection."""
     def __init__(self, monitor):
         super(Wmis, self).__init__(monitor)
         self._meta_data['allowed_lazy_attributes'] = [Wmi]
@@ -801,7 +803,7 @@ class Wmis(Collection):
 
 
 class Wmi(UpdateMonitorMixin, Resource):
-    """BIG-IP Wmi monitor resource."""
+    """BIG-IP® Wmi monitor resource."""
     def __init__(self, wmis):
         super(Wmi, self).__init__(wmis)
         self._meta_data['required_json_kind'] =\

--- a/f5/bigip/ltm/nat.py
+++ b/f5/bigip/ltm/nat.py
@@ -1,4 +1,6 @@
-# Copyright 2014-2016 F5 Networks Inc.
+# coding=utf-8
+#
+#  Copyright 2014-2016 F5 Networks Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -12,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-"""BIG-IP Local Traffic Manager (LTM) Nat module.
+"""BIG-IP® Local Traffic Manager (LTM) Nat module.
 
 REST URI
     ``http://localhost/mgmt/tm/ltm/nat``
@@ -31,7 +33,7 @@ from f5.bigip.resource import Resource
 
 
 class Nats(Collection):
-    """BIG-IP LTM Nat collection object"""
+    """BIG-IP® LTM Nat collection object"""
     def __init__(self, ltm):
         super(Nats, self).__init__(ltm)
         self._meta_data['allowed_lazy_attributes'] = [Nat]
@@ -40,7 +42,7 @@ class Nats(Collection):
 
 
 class Nat(Resource, ExclusiveAttributesMixin):
-    """BIG-IP LTM Nat collection resource"""
+    """BIG-IP® LTM Nat collection resource"""
     def __init__(self, nat_s):
         super(Nat, self).__init__(nat_s)
         self._meta_data['required_creation_parameters'].update(
@@ -49,7 +51,7 @@ class Nat(Resource, ExclusiveAttributesMixin):
         self._meta_data['exclusive_attributes'].append(('enable', 'disable'))
 
     def create(self, **kwargs):
-        """Create the resource on the BIG-IP.
+        """Create the resource on the BIG-IP®.
 
         Uses HTTP POST to the `collection` URI to create a resource associated
         with a new unique URI on the device.
@@ -73,7 +75,7 @@ class Nat(Resource, ExclusiveAttributesMixin):
 
         :param kwargs: All the key-values needed to create the resource
         :returns: ``self`` - A python object that represents the object's
-                  configuration and state on the BIG-IP.
+                  configuration and state on the BIG-IP®.
 
         """
         itg = kwargs.get('inheritedTrafficGroup', None)

--- a/f5/bigip/ltm/node.py
+++ b/f5/bigip/ltm/node.py
@@ -1,4 +1,6 @@
-# Copyright 2016 F5 Networks Inc.
+# coding=utf-8
+#
+#  Copyright 2016 F5 Networks Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -13,7 +15,7 @@
 # limitations under the License.
 #
 
-"""BIG-IP Local Traffic Manager (LTM) node module.
+"""BIG-IP® Local Traffic Manager (LTM) node module.
 
 REST URI
     ``http://localhost/mgmt/tm/ltm/node``
@@ -30,7 +32,7 @@ from f5.bigip.resource import Resource
 
 
 class Nodes(Collection):
-    """BIG-IP LTM node collection"""
+    """BIG-IP® LTM node collection"""
     def __init__(self, ltm):
         super(Nodes, self).__init__(ltm)
         self._meta_data['allowed_lazy_attributes'] = [Node]
@@ -39,7 +41,7 @@ class Nodes(Collection):
 
 
 class Node(Resource):
-    """BIG-IP LTM node resource"""
+    """BIG-IP® LTM node resource"""
     def __init__(self, nodes):
         super(Node, self).__init__(nodes)
         self._meta_data['required_json_kind'] = 'tm:ltm:node:nodestate'

--- a/f5/bigip/ltm/persistence.py
+++ b/f5/bigip/ltm/persistence.py
@@ -1,4 +1,6 @@
-# Copyright 2016 F5 Networks Inc.
+# coding=utf-8
+#
+#  Copyright 2016 F5 Networks Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/f5/bigip/ltm/policy.py
+++ b/f5/bigip/ltm/policy.py
@@ -1,4 +1,6 @@
-# Copyright 2014-2016 F5 Networks Inc.
+# coding=utf-8
+#
+#  Copyright 2014-2016 F5 Networks Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -13,7 +15,7 @@
 # limitations under the License.
 #
 
-"""BIG-IP Local Traffic Manager (LTM) policy module.
+"""BIG-IP® Local Traffic Manager (LTM) policy module.
 
 REST URI
     ``http://localhost/mgmt/tm/ltm/policy``
@@ -30,7 +32,7 @@ from f5.bigip.resource import Resource
 
 
 class Policys(Collection):
-    """BIG-IP LTM policy collection."""
+    """BIG-IP® LTM policy collection."""
     def __init__(self, ltm):
         super(Policys, self).__init__(ltm)
         self._meta_data['allowed_lazy_attributes'] = [Policy]
@@ -39,7 +41,7 @@ class Policys(Collection):
 
 
 class Policy(Resource):
-    """BIG-IP LTM policy resource."""
+    """BIG-IP® LTM policy resource."""
     def __init__(self, policy_s):
         super(Policy, self).__init__(policy_s)
         self._meta_data['required_json_kind'] = 'tm:ltm:policy:policystate'
@@ -49,7 +51,7 @@ class Policy(Resource):
 
 
 class Rules_s(Collection):
-    """BIG-IP LTM policy rules sub-collection."""
+    """BIG-IP® LTM policy rules sub-collection."""
     def __init__(self, policy):
         super(Rules_s, self).__init__(policy)
         self._meta_data['attribute_registry'] =\
@@ -60,7 +62,7 @@ class Rules_s(Collection):
 
 
 class Rules(Resource):
-    """BIG-IP LTM policy rules sub-collection resource."""
+    """BIG-IP® LTM policy rules sub-collection resource."""
     def __init__(self, rules_s):
         super(Rules, self).__init__(rules_s)
         self._meta_data['required_json_kind'] =\
@@ -73,7 +75,7 @@ class Rules(Resource):
 
 
 class Actions_s(Collection):
-    """BIG-IP LTM policy actions sub-collection."""
+    """BIG-IP® LTM policy actions sub-collection."""
     def __init__(self, rules):
         super(Actions_s, self).__init__(rules)
         self._meta_data['required_json_kind'] =\
@@ -84,7 +86,7 @@ class Actions_s(Collection):
 
 
 class Actions(Resource):
-    """BIG-IP LTM policy actions sub-collection resource."""
+    """BIG-IP® LTM policy actions sub-collection resource."""
     def __init__(self, actions_s):
         super(Actions, self).__init__(actions_s)
         self._meta_data['required_json_kind'] =\
@@ -92,7 +94,7 @@ class Actions(Resource):
 
 
 class Conditions_s(Collection):
-    """BIG-IP LTM policy conditions sub-collection."""
+    """BIG-IP® LTM policy conditions sub-collection."""
     def __init__(self, rules):
         super(Conditions_s, self).__init__(rules)
         self._meta_data['required_json_kind'] =\
@@ -103,7 +105,7 @@ class Conditions_s(Collection):
 
 
 class Conditions(Resource):
-    """BIG-IP LTM policy conditions sub-collection resource."""
+    """BIG-IP® LTM policy conditions sub-collection resource."""
     def __init__(self, conditions_s):
         super(Conditions, self).__init__(conditions_s)
         self._meta_data['required_json_kind'] =\

--- a/f5/bigip/ltm/pool.py
+++ b/f5/bigip/ltm/pool.py
@@ -1,4 +1,6 @@
-# Copyright 2014-2016 F5 Networks Inc.
+# coding=utf-8
+#
+#  Copyright 2014-2016 F5 Networks Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -13,7 +15,7 @@
 # limitations under the License.
 #
 
-"""BIG-IP Local Traffic Manager (LTM) pool module.
+"""BIG-IP® Local Traffic Manager™ (LTM®) pool module.
 
 REST URI
     ``http://localhost/mgmt/tm/ltm/pool``
@@ -37,7 +39,7 @@ class MemberStateAlwaysRequiredOnUpdate(F5SDKError):
 
 
 class Pools(Collection):
-    """BIG-IP LTM pool collection"""
+    """BIG-IP® LTM pool collection"""
     def __init__(self, ltm):
         super(Pools, self).__init__(ltm)
         self._meta_data['allowed_lazy_attributes'] = [Pool]
@@ -46,7 +48,7 @@ class Pools(Collection):
 
 
 class Pool(Resource):
-    """BIG-IP LTM pool resource"""
+    """BIG-IP® LTM pool resource"""
     def __init__(self, pool_s):
         super(Pool, self).__init__(pool_s)
         self._meta_data['required_json_kind'] = 'tm:ltm:pool:poolstate'
@@ -56,7 +58,7 @@ class Pool(Resource):
 
 
 class Members_s(Collection):
-    """BIG-IP LTM pool members sub-collection"""
+    """BIG-IP® LTM pool members sub-collection"""
     def __init__(self, pool):
         super(Members_s, self).__init__(pool)
         self._meta_data['allowed_lazy_attributes'] = [Members]
@@ -67,7 +69,7 @@ class Members_s(Collection):
 
 
 class Members(Resource):
-    """BIG-IP LTM pool members sub-collection resource"""
+    """BIG-IP® LTM pool members sub-collection resource"""
     def __init__(self, members_s):
         super(Members, self).__init__(members_s)
         self._meta_data['required_json_kind'] =\

--- a/f5/bigip/ltm/rule.py
+++ b/f5/bigip/ltm/rule.py
@@ -1,3 +1,5 @@
+# coding=utf-8
+#
 # Copyright 2014-2015 F5 Networks Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -13,7 +15,7 @@
 # limitations under the License.
 #
 
-"""BIG-IP Local Traffic Manager (LTM) rule module.
+"""BIG-IP® Local Traffic Manager (LTM) rule module.
 
 REST URI
     ``http://localhost/mgmt/tm/ltm/rule``
@@ -30,7 +32,7 @@ from f5.bigip.resource import Resource
 
 
 class Rules(Collection):
-    """BIG-IP LTM rule collection"""
+    """BIG-IP® LTM rule collection"""
     def __init__(self, ltm):
         super(Rules, self).__init__(ltm)
         self._meta_data['allowed_lazy_attributes'] = [Rule]
@@ -39,7 +41,7 @@ class Rules(Collection):
 
 
 class Rule(Resource):
-    """BIG-IP LTM rule resource"""
+    """BIG-IP® LTM rule resource"""
     def __init__(self, rule_s):
         super(Rule, self).__init__(rule_s)
         self._meta_data['required_json_kind'] = 'tm:ltm:rule:rulestate'

--- a/f5/bigip/ltm/snat.py
+++ b/f5/bigip/ltm/snat.py
@@ -1,3 +1,5 @@
+# coding=utf-8
+#
 # Copyright 2014-2016 F5 Networks Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -13,7 +15,7 @@
 # limitations under the License.
 #
 
-"""BIG-IP Local Traffic Manager (LTM) Snat module.
+"""BIG-IP® Local Traffic Manager (LTM) Snat module.
 
 REST URI
     ``http://localhost/mgmt/tm/ltm/snat``
@@ -35,7 +37,7 @@ class RequireOneOf(MissingRequiredCreationParameter):
 
 
 class Snats(Collection):
-    """BIG-IP LTM Snat collection"""
+    """BIG-IP® LTM Snat collection"""
     def __init__(self, ltm):
         super(Snats, self).__init__(ltm)
         self._meta_data['allowed_lazy_attributes'] = [Snat]
@@ -44,7 +46,7 @@ class Snats(Collection):
 
 
 class Snat(Resource):
-    """BIG-IP LTM Snat resource"""
+    """BIG-IP® LTM Snat resource"""
     def __init__(self, snat_s):
         '''This represents a Snat.
 
@@ -57,7 +59,7 @@ class Snat(Resource):
             ('partition', 'origins'))
 
     def create(self, **kwargs):
-        """Call this to create a new snat on the BIG-IP.
+        """Call this to create a new snat on the BIG-IP®.
 
         Uses HTTP POST to 'containing' URI to create a service associated with
         a new URI on the device.

--- a/f5/bigip/ltm/virtual.py
+++ b/f5/bigip/ltm/virtual.py
@@ -1,3 +1,5 @@
+# coding=utf-8
+#
 # Copyright 2014 F5 Networks Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -13,7 +15,7 @@
 # limitations under the License.
 #
 
-"""BIG-IP Local Traffic Manager (LTM) virtual module.
+"""BIG-IP® Local Traffic Manager (LTM) virtual module.
 
 REST URI
     ``http://localhost/mgmt/tm/ltm/virtual``
@@ -30,7 +32,7 @@ from f5.bigip.resource import Resource
 
 
 class Virtuals(Collection):
-    """BIG-IP LTM virtual collection"""
+    """BIG-IP® LTM virtual collection"""
     def __init__(self, ltm):
         super(Virtuals, self).__init__(ltm)
         self._meta_data['allowed_lazy_attributes'] = [Virtual]
@@ -39,7 +41,7 @@ class Virtuals(Collection):
 
 
 class Virtual(Resource):
-    """BIG-IP LTM virtual resource"""
+    """BIG-IP® LTM virtual resource"""
     def __init__(self, virtual_s):
         super(Virtual, self).__init__(virtual_s)
         # self._meta_data['allowed_lazy_attributes'] = [Profiles_s]

--- a/f5/bigip/mixins.py
+++ b/f5/bigip/mixins.py
@@ -1,3 +1,5 @@
+# coding=utf-8
+#
 # Copyright 2015-2016 F5 Networks Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/f5/bigip/net/__init__.py
+++ b/f5/bigip/net/__init__.py
@@ -1,3 +1,5 @@
+# coding=utf-8
+#
 # Copyright 2015 F5 Networks Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -13,7 +15,7 @@
 # limitations under the License.
 #
 
-"""BIG-IP net module
+"""BIG-IP® net module
 
 REST URI
     ``http://localhost/mgmt/tm/net/``

--- a/f5/bigip/net/arp.py
+++ b/f5/bigip/net/arp.py
@@ -1,4 +1,6 @@
-# Copyright 2016 F5 Networks Inc.
+# coding=utf-8
+#
+#  Copyright 2016 F5 Networks Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -13,7 +15,7 @@
 # limitations under the License.
 #
 
-"""BIG-IP Network ARP module.
+"""BIG-IP® Network ARP module.
 
 REST URI
     ``http://localhost/mgmt/tm/net/arp``
@@ -30,7 +32,7 @@ from f5.bigip.resource import Resource
 
 
 class Arps(Collection):
-    """BIG-IP network ARP collection"""
+    """BIG-IP® network ARP collection"""
     def __init__(self, net):
         super(Arps, self).__init__(net)
         self._meta_data['allowed_lazy_attributes'] = [Arp]
@@ -40,7 +42,7 @@ class Arps(Collection):
 
 
 class Arp(Resource):
-    """BIG-IP network ARP resource"""
+    """BIG-IP® network ARP resource"""
     def __init__(self, arp_s):
         super(Arp, self).__init__(arp_s)
         self._meta_data['required_json_kind'] = 'tm:net:arp:arpstate'

--- a/f5/bigip/net/fdb.py
+++ b/f5/bigip/net/fdb.py
@@ -1,3 +1,5 @@
+# coding=utf-8
+#
 # Copyright 2016 F5 Networks Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/f5/bigip/net/interface.py
+++ b/f5/bigip/net/interface.py
@@ -1,4 +1,6 @@
-# Copyright 2014-2016 F5 Networks Inc.
+# coding=utf-8
+#
+#  Copyright 2014-2016 F5 Networks Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -13,7 +15,7 @@
 # limitations under the License.
 #
 
-"""BIG-IP Network interface module.
+"""BIG-IP® Network interface module.
 
 REST URI
     ``http://localhost/mgmt/tm/net/interface``
@@ -32,7 +34,7 @@ from f5.bigip.resource import UnsupportedOperation
 
 
 class Interfaces(Collection):
-    """BIG-IP network interface collection"""
+    """BIG-IP® network interface collection"""
     def __init__(self, net):
         super(Interfaces, self).__init__(net)
         self._meta_data['allowed_lazy_attributes'] = [Interface]
@@ -42,7 +44,7 @@ class Interfaces(Collection):
 
 
 class Interface(Resource, ExclusiveAttributesMixin):
-    """BIG-IP network interface collection"""
+    """BIG-IP® network interface collection"""
     def __init__(self, interface_s):
         super(Interface, self).__init__(interface_s)
         self._meta_data['required_json_kind'] =\

--- a/f5/bigip/net/route.py
+++ b/f5/bigip/net/route.py
@@ -1,3 +1,5 @@
+# coding=utf-8
+#
 # Copyright 2016 F5 Networks Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -13,7 +15,7 @@
 # limitations under the License.
 #
 
-"""BIG-IP Network route module.
+"""BIG-IP® Network route module.
 
 REST URI
     ``http://localhost/mgmt/tm/net/route``
@@ -32,7 +34,7 @@ from f5.bigip.resource import Resource
 
 
 class Routes(Collection):
-    """BIG-IP network route collection"""
+    """BIG-IP® network route collection"""
     def __init__(self, net):
         super(Routes, self).__init__(net)
         self._meta_data['allowed_lazy_attributes'] = [Route]
@@ -42,7 +44,7 @@ class Routes(Collection):
 
 
 class Route(Resource, ExclusiveAttributesMixin):
-    """BIG-IP network route resource"""
+    """BIG-IP® network route resource"""
     def __init__(self, route_s):
         super(Route, self).__init__(route_s)
         self._meta_data['required_json_kind'] = 'tm:net:route:routestate'
@@ -53,7 +55,7 @@ class Route(Resource, ExclusiveAttributesMixin):
             ('blackhole', 'gw', 'tmInterface', 'pool'))
 
     def create(self, **kwargs):
-        '''Create a Route on the BIG-IP and the associated python object.
+        '''Create a Route on the BIG-IP® and the associated python object.
 
         One of the following gateways is required when creating the route
         objects: ``blackhole``, ``gw``, ``tmInterface``, ``pool``.

--- a/f5/bigip/net/route_domain.py
+++ b/f5/bigip/net/route_domain.py
@@ -1,3 +1,5 @@
+# coding=utf-8
+#
 # Copyright 2016 F5 Networks Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/f5/bigip/net/selfip.py
+++ b/f5/bigip/net/selfip.py
@@ -1,3 +1,5 @@
+# coding=utf-8
+#
 # Copyright 2016 F5 Networks Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -13,7 +15,7 @@
 # limitations under the License.
 #
 
-"""BIG-IP Network self-ip module.
+"""BIG-IP® Network self-ip module.
 
 .. note::
 
@@ -35,7 +37,7 @@ from f5.bigip.resource import Resource
 
 
 class Selfips(Collection):
-    """BIG-IP network Self-IP collection
+    """BIG-IP® network Self-IP collection
 
     .. note::
 
@@ -54,10 +56,10 @@ class Selfips(Collection):
 
 
 class Selfip(Resource):
-    '''BIG-IP Self-IP resource
+    '''BIG-IP® Self-IP resource
 
     Use this object to create, refresh, update, delete, and load self ip
-    configuration on the BIG-IP.  This requires that a
+    configuration on the BIG-IP®.  This requires that a
     :class:`~f5.BIG-IP.network.vlan.VLAN` object be present on the system and
     that object's :attrib:`fullPath` be used as the VLAN name.
 

--- a/f5/bigip/net/tunnels.py
+++ b/f5/bigip/net/tunnels.py
@@ -1,3 +1,5 @@
+# coding=utf-8
+#
 # Copyright 2016 F5 Networks Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -13,7 +15,7 @@
 # limitations under the License.
 #
 
-"""BIG-IP Network tunnels module.
+"""BIG-IP® Network tunnels module.
 
 REST URI
     ``http://localhost/mgmt/tm/net/tunnels``
@@ -30,7 +32,7 @@ from f5.bigip.resource import Resource
 
 
 class Tunnels_s(Collection):
-    """BIG-IP network tunnels collection"""
+    """BIG-IP® network tunnels collection"""
     def __init__(self, net):
         super(Tunnels_s, self).__init__(net)
         self._meta_data['allowed_lazy_attributes'] = [
@@ -41,7 +43,7 @@ class Tunnels_s(Collection):
 
 
 class Tunnels(Collection):
-    """BIG-IP network tunnels resource (collection for GRE, Tunnel, VXLANs"""
+    """BIG-IP® network tunnels resource (collection for GRE, Tunnel, VXLANs"""
     def __init__(self, tunnels_s):
         super(Tunnels, self).__init__(tunnels_s)
         self._meta_data['allowed_lazy_attributes'] = [Gres, Tunnel, Vxlans]
@@ -50,7 +52,7 @@ class Tunnels(Collection):
 
 
 class Tunnel(Resource):
-    """BIG-IP tunnels tunnel resource"""
+    """BIG-IP® tunnels tunnel resource"""
     def __init__(self, tunnels):
         super(Tunnel, self).__init__(tunnels)
         self._meta_data['required_creation_parameters'].update(('partition',))
@@ -59,7 +61,7 @@ class Tunnel(Resource):
 
 
 class Gres(Collection):
-    """BIG-IP tunnels GRE sub-collection"""
+    """BIG-IP® tunnels GRE sub-collection"""
     def __init__(self, tunnels_s):
         super(Gres, self).__init__(tunnels_s)
         self._meta_data['allowed_lazy_attributes'] = [Gre]
@@ -68,7 +70,7 @@ class Gres(Collection):
 
 
 class Gre(Resource):
-    """BIG-IP tunnels GRE sub-collection resource"""
+    """BIG-IP® tunnels GRE sub-collection resource"""
     def __init__(self, gres):
         super(Gre, self).__init__(gres)
         self._meta_data['required_creation_parameters'].update(('partition',))
@@ -77,7 +79,7 @@ class Gre(Resource):
 
 
 class Vxlans(Collection):
-    """BIG-IP tunnels VXLAN sub-collection"""
+    """BIG-IP® tunnels VXLAN sub-collection"""
     def __init__(self, tunnels_s):
         super(Vxlans, self).__init__(tunnels_s)
         self._meta_data['allowed_lazy_attributes'] = [Vxlan]
@@ -86,7 +88,7 @@ class Vxlans(Collection):
 
 
 class Vxlan(Resource):
-    """BIG-IP tunnels VXLAN sub-collection resource"""
+    """BIG-IP® tunnels VXLAN sub-collection resource"""
     def __init__(self, vxlans):
         super(Vxlan, self).__init__(vxlans)
         self._meta_data['required_creation_parameters'].update(('partition',))

--- a/f5/bigip/net/vlan.py
+++ b/f5/bigip/net/vlan.py
@@ -1,3 +1,5 @@
+# coding=utf-8
+#
 # Copyright 2014-2016 F5 Networks Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -13,7 +15,7 @@
 # limitations under the License.
 #
 
-"""BIG-IP Network vlan module.
+"""BIG-IP® Network vlan module.
 
 REST URI
     ``http://localhost/mgmt/tm/net/vlan``
@@ -31,7 +33,7 @@ from f5.bigip.resource import Resource
 
 
 class Vlans(Collection):
-    """BIG-IP network Vlan collection."""
+    """BIG-IP® network Vlan collection."""
     def __init__(self, net):
         super(Vlans, self).__init__(net)
         self._meta_data['allowed_lazy_attributes'] = [Vlan]
@@ -40,7 +42,7 @@ class Vlans(Collection):
 
 
 class Vlan(Resource):
-    """BIG-IP network Vlan resource."""
+    """BIG-IP® network Vlan resource."""
     def __init__(self, vlan_s):
         super(Vlan, self).__init__(vlan_s)
         self._meta_data['required_json_kind'] = 'tm:net:vlan:vlanstate'
@@ -49,7 +51,7 @@ class Vlan(Resource):
 
 
 class Interfaces_s(Collection):
-    '''BIG-IP network Vlan interface collection.
+    '''BIG-IP® network Vlan interface collection.
 
     .. note::
         Not to be confused with ``tm/mgmt/net/interface``.  This is object
@@ -64,7 +66,7 @@ class Interfaces_s(Collection):
 
 
 class Interfaces(Resource, ExclusiveAttributesMixin):
-    """BIG-IP network Vlan interface resource."""
+    """BIG-IP® network Vlan interface resource."""
     def __init__(self, interfaces_s):
         super(Interfaces, self).__init__(interfaces_s)
         # Vlan intefaces objects do not have a partition

--- a/f5/bigip/resource.py
+++ b/f5/bigip/resource.py
@@ -1,3 +1,5 @@
+# coding=utf-8
+#
 # Copyright 2015-2016 F5 Networks Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -31,14 +33,14 @@ Examples:
  * Expression:     pool_a = pools1.create(partition="Common", name="foo")
  * URI Returned:   https://a/mgmt/tm/ltm/pool/~Common~foo
 
-There are different types of resources published by the BIG-IP REST Server,
+There are different types of resources published by the BIG-IP® REST Server,
 they are represented by the classes in this module.
 
 We refer to a server-provided resource as a "service".  Thus far all URI
 referenced resources are "services" in this sense.
 
 We use methods named Create, Refresh, Update, Load, and Delete to manipulate
-BIG-IP device services.
+BIG-IP® device services.
 
 Methods:
 
@@ -124,7 +126,7 @@ class UnregisteredKind(F5SDKError):
 
 
 class GenerationMismatch(F5SDKError):
-    """The server reported BIG-IP is not the expacted value."""
+    """The server reported BIG-IP® is not the expacted value."""
     pass
 
 
@@ -146,7 +148,7 @@ class UnsupportedOperation(F5SDKError):
 class PathElement(LazyAttributeMixin):
     """Base class to represent a URI path element that does not contain data.
 
-    The BIG-IP iControl REST API has URIs that are made up of path components
+    The BIG-IP® iControl REST API has URIs that are made up of path components
     that do not return data when they are queried.  This class represents
     those elements and does not support any of the CURDLE methods that
     the other objects do.
@@ -168,9 +170,9 @@ class PathElement(LazyAttributeMixin):
 
 
 class ResourceBase(PathElement, ToDictMixin):
-    """Base class for all BIG-IP iControl REST API endpoints.
+    """Base class for all BIG-IP® iControl REST API endpoints.
 
-    The BIG-IP is represented by an object that converts device published uri's
+    The BIG-IP® is represented by an object that converts device published uri's
     into Python objects.  Each uri maps to a Python object. The mechanism for
     instantiating these objects is the __getattr__ Special Function in the
     LazyAttributeMixin.  When a registered attribute is `dot` referenced, on
@@ -218,7 +220,7 @@ class ResourceBase(PathElement, ToDictMixin):
 
         Since all ResourceBases sub-types must support the `refresh` method, it
         is defined here, in the base class.
-        NOTE: The BIG-IP uri 'mgmt/tm/' uniquely passes itself to this
+        NOTE: The BIG-IP® uri 'mgmt/tm/' uniquely passes itself to this
         constructor as the "container".
 
         :param container: instance is an attribute of a ResourceBase container
@@ -342,9 +344,9 @@ class OrganizingCollection(ResourceBase):
       resources on the device.
     """
     def __init__(self, bigip):
-        """Call this to construct an OC. It should be an attribute of BIG-IP.
+        """Call this to construct an OC. It should be an attribute of BIG-IP®.
 
-        :param bigip: all OCs are attributes of a BIG-IP instance
+        :param bigip: all OCs are attributes of a BIG-IP® instance
         """
         super(OrganizingCollection, self).__init__(bigip)
 
@@ -567,7 +569,7 @@ class Resource(ResourceBase):
         return self
 
     def create(self, **kwargs):
-        """Create the resource on the BIG-IP.
+        """Create the resource on the BIG-IP®.
 
         Uses HTTP POST to the `collection` URI to create a resource associated
         with a new unique URI on the device.
@@ -591,7 +593,7 @@ class Resource(ResourceBase):
         be passed to the underlying requests.session.post method where it will
         be handled according to that API. THIS IS HOW TO PASS QUERY-ARGS!
         :returns: ``self`` - A python object that represents the object's
-                  configuration and state on the BIG-IP.
+                  configuration and state on the BIG-IP®.
 
         """
         self._create(**kwargs)
@@ -618,7 +620,7 @@ class Resource(ResourceBase):
     def load(self, **kwargs):
         """Load an already configured service into this instance.
 
-        This method uses HTTP GET to obtain a resource from the BIG-IP.
+        This method uses HTTP GET to obtain a resource from the BIG-IP®.
 
         ..
             The URI of the target service is constructed from the instance's
@@ -656,7 +658,7 @@ class Resource(ResourceBase):
         session = self._meta_data['bigip']._meta_data['icr_session']
         read_only = self._meta_data.get('read_only_attributes', [])
 
-        # Get the current state of the object on BIG-IP and check the
+        # Get the current state of the object on BIG-IP® and check the
         # generation Use pop here because we don't want force in the data_dict
         force = self._check_force_arg(kwargs.pop('force', False))
         if not force:
@@ -668,7 +670,7 @@ class Resource(ResourceBase):
 
         # Need to remove any of the Collection objects from self.__dict__
         # because these are subCollections and _meta_data and
-        # other non-BIG-IP attrs are not removed from the subCollections
+        # other non-BIG-IP® attrs are not removed from the subCollections
         # See issue #146 for details
         for key, value in self.__dict__.items():
             if isinstance(value, Collection):
@@ -677,7 +679,7 @@ class Resource(ResourceBase):
 
         # Remove any read-only attributes from our data_dict before we update
         # the data dict with the attributes.  If they pass in read-only attrs
-        # in the method call we are going to let BIG-IP let them know about it
+        # in the method call we are going to let BIG-IP® let them know about it
         # when it fails
         for attr in read_only:
             data_dict.pop(attr, '')
@@ -688,9 +690,9 @@ class Resource(ResourceBase):
         self._local_update(response.json())
 
     def update(self, **kwargs):
-        """Update the configuration of the resource on the BIG-IP.
+        """Update the configuration of the resource on the BIG-IP®.
 
-        This method uses HTTP PUT alter the resource state on the BIG-IP.
+        This method uses HTTP PUT alter the resource state on the BIG-IP®.
 
         The attributes of the instance will be packaged as a dictionary.  That
         dictionary will be updated with kwargs.  It is then submitted as JSON
@@ -724,9 +726,9 @@ class Resource(ResourceBase):
             self.__dict__ = {'deleted': True}
 
     def delete(self, **kwargs):
-        """Delete the resource on the BIG-IP.
+        """Delete the resource on the BIG-IP®.
 
-        Uses HTTP DELETE to delete the resource on the BIG-IP.
+        Uses HTTP DELETE to delete the resource on the BIG-IP®.
 
         After this method is called, and status_code 200 response is received
         ``instance.__dict__`` is replace with ``{'deleted': True}``
@@ -755,7 +757,7 @@ class Resource(ResourceBase):
         NOTE: If kwargs has a 'requests_params' key the corresponding dict will
         be passed to the underlying requests.session.get method where it will
         be handled according to that API. THIS IS HOW TO PASS QUERY-ARGS!
-        :returns: bool -- The objects exists on BIG-IP or not.
+        :returns: bool -- The objects exists on BIG-IP® or not.
         :raises: :exc:`requests.HTTPError`, Any HTTP error that was not status
                  code 404.
         """
@@ -780,7 +782,7 @@ class Resource(ResourceBase):
         return force
 
     def _check_generation(self):
-        '''Check that the generation on the BIG-IP matches the object
+        '''Check that the generation on the BIG-IP® matches the object
 
         This will do a get to the objects URI and check that the generation
         returned in the JSON matches the one the object currently has.  If it

--- a/f5/bigip/resource.py
+++ b/f5/bigip/resource.py
@@ -172,12 +172,13 @@ class PathElement(LazyAttributeMixin):
 class ResourceBase(PathElement, ToDictMixin):
     """Base class for all BIG-IP® iControl REST API endpoints.
 
-    The BIG-IP® is represented by an object that converts device published uri's
-    into Python objects.  Each uri maps to a Python object. The mechanism for
-    instantiating these objects is the __getattr__ Special Function in the
-    LazyAttributeMixin.  When a registered attribute is `dot` referenced, on
-    the device object (e.g. ``bigip.ltm`` or simply ``bigip``), an appropriate
-    object is instantiated and attributed to the referencing object:
+    The BIG-IP® is represented by an object that converts device-published
+    uri's into Python objects. Each uri maps to a Python object. The
+    mechanism for instantiating these objects is the __getattr__ Special
+    Function in the LazyAttributeMixin. When a registered attribute is `dot`
+    referenced, on the device object (e.g. ``bigip.ltm`` or simply ``bigip``),
+    an appropriate object is instantiated and attributed to the referencing
+    object:
 
     .. code-block:: python
 
@@ -208,7 +209,7 @@ class ResourceBase(PathElement, ToDictMixin):
 
     The net result is a succinct mapping between uri's and objects,
     that represents objects in a hierarchical relationship similar to the
-    devices uri path hierarchy.
+    device's uri path hierarchy.
     """
     def __init__(self, container):
         """Call this with containing_object_instance.FOO

--- a/f5/bigip/shared/__init__.py
+++ b/f5/bigip/shared/__init__.py
@@ -1,3 +1,5 @@
+# coding=utf-8
+#
 # Copyright 2016 F5 Networks Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -13,7 +15,7 @@
 # limitations under the License.
 #
 
-"""BIG-IP Shared (shared) module
+"""BIG-IP® Shared (shared) module
 
 REST URI
     ``http://localhost/mgmt/tm/shared/``

--- a/f5/bigip/shared/bigip_failover_state.py
+++ b/f5/bigip/shared/bigip_failover_state.py
@@ -1,3 +1,5 @@
+# coding=utf-8
+#
 # Copyright 2016 F5 Networks Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-"""BIG-IP shared failover state module
+"""BIG-IP® shared failover state module
 
 REST URI
     ``http://localhost/mgmt/tm/shared/bigip-failover-state``
@@ -29,7 +31,7 @@ from f5.bigip.resource import Resource
 
 
 class Bigip_Failover_State(UnnamedResourceMixin, Resource):
-    """BIG-IP failover state information
+    """BIG-IP® failover state information
 
     Failover state objects only support the
     :meth:`~f5.bigip.resource.Resource.load` method because they cannot be
@@ -49,7 +51,7 @@ class Bigip_Failover_State(UnnamedResourceMixin, Resource):
         self._meta_data['uri'] = uri.replace('_', '-')
 
     def update(self, **kwargs):
-        '''Update is not supported for BIG-IP failover state.
+        '''Update is not supported for BIG-IP® failover state.
 
         :raises: UnsupportedOperation
         '''

--- a/f5/bigip/shared/licensing.py
+++ b/f5/bigip/shared/licensing.py
@@ -1,3 +1,5 @@
+# coding=utf-8
+#
 # Copyright 2016 F5 Networks Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-"""BIG-IP system failover module
+"""BIG-IP® system failover module
 
 REST URI
     ``http://localhost/mgmt/tm/shared/license``
@@ -30,7 +32,7 @@ from f5.bigip.resource import Resource
 
 
 class Licensing(PathElement):
-    """BIG-IP licensing stats and states.
+    """BIG-IP® licensing stats and states.
 
     Licensing objects themselves do not support any methods and are just
     containers for lower level objects.
@@ -55,7 +57,7 @@ class Licensing(PathElement):
 
 
 class Activation(UnnamedResourceMixin, Resource):
-    """BIG-IP license activation status
+    """BIG-IP® license activation status
 
     Activation state objects only support the
     :meth:`~f5.bigip.resource.Resource.load` method because they cannot be
@@ -85,7 +87,7 @@ class Activation(UnnamedResourceMixin, Resource):
 
 
 class Registration(UnnamedResourceMixin, Resource):
-    """BIG-IP license registration status
+    """BIG-IP® license registration status
 
     Registration state objects only support the
     :meth:`~f5.bigip.resource.Resource.load` method because they cannot be

--- a/f5/bigip/sys/__init__.py
+++ b/f5/bigip/sys/__init__.py
@@ -1,3 +1,5 @@
+# coding=utf-8
+#
 # Copyright 2015 F5 Networks Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -13,7 +15,7 @@
 # limitations under the License.
 #
 
-"""BIG-IP System (sys) module
+"""BIG-IP® System (sys) module
 
 REST URI
     ``http://localhost/mgmt/tm/sys/``

--- a/f5/bigip/sys/application.py
+++ b/f5/bigip/sys/application.py
@@ -1,3 +1,5 @@
+# coding=utf-8
+#
 # Copyright 2014-2016 F5 Networks Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -13,7 +15,7 @@
 # limitations under the License.
 #
 
-"""BIG-IP iApp (application) module
+"""BIG-IP® iApp (application) module
 
 REST URI
     ``http://localhost/mgmt/sys/application/``
@@ -33,7 +35,7 @@ from requests import HTTPError
 
 
 class Applications(Collection):
-    """BIG-IP iApp collection."""
+    """BIG-IP® iApp collection."""
     def __init__(self, sys):
         super(Applications, self).__init__(sys)
         self._meta_data['allowed_lazy_attributes'] = [
@@ -45,7 +47,7 @@ class Applications(Collection):
 
 
 class Aplscripts(Collection):
-    """BIG-IP iApp script collection."""
+    """BIG-IP® iApp script collection."""
     def __init__(self, application):
         super(Aplscripts, self).__init__(application)
         self._meta_data['allowed_lazy_attributes'] = [Aplscript]
@@ -54,7 +56,7 @@ class Aplscripts(Collection):
 
 
 class Aplscript(Resource):
-    """BIG-IP iApp script resource."""
+    """BIG-IP® iApp script resource."""
     def __init__(self, apl_script_s):
         super(Aplscript, self).__init__(apl_script_s)
         self._meta_data['required_json_kind'] =\
@@ -62,7 +64,7 @@ class Aplscript(Resource):
 
 
 class Customstats(Collection):
-    """BIG-IP iApp custom stats sub-collection."""
+    """BIG-IP® iApp custom stats sub-collection."""
     def __init__(self, application):
         super(Customstats, self).__init__(application)
         self._meta_data['allowed_lazy_attributes'] = [Customstat]
@@ -71,7 +73,7 @@ class Customstats(Collection):
 
 
 class Customstat(Resource):
-    """BIG-IP iApp custom stats sub-collection resource."""
+    """BIG-IP® iApp custom stats sub-collection resource."""
     def __init__(self, custom_stat_s):
         super(Customstat, self).__init__(custom_stat_s)
         self._meta_data['required_json_kind'] =\
@@ -79,7 +81,7 @@ class Customstat(Resource):
 
 
 class Services(Collection):
-    """BIG-IP iApp service sub-collection."""
+    """BIG-IP® iApp service sub-collection."""
     def __init__(self, application):
         super(Services, self).__init__(application)
         self._meta_data['allowed_lazy_attributes'] = [Service]
@@ -88,7 +90,7 @@ class Services(Collection):
 
 
 class Service(Resource):
-    """BIG-IP iApp service sub-collection resource"""
+    """BIG-IP® iApp service sub-collection resource"""
     def __init__(self, service_s):
         super(Service, self).__init__(service_s)
         self._meta_data['required_creation_parameters'].update(
@@ -116,7 +118,7 @@ class Service(Resource):
                     "retrieved" not in ex.response.text:
                 raise
 
-            # BIG-IP will create in Common partition if none is given.
+            # BIG-IP® will create in Common partition if none is given.
             # In order to create the uri properly in this class's load,
             # drop in Common as the partition in kwargs.
             if 'partition' not in kwargs:
@@ -153,7 +155,7 @@ class Service(Resource):
         return self._update(**kwargs)
 
     def _load(self, **kwargs):
-        '''Load python Service object with response JSON from BIG-IP.
+        '''Load python Service object with response JSON from BIG-IP®.
 
         :params kwargs: keyword arguments for talking to the device
         :returns: populated Service object
@@ -207,7 +209,7 @@ class Service(Resource):
         NOTE: If kwargs has a 'requests_params' key the corresponding dict will
         be passed to the underlying requests.session.get method where it will
         be handled according to that API. THIS IS HOW TO PASS QUERY-ARGS!
-        :returns: bool -- The objects exists on BIG-IP or not.
+        :returns: bool -- The objects exists on BIG-IP® or not.
         :raises: :exc:`requests.HTTPError`, Any HTTP error that was not status
                  code 404.
         '''
@@ -233,7 +235,7 @@ class Service(Resource):
 
 
 class Templates(Collection):
-    """BIG-IP iApp template sub-collection"""
+    """BIG-IP® iApp template sub-collection"""
     def __init__(self, application):
         super(Templates, self).__init__(application)
         self._meta_data['allowed_lazy_attributes'] = [Template]
@@ -242,7 +244,7 @@ class Templates(Collection):
 
 
 class Template(Resource):
-    """BIG-IP iApp template sub-collection resource"""
+    """BIG-IP® iApp template sub-collection resource"""
     def __init__(self, template_s):
         super(Template, self).__init__(template_s)
         self._meta_data['required_creation_parameters'].update(('partition',))

--- a/f5/bigip/sys/db.py
+++ b/f5/bigip/sys/db.py
@@ -1,3 +1,5 @@
+# coding=utf-8
+#
 # Copyright 2016 F5 Networks Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -13,7 +15,7 @@
 # limitations under the License.
 #
 
-"""BIG-IP db module
+"""BIG-IP® db module
 
 REST URI
     ``http://localhost/mgmt/sys/db/``
@@ -31,7 +33,7 @@ from f5.bigip.resource import UnsupportedOperation
 
 
 class Dbs(Collection):
-    """BIG-IP db collection"""
+    """BIG-IP® db collection"""
     def __init__(self, sys):
         super(Dbs, self).__init__(sys)
         self._meta_data['allowed_lazy_attributes'] = [Db]
@@ -40,7 +42,7 @@ class Dbs(Collection):
 
 
 class Db(Resource):
-    """BIG-IP db resource
+    """BIG-IP® db resource
 
     .. note::
         db objects are read-only.

--- a/f5/bigip/sys/failover.py
+++ b/f5/bigip/sys/failover.py
@@ -1,3 +1,5 @@
+# coding=utf-8
+#
 # Copyright 2016 F5 Networks Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-"""BIG-IP system failover module
+"""BIG-IP® system failover module
 
 REST URI
     ``http://localhost/mgmt/tm/sys/failover``
@@ -29,7 +31,7 @@ from f5.bigip.resource import Resource
 
 
 class Failover(UnnamedResourceMixin, Resource):
-    '''BIG-IP Failover stats and state change.
+    '''BIG-IP® Failover stats and state change.
 
     The failover object only supports load, update, and refresh because it is
      an unnamed resource.

--- a/f5/bigip/sys/folder.py
+++ b/f5/bigip/sys/folder.py
@@ -1,3 +1,5 @@
+# coding=utf-8
+#
 # Copyright 2016 F5 Networks Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -13,7 +15,7 @@
 # limitations under the License.
 #
 
-"""BIG-IP system folder (partition) module
+"""BIG-IP® system folder (partition) module
 
 REST URI
     ``http://localhost/mgmt/tm/sys/folder``
@@ -31,7 +33,7 @@ from requests.exceptions import HTTPError
 
 
 class Folders(Collection):
-    """BIG-IP system folder collection.
+    """BIG-IP® system folder collection.
 
     These are what we refer to as ``partition`` in the SDK.
     """
@@ -44,7 +46,7 @@ class Folders(Collection):
 
 class Folder(Resource):
     def __init__(self, folder_s):
-        '''BIG-IP system folder resource.
+        '''BIG-IP® system folder resource.
 
         Folder objects are the same as the partition so we need to deal with
         them slightly differently than other Resources.  For example when
@@ -115,7 +117,7 @@ class Folder(Resource):
         NOTE: If kwargs has a 'requests_params' key the corresponding dict will
         be passed to the underlying requests.session.get method where it will
         be handled according to that API. THIS IS HOW TO PASS QUERY-ARGS!
-        :returns: bool -- The objects exists on BIG-IP or not.
+        :returns: bool -- The objects exists on BIG-IP® or not.
         :raises: :exc:`requests.HTTPError`, Any HTTP error that was not status
             code 404.
         """

--- a/f5/bigip/sys/global_settings.py
+++ b/f5/bigip/sys/global_settings.py
@@ -1,3 +1,5 @@
+# coding=utf-8
+#
 # Copyright 2016 F5 Networks Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -13,7 +15,7 @@
 # limitations under the License.
 #
 
-"""BIG-IP system global-settings module
+"""BIG-IP® system global-settings module
 
 REST URI
     ``http://localhost/mgmt/tm/sys/global-settings``
@@ -30,7 +32,7 @@ from f5.bigip.resource import Resource
 
 
 class Global_Settings(UnnamedResourceMixin, Resource):
-    """BIG-IP system global-settings resource
+    """BIG-IP® system global-settings resource
 
     The global_settings object only supports load and update because it is an
     unnamed resource.

--- a/f5/bigip/sys/ntp.py
+++ b/f5/bigip/sys/ntp.py
@@ -1,3 +1,5 @@
+# coding=utf-8
+#
 # Copyright 2016 F5 Networks Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -13,7 +15,7 @@
 #   limitations under the License.
 #
 
-"""BIG-IP system ntp module
+"""BIG-IP® system ntp module
 
 REST URI
     ``http://localhost/mgmt/tm/sys/ntp``
@@ -31,7 +33,7 @@ from f5.bigip.resource import Resource
 
 
 class Ntp(UnnamedResourceMixin, Resource):
-    """BIG-IP system NTP unnamed resource
+    """BIG-IP® system NTP unnamed resource
 
         .. note::
 
@@ -51,7 +53,7 @@ class Ntp(UnnamedResourceMixin, Resource):
 
 
 class Restricts(Collection):
-    """BIG-IP system NTP restrict sub-collection"""
+    """BIG-IP® system NTP restrict sub-collection"""
     def __init__(self, ntp):
         super(Restricts, self).__init__(ntp)
         self._meta_data['allowed_lazy_attributes'] = [Restrict]
@@ -62,7 +64,7 @@ class Restricts(Collection):
 
 
 class Restrict(Resource):
-    """BIG-IP system NTP restrict sub-collection resource"""
+    """BIG-IP® system NTP restrict sub-collection resource"""
     def __init__(self, restricts):
         super(Restrict, self).__init__(restricts)
         self._meta_data['required_json_kind'] =\

--- a/f5/bigip/sys/performance.py
+++ b/f5/bigip/sys/performance.py
@@ -1,3 +1,5 @@
+# coding=utf-8
+#
 # Copyright 2016 F5 Networks Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -13,7 +15,7 @@
 # limitations under the License.
 #
 
-"""BIG-IP system peformance stats module.
+"""BIG-IP® system peformance stats module.
 
 REST URI
     ``http://localhost/mgmt/tm/sys/performance``
@@ -32,7 +34,7 @@ from f5.bigip.resource import UnsupportedOperation
 
 
 class Performance(Collection):
-    """BIG-IP system performace stats collection"""
+    """BIG-IP® system performace stats collection"""
     def __init__(self, sys):
         super(Performance, self).__init__(sys)
         self._meta_data['allowed_lazy_attributes'] = [All_Stats]
@@ -40,7 +42,7 @@ class Performance(Collection):
             self._meta_data['container']._meta_data['uri'] + "performance/"
 
     def get_collection(self):
-        '''Performance collections are not proper BIG-IP collection objects.
+        '''Performance collections are not proper BIG-IP® collection objects.
 
         :raises: :exc:`~f5.BIG-IP.resource.UnsupportedOperation`
         '''
@@ -51,7 +53,7 @@ class Performance(Collection):
 
 
 class All_Stats(UnnamedResourceMixin, Resource):
-    """BIG-IP system performace stats unnamed resource"""
+    """BIG-IP® system performace stats unnamed resource"""
     def __init__(self, performance):
         super(All_Stats, self).__init__(performance)
         self._meta_data['required_load_parameters'] = set()

--- a/f5/bigip/test/big_ip_mock.py
+++ b/f5/bigip/test/big_ip_mock.py
@@ -17,9 +17,9 @@ import mock
 
 
 class BigIPMock(object):
-    """Mock BIG-IP object
+    """Mock BIG-IP® object
 
-    Mocks a BIG-IP object by substituting a mock icr_session object which
+    Mocks a BIG-IP® object by substituting a mock icr_session object which
     returns a user created mock response object. To use, create a mock response
     object which will get returned by any icr_session HTTP method, then create
     an interface object, passing in this BIG-IPMock object.
@@ -34,7 +34,7 @@ class BigIPMock(object):
           200, BIG-IPMock.read_json_file("f5/BIG-IP/interfaces/test/pool.json")
         )
 
-        # Create BIG-IP object, passing in mocked response object
+        # Create BIG-IP® object, passing in mocked response object
         big_ip = BIG-IPMock(response)
 
         # Create interface object


### PR DESCRIPTION
@swormke @b225ccc 
Fixes: #310, #300 
#### What's this change do?

Address #310 (change local traffic monitor to local traffic manager)
add trademarks to all references to F5, F5 Networks, BIG-IP, iControl, and any other products, that are public-facing.
#### Where should the reviewer start?

It's probably easiest to clone my fork and do a search for F5, etc., with a space or period after, to see if there are any instances I missed adding the trademarks to.
#### Any background context?
