### PR TITLE
Add support for saving config #342

### DIFF
--- a/f5/bigip/sys/__init__.py
+++ b/f5/bigip/sys/__init__.py
@@ -29,6 +29,7 @@ REST Kind
 
 from f5.bigip.resource import OrganizingCollection
 from f5.bigip.sys.application import Applications
+from f5.bigip.sys.config import Config
 from f5.bigip.sys.db import Dbs
 from f5.bigip.sys.failover import Failover
 from f5.bigip.sys.folder import Folders
@@ -41,6 +42,7 @@ class Sys(OrganizingCollection):
     def __init__(self, bigip):
         super(Sys, self).__init__(bigip)
         self._meta_data['allowed_lazy_attributes'] = [
+            Config,
             Folders,
             Applications,
             Performance,

--- a/f5/bigip/sys/config.py
+++ b/f5/bigip/sys/config.py
@@ -1,0 +1,57 @@
+# coding=utf-8
+#
+# Copyright 2016 F5 Networks Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+"""BIG-IP® system config module
+
+REST URI
+    ``http://localhost/mgmt/tm/sys/config``
+
+GUI Path
+    N/A
+
+REST Kind
+    ``tm:sys:config:*``
+"""
+
+from f5.bigip.mixins import UnnamedResourceMixin
+from f5.bigip.resource import Resource
+
+
+class Config(UnnamedResourceMixin, Resource):
+    def __init__(self, sys):
+        super(Config, self).__init__(sys)
+        endpoint = self.__class__.__name__.lower()
+        self._meta_data['allowed_lazy_attributes'] = []
+        self._meta_data['attribute_registry'] = {}
+        self._meta_data['uri'] =\
+            self._meta_data['container']._meta_data['uri'] + endpoint + '/'
+
+    def update(self, **kwargs):
+        '''Update is not supported for Config
+
+        :raises: UnsupportedOperation
+        '''
+        raise self.UnsupportedMethod(
+            "%s does not support the update method" % self.__class__.__name__
+        )
+
+    def save(self):
+        '''Save the configuration on the device. '''
+        payload = {'command': 'save'}
+        session = self._meta_data['bigip']._meta_data['icr_session']
+        uri = self._meta_data['uri']
+        response = session.post(uri, json=payload)
+        self._local_update(response.json())

--- a/test/functional/sys/test_config.py
+++ b/test/functional/sys/test_config.py
@@ -1,0 +1,20 @@
+# Copyright 2016 F5 Networks Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+
+class TestConfig(object):
+    def test_save(self, bigip):
+        c = bigip.sys.config
+        c.save()


### PR DESCRIPTION
@jlongstaf 
Issues:
Fixes #342

Problem:
Need to save BIG-IP configuration. Using the BIG-IP REST API, POST JSON {'command': 'save'} to /sys/config.

Analysis:
- Added a new sys/Config module as an UnnamedResource
- Added a save method to the new module
- Added tests

Tests:
- Flake8
- Unit
- Functional
