### PR TITLE
FDB needs to support a 11.5.0 api version only #314

### DIFF
--- a/f5/bigip/__init__.py
+++ b/f5/bigip/__init__.py
@@ -34,19 +34,27 @@ class BigIP(OrganizingCollection):
         timeout = kwargs.pop('timeout', 30)
         allowed_lazy_attrs = kwargs.pop('allowed_lazy_attributes',
                                         allowed_lazy_attributes)
+        icontrol_version = kwargs.pop('icontrol_version', '')
         if kwargs:
             raise TypeError('Unexpected **kwargs: %r' % kwargs)
         # _meta_data variable values
         iCRS = iControlRESTSession(username, password, timeout=timeout)
         # define _meta_data
-        self._meta_data = {'allowed_lazy_attributes': allowed_lazy_attrs,
-                           'hostname': hostname,
-                           'uri': 'https://%s/mgmt/tm/' % hostname,
-                           'icr_session': iCRS,
-                           'device_name': None,
-                           'local_ip': None,
-                           'bigip': self}
+        self._meta_data = {
+            'allowed_lazy_attributes': allowed_lazy_attrs,
+            'hostname': hostname,
+            'uri': 'https://%s/mgmt/tm/' % hostname,
+            'icr_session': iCRS,
+            'device_name': None,
+            'local_ip': None,
+            'bigip': self,
+            'icontrol_version': icontrol_version,
+        }
 
     @property
     def hostname(self):
         return self._meta_data['hostname']
+
+    @property
+    def icontrol_version(self):
+        return self._meta_data['icontrol_version']

--- a/f5/bigip/net/__init__.py
+++ b/f5/bigip/net/__init__.py
@@ -28,6 +28,7 @@ REST Kind
 """
 
 from f5.bigip.net.arp import Arps
+from f5.bigip.net.fdb import Fdbs
 from f5.bigip.net.interface import Interfaces
 from f5.bigip.net.route import Routes
 from f5.bigip.net.route_domain import Route_Domains
@@ -42,6 +43,7 @@ class Net(OrganizingCollection):
         super(Net, self).__init__(bigip)
         self._meta_data['allowed_lazy_attributes'] = [
             Arps,
+            Fdbs,
             Interfaces,
             Routes,
             Route_Domains,

--- a/f5/bigip/net/fdb.py
+++ b/f5/bigip/net/fdb.py
@@ -18,7 +18,7 @@
 """Directory: net module: fdb.
 
 REST URI
-    ``https://localhost/mgmt/tm/net/fdb?ver=11.6.0``
+    ``https://localhost/mgmt/tm/net/fdb``
 
 GUI Path
     ``XXX``
@@ -41,6 +41,7 @@ class Fdbs(Collection):
         # self._meta_data['attribute_registry'] =\
         #    {u'tm:net:fdb:fdbstate': Fdb}
         self._meta_data['template_generated'] = True
+        self._meta_data['icontrol_version'] = '11.5.0'
 
 
 class Tunnel(Resource):
@@ -51,8 +52,10 @@ class Tunnel(Resource):
         self._meta_data['template_generated'] = True
         self._meta_data['required_json_kind'] =\
             u"tm:net:fdb:tunnel:tunnelstate"
-        self._meta_data['attribute_registry'] =\
-            {}
+        self._meta_data['attribute_registry'] = {}
+        # Setting this here to be explicit, even though it is set via
+        # the super call from its containing object.
+        self._meta_data['icontrol_version'] = '11.5.0'
 
 
 class Tunnels(Collection):
@@ -64,6 +67,9 @@ class Tunnels(Collection):
         self._meta_data['attribute_registry'] =\
             {u'tm:net:fdb:tunnel:tunnelstate': Tunnel}
         self._meta_data['template_generated'] = True
+        # Setting this here to be explicit, even though it is set via
+        # the super call from its containing object.
+        self._meta_data['icontrol_version'] = '11.5.0'
 
 
 class Vlans(Collection):
