### PR TITLE
Object is missing the allowed_lazy_attributes metadata #337

### DIFF
--- a/f5/bigip/net/fdb.py
+++ b/f5/bigip/net/fdb.py
@@ -37,9 +37,7 @@ class Fdbs(Collection):
     def __init__(self, net):
         '''Auto generated constructor.'''
         super(Fdbs, self).__init__(net)
-        # self._meta_data['allowed_lazy_attributes'] = [Fdb]
-        # self._meta_data['attribute_registry'] =\
-        #    {u'tm:net:fdb:fdbstate': Fdb}
+        self._meta_data['allowed_lazy_attributes'] = [Tunnels]
         self._meta_data['template_generated'] = True
         self._meta_data['icontrol_version'] = '11.5.0'
 


### PR DESCRIPTION
@jlongstaf @zancas 
Issues:
Fixes #337

Problem:
Calling `bigip.net.fdbs.tunnels.tunnel` raises an error because
the allowed lazy attributes are not set in the object.

Analysis:
- Added Tunnels as the allowed lazy attribute for Fdbs

Tests:
