### PR TITLE
Fix docs and add slack channel URL

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,13 +1,17 @@
 f5-common-python
 ================
 
-|Build Status| |Docs Build Status|
+|Build Status| |Docs Build Status| |slack badge|
 
 Introduction
 ------------
 This project implements an SDK for the iControl REST interface for BIG-IP®.
 Users of this library can create, edit, update, and delete configuration objects
 on a BIG-IP®.
+
+Documentation
+-------------
+Documentation is hosted on `Read the Docs <https://f5-sdk.readthedocs.org>`_
 
 Submodules
 ~~~~~~~~~~
@@ -62,9 +66,6 @@ Usage
         pool_b.delete()
 
 
-Documentation
--------------
-Documentation is hosted on `Read the Docs <https://f5-sdk.readthedocs.org>`_
 
 Filing Issues
 -------------
@@ -112,11 +113,6 @@ the Unit Test section).
 
     $ flake8 ./
 
-
-Contact
--------
-f5_common_python@f5.com
-
 Copyright
 ---------
 Copyright 2014-2016 F5 Networks Inc.
@@ -154,3 +150,8 @@ project.
 .. |Docs Build Status| image:: http://readthedocs.org/projects/f5-sdk/badge/?version=latest
     :target: http://f5-sdk.readthedocs.org/en/latest/?badge=latest
     :alt: Documentation Status
+
+.. |slack badge| image:: https://f5-openstack-slack.herokuapp.com/badge.svg
+    :target: https://f5-openstack-slack.herokuapp.com/
+    :alt: Slack
+

--- a/docs/apidoc/f5.bigip.ltm.rst
+++ b/docs/apidoc/f5.bigip.ltm.rst
@@ -263,7 +263,7 @@ virtual
     :members:
 
     Virtual Collections and Resources
-    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     .. py:currentmodule:: f5.bigip.ltm.virtual
 
     .. autosummary::

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -2,12 +2,17 @@ F5 Python SDK Documentation
 ===========================
 |Build Status| |Docs Build Status|
 
+.. raw:: html
+
+    <script async defer src="https://f5-openstack-slack.herokuapp.com/slackin.js"></script>
+
+
 Introduction
 ------------
-This project implements an object model based SDK for the F5 Networks BIG-IP®
-iControl REST interface. Users of this library can create, edit, update, and
-delete configuration objects on a BIG-IP® device.  For more information on the
-basic principals that the SDK uses see the :doc:`userguide/index`.
+This project implements an object model based SDK for the F5 Networks® BIG-IP®
+iControl® REST interface. Users of this library can create, edit, update, and
+delete configuration objects on a BIG-IP®. For more information on the
+basic principals that the SDK uses, see the :doc:`userguide/index`.
 
 Quick Start
 -----------
@@ -18,6 +23,7 @@ Installation
     $> pip install f5-sdk
 
 .. note::
+
     If you are using a pre-release version you must use the ``--pre``
     option with the pip command.
 
@@ -61,11 +67,6 @@ Detailed Documentation
    devguide
    F5 SDK API Docs <apidoc/modules>
 
-
-Contact
--------
-f5_common_python@f5.com
-
 Copyright
 ---------
 Copyright 2014-2016 F5 Networks Inc.
@@ -101,3 +102,4 @@ project.
 .. |Docs Build Status| image:: http://readthedocs.org/projects/f5-sdk/badge/?version=latest
     :target: http://f5-sdk.readthedocs.org/en/latest/?badge=latest
     :alt: Documentation Status
+

--- a/docs/userguide/SDK_plural_note.rst
+++ b/docs/userguide/SDK_plural_note.rst
@@ -1,6 +1,6 @@
 .. important::
 
-    When using the SDK, you'll notice that :ref:`collection <collection_section>` objects are referenced using the plural version of the |Resource| objects they contain. When the |Resource| object's type is plural (ends in an ``s``), you need to add ``_s`` to the name when referring to the object.
+    When using the SDK, you'll notice that :ref:`collection <collection_section>` objects are referenced using the plural version of the |Resource| objects they contain. When the |Resource| object's type is plural (ends in an ``s``), you need to add ``_s`` to the name when referring to the collection.
 
     This ``_s`` rule applies to all object collections where the object in the collection already ends in ``s``.
 

--- a/docs/userguide/basics.rst
+++ b/docs/userguide/basics.rst
@@ -74,7 +74,7 @@ Almost all iControl REST API entries contain a parameter named ``kind``. This pa
     +---------------------+--------------------------+-------------------------------------------------+
 
 