@@ -75,3 +81,6 @@ class Vlans(Collection):
         # self._meta_data['attribute_registry'] =\
         #     {u'tm:net:fdb:vlan:vlanstate': Vlan}
         self._meta_data['template_generated'] = True
+        # Setting this here to be explicit, even though it is set via
+        # the super call from its containing.
+        self._meta_data['icontrol_version'] = '11.5.0'

--- a/f5/bigip/resource.py
+++ b/f5/bigip/resource.py
@@ -154,8 +154,11 @@ class PathElement(LazyAttributeMixin):
     the other objects do.
     """
     def __init__(self, container):
-        self._meta_data = {'container': container,
-                           'bigip': container._meta_data['bigip']}
+        self._meta_data = {
+            'container': container,
+            'bigip': container._meta_data['bigip'],
+            'icontrol_version': container._meta_data['icontrol_version']
+        }
         base_uri = self.__class__.__name__.lower() + '/'
         self._meta_data['uri'] =\
             self._meta_data['container']._meta_data['uri'] + base_uri
@@ -274,12 +277,27 @@ class ResourceBase(PathElement, ToDictMixin):
         return rdict
 
     def _handle_requests_params(self, kwargs):
+        """Validate parameters that will be passed to the requests verbs.
+
+        This method validates that there is no conflict in the names of the
+        requests_params passed to the function an the other kwargs.  It also
+        ensures that the required request parameters for the object are
+        added to the request params that are passed into the verbs.  An
+        example of the latter is ensuring that a certain version of the API
+        is always called to add 'ver=11.6.0' to the url.
+        """
         requests_params = kwargs.pop('requests_params', {})
         for param in requests_params:
             if param in kwargs:
                 error_message = 'Requests Parameter %r collides with a load'\
                     ' parameter of the same name.' % param
                 raise RequestParamKwargCollision(error_message)
+
+        # If we have an icontrol version we need to add 'ver' to params
+        if self._meta_data['icontrol_version']:
+            params = requests_params.pop('params', {})
+            params.update({'ver': self._meta_data['icontrol_version']})
+            requests_params.update({'params': params})
         return requests_params
 
     def _refresh(self, **kwargs):

--- a/f5/bigip/sys/test/test_sys_application.py
+++ b/f5/bigip/sys/test/test_sys_application.py
@@ -112,9 +112,11 @@ def MakeFakeContainer(FakeService, mock_json, mock_bigip):
     mock_bigip._meta_data = {
         'hostname': 'testhost',
         'icr_session': mock_session,
-        'uri': ''
+        'uri': '',
+        'icontrol_version': '',
     }
     FakeService._meta_data['bigip'] = mock_bigip
+    FakeService._meta_data['icontrol_version'] = ''
     return FakeService
 
 
@@ -128,12 +130,14 @@ def MakeFakeContainerRaise(FakeService, mock_json, side_effect, mock_bigip):
     mock_bigip._meta_data = {
         'hostname': 'testhost',
         'icr_session': mock_session,
-        'uri': ''
+        'uri': '',
+        'icontrol_version': '',
     }
     FakeService._meta_data['bigip'] = mock_bigip
     mock_base_uri = mock.MagicMock()
     mock_base_uri._meta_data = {'uri': 'base_uri'}
     FakeService._meta_data['container'] = mock_base_uri
+    FakeService._meta_data['icontrol_version'] = ''
     return FakeService
 
 


### PR DESCRIPTION
@zancas @jlongstaf @richbrowne 

Issues:
Fixes #314

Problem:
The fdb API changed in v12.0, we want to make sure that this
call only calls API less than v12.0.

Analysis:
- Added fdb to the lazy attributes of net
- Added version support the the base bigip, set to '' by default
- Resources use their container's version

Test:
- Added unit tests
- Ran the functional tests
- Ran the unit tests
- Ran the flake8 tests
