### PR TITLE
Add hostname as a BigIP property #326

### DIFF
--- a/f5/bigip/__init__.py
+++ b/f5/bigip/__init__.py
@@ -46,3 +46,7 @@ class BigIP(OrganizingCollection):
                            'device_name': None,
                            'local_ip': None,
                            'bigip': self}
+
+    @property
+    def hostname(self):
+        return self._meta_data['hostname']

--- a/f5/bigip/test/test___init__.py
+++ b/f5/bigip/test/test___init__.py
@@ -41,3 +41,4 @@ def test___get__attr(FakeBigIP):
     assert isinstance(bigip_dot_sys, Sys)
     with pytest.raises(AttributeError):
         FakeBigIP.this_is_not_a_real_attribute
+    assert FakeBigIP.hostname == 'FakeHostName'


### PR DESCRIPTION
Issues:
Fixes #326

Problem:
The BigIP object needs to have a property to retrieve the hostname
of the device. We store this in _meta_data['hostname'] but that
implies it is a private attributed of the object. We need a more
public way to access it.

Analysis:
- Created a `@property` decorated method to return the hostname
  from `self._meta_data[]`

Tests:
- New unit test
- Flake8