-.. methods_section:
+.. _methods_section:
 
 Methods
 -------

--- a/docs/userguide/endpoints/subcollection.rst
+++ b/docs/userguide/endpoints/subcollection.rst
@@ -5,9 +5,7 @@ Subcollection
 
 ``kind``: ``collectionstate``
 
-A subcollection is a |Collection| that's attached to a higher-level |Resource| object. Subcollections are almost exactly the same as collections; the exception is that they can only be accessed via the resource they're attached to (the 'parent' resource). A subcollection can be identified by the value ``isSubcollection: true``, followed by an ``items`` attribute listing the subcollection's resources. Just as with
-collections, you can use :meth:`~f5.bigip.resource.Collection
-    .get_collection` to get a list of the resources in the subcollection.
+A subcollection is a |Collection| that's attached to a higher-level |Resource| object. Subcollections are almost exactly the same as collections; the exception is that they can only be accessed via the resource they're attached to (the 'parent' resource). A subcollection can be identified by the value ``isSubcollection: true``, followed by an ``items`` attribute listing the subcollection's resources. Just as with collections, you can use :meth:`~f5.bigip.resource.Collection.get_collection` to get a list of the resources in the subcollection.
 
 .. _subcollection_example:
 

--- a/docs/userguide/endpoints/subcollection_resource.rst
+++ b/docs/userguide/endpoints/subcollection_resource.rst
@@ -14,7 +14,7 @@ A subcollection resource is essentially the same as a :ref:`resource <resource_s
    >>> from f5.bigip import BigIP
    >>> bigip = BigIP('192.168.1.1', 'myuser', 'mypass')
    >>> pool = bigip.ltm.pools.pool.load(partition='Common', name='p1')
-   >>> member = pool.members_s.member.load(partition='Common', name='n1:80')
+   >>> member = pool.members_s.members.load(partition='Common', name='n1:80')
 
    The JSON below shows a :obj:`f5.bigip.ltm.pool.members_s.members` object.
 

--- a/docs/userguide/further_reading.rst
+++ b/docs/userguide/further_reading.rst
@@ -5,8 +5,9 @@ Further Reading
 
 * `F5 iControl REST DevCentral Site <https://devcentral.f5.com/wiki/iControlREST.HomePage.ashx>`_
 
-* `F5 iControl REST API Reference <https://devcentral.f5.com/d/icontrol-rest-api-reference-version-120?download=true>`_
+* `F5 iControl REST API Reference (PDF) <https://devcentral.f5.com/d/icontrol-rest-api-reference-version-120?download=true>`_
 
-* `F5 iControl REST API Guide <https://devcentral.f5.com/d/the-user-guide-for-the-icontrol-rest-interface-in-big-ip-version-1160?download=true>`_
+* `F5 iControl REST API Guide (PDF) <https://devcentral.f5
+.com/d/the-user-guide-for-the-icontrol-rest-interface-in-big-ip-version-1160?download=true>`_
 
 

--- a/docs/userguide/index.rst
+++ b/docs/userguide/index.rst
@@ -2,9 +2,9 @@ User Guide
 ==========
 To get the most out of using our SDK, it's useful to understand the basic
 concepts and principals we used when we designed it. It is also important
-that you are familiar with the F5 BIG-IP® and, at a minimum, how to configure BIG-IP®
-using the configuration utility (the GUI). More useful still would be if you are already familiar with the
-`iControl REST API <https://devcentral.f5.com/wiki/iControlREST.HomePage.ashx>`_.
+that you are familiar with the F5® BIG-IP® and, at a minimum, how to configure BIG-IP®
+using the configuration utility (the GUI). More useful still would be if you are already familiar with the `iControl® REST API <https://devcentral.f5.com/wiki/iControlREST
+.HomePage.ashx>`_.
 
 .. toctree::
 

--- a/docs/userguide/ltm_pools_members_code_example.rst
+++ b/docs/userguide/ltm_pools_members_code_example.rst
@@ -19,7 +19,7 @@ Coding Example
         pool_obj = bigip.ltm.pools.pool
         pool_1 = pool_obj.load(partition='Common', name='mypool')
 
-        # We can also create the object and load the pool at the same time
+        # We can also skip creating the object and load the pool directly
         pool_2 = bigip.ltm.pools.pool.load(partition='Common', name='mypool')
 
         # Print the object
