### PR TITLE
Change test class names to silence warnings

### DIFF
--- a/f5/bigip/test/test_mixins.py
+++ b/f5/bigip/test/test_mixins.py
@@ -93,14 +93,14 @@ def test_ToDictMixinAttribute_Nested():
     assert json.dumps(mtc_as_dict) == '{"x": {"y": {"a": 3}}}'
 
 
-class TestClass(object):
+class DictableClass(object):
     def __init__(self):
         self.test_attribute = 42
 
 
 def test_TestClass_Basic():
     TDMAttrObj = ToDictMixinAttribute()
-    TDMAttrObj.y = TestClass()
+    TDMAttrObj.y = DictableClass()
     mtc_as_dict = TDMAttrObj.to_dict()
     assert json.dumps(mtc_as_dict) == '{"y": {"test_attribute": 42}}'
 

--- a/f5/bigip/test/test_resource.py
+++ b/f5/bigip/test/test_resource.py
@@ -392,13 +392,13 @@ def test_ResourceBase():
         "Only Resources support 'delete'."
 
 
-class Test_s(Collection):
+class Under_s(Collection):
     def __init__(self, container):
-        super(Test_s, self).__init__(container)
+        super(Under_s, self).__init__(container)
 
 
 def test_collection_s():
     MC = mock.MagicMock()
     MC._meta_data = {'bigip': 'bigip', 'uri': 'BASEURI/'}
-    tc_s = Test_s(MC)
-    assert tc_s._meta_data['uri'] == 'BASEURI/test/'
+    tc_s = Under_s(MC)
+    assert tc_s._meta_data['uri'] == 'BASEURI/under/'


### PR DESCRIPTION
Issues:
Fixes #321

Problem: Pytest treats class named "{T|t}est" specially.

Analysis: Renamed classes to not start with "Test"

Tests: Warnings are silenced in extant tests.