@@ -68,7 +68,7 @@ Coding Example
 
         # Make sure it is gone
         if pool_1.members_s.members.exists(partition='Common', name='m1:80'):
-        raise Exception("Object should have been deleted")
+            raise Exception("Object should have been deleted")
 
         # We are done with this pool so remove it from BIG-IP®
         pool_1.delete()

--- a/docs/userguide/object_path.rst
+++ b/docs/userguide/object_path.rst
@@ -11,7 +11,7 @@ The object classes used in the SDK directly correspond to the REST endpoints you
 
 4. The characters ``.`` and ``-`` are always replaced with ``_`` in the SDK.
 
-Because the REST API endpoints have a hierarchical structure, you need to load/create the highest-level objects before you can load lower-level ones. The example below shows how the pieces of the URI correspond to the REST endpoints/SDK classes. The first part of the URI is the IP address of your BIG-IP® device.
+Because the REST API endpoints have a hierarchical structure, you need to load/create the highest-level objects before you can load lower-level ones. The example below shows how the pieces of the URI correspond to the REST endpoints/SDK classes. The first part of the URI is the IP address of your BIG-IP®.
 
 .. include:: uri_code_breakdown.rst
 
@@ -26,18 +26,18 @@ Because the REST API endpoints have a hierarchical structure, you need to load/c
     =============   ==================================================
 
 
-In the sections below, we'll walk through the Python object paths using LTM pools and pool members as examples. You can also skip straight to the |Coding Example|.
+In the sections below, we'll walk through the Python object paths using LTM® pools and pool members as examples. You can also skip straight to the |Coding Example|.
 
 .. _oc_section:
 
 |Organizing Collection Section|
 -------------------------------
-The ``mgmt/tm`` and ``ltm`` organizing collections define what area of the BIG-IP® you're going to work with. The ``mgmt/tm`` organizing collection corresponds to the management plane of your BIG-IP® device (TMOS). Loading ``ltm`` indicates that we're going to work with the BIG-IP®'s :guilabel:`Local Traffic` module.
+The ``mgmt/tm`` and ``ltm`` organizing collections define what area of the BIG-IP® you're going to work with. The ``mgmt/tm`` organizing collection corresponds to the management plane of your BIG-IP® device (TMOS). Loading ``ltm`` indicates that we're going to work with the BIG-IP®'s :guilabel:`Local Traffic Manager®` module.
 
 .. include:: endpoints/endpoint_table_tm.rst
 .. include:: endpoints/endpoint_table_ltm.rst
 
-.. topic:: Example: Connect to the BIG-IP® and load the LTM module
+.. topic:: Example: Connect to the BIG-IP® and load the LTM® module
 
     .. code-block:: python
 
@@ -57,11 +57,11 @@ The ``mgmt/tm`` and ``ltm`` organizing collections define what area of the BIG-I
 |Collection Section|
 --------------------
 
-Now that the higher-level organizing collections are loaded (in other words, we're signed in to the BIG-IP® and accessed the LTM module), we can load the ``pool`` collection.
+Now that the higher-level organizing collections are loaded (in other words, we signed in to the BIG-IP® and accessed the LTM® module), we can load the ``pool`` collection.
 
 .. include:: endpoints/endpoint_table_ltm_pool.rst
 
-.. topic:: Example: Load the pool collection
+.. topic:: Example: Load the pools collection
 
     .. code-block:: python
 
@@ -90,7 +90,7 @@ In the SDK, we refer to a single instance of a configuration object as a resourc
 
 .. include:: endpoints/endpoint_table_ltm_pool_pools.rst
 
-.. topic:: Example: Load a pools collection
+.. topic:: Example: Load a pool resource
 
     .. code-block:: python
 
@@ -102,8 +102,7 @@ In the example above, we instantiated the class :class:`f5.bigip.ltm.pool.Pool` 
 
 .. tip::
 
-    You can always see the representation of an object using the :meth:`~f5
-    .bigip.ltm.pool.Pools.raw` method.
+    You can always see the representation of an object using the :meth:`~f5.bigip.ltm.pool.Pools.raw` method.
 
     .. code-block:: python
 


### PR DESCRIPTION
@zancas @swormke 

Fixes #323 #261 
#### What's this change do?
- addresses the issues reported in #261 
- replaces the contact email address with the slack channel invitation URL
- moved the documentation section higher up in the README to direct users to RTD
- removed 'device' from references to BIG-IP (device is used in F5 docs to refer to hardware).
#### Where should the reviewer start?

Changes are minimal and can be reviewed below.
#### Any background context?
