### PR TITLE
WIP: Adds support for connecting to BIG-IPs on off-numbered ports

### DIFF
--- a/f5/bigip/__init__.py
+++ b/f5/bigip/__init__.py
@@ -32,6 +32,7 @@ class BigIP(OrganizingCollection):
     """An interface to a single BIG-IP"""
     def __init__(self, hostname, username, password, **kwargs):
         timeout = kwargs.pop('timeout', 30)
+        port = kwargs.pop('port', 443)
         allowed_lazy_attrs = kwargs.pop('allowed_lazy_attributes',
                                         allowed_lazy_attributes)
         icontrol_version = kwargs.pop('icontrol_version', '')
@@ -43,7 +44,7 @@ class BigIP(OrganizingCollection):
         self._meta_data = {
             'allowed_lazy_attributes': allowed_lazy_attrs,
             'hostname': hostname,
-            'uri': 'https://%s/mgmt/tm/' % hostname,
+            'uri': 'https://%s:%s/mgmt/tm/' % (hostname, port),
             'icr_session': iCRS,
             'device_name': None,
             'local_ip': None,

--- a/f5/bigip/resource.py
+++ b/f5/bigip/resource.py
@@ -532,15 +532,15 @@ class Resource(ResourceBase):
         :param selfLinkuri: the server provided selfLink (contains localhost)
         :raises: URICreationCollision
         """
-        # hostname local alias
-        hostname = self._meta_data['bigip']._meta_data['hostname']
+        # netloc local alias
+        uri = urlparse.urlsplit(self._meta_data['bigip']._meta_data['uri'])
 
         # attrs local alias
         attribute_reg = self._meta_data.get('attribute_registry', {})
         attrs = attribute_reg.values()
 
         (scheme, domain, path, qarg, frag) = urlparse.urlsplit(selfLinkuri)
-        path_uri = urlparse.urlunsplit((scheme, hostname, path, '', ''))
+        path_uri = urlparse.urlunsplit((scheme, uri.netloc, path, '', ''))
         if not path_uri.endswith('/'):
             path_uri = path_uri + '/'
         qargs = urlparse.parse_qs(qarg)

--- a/f5/bigip/sys/test/test_sys_application.py
+++ b/f5/bigip/sys/test/test_sys_application.py
@@ -113,7 +113,7 @@ def MakeFakeContainer(FakeService, mock_json, mock_bigip):
         'hostname': 'testhost',
         'icr_session': mock_session,
         'uri': '',
-        'icontrol_version': '',
+        'icontrol_version': ''
     }
     FakeService._meta_data['bigip'] = mock_bigip
     FakeService._meta_data['icontrol_version'] = ''
@@ -131,7 +131,7 @@ def MakeFakeContainerRaise(FakeService, mock_json, side_effect, mock_bigip):
         'hostname': 'testhost',
         'icr_session': mock_session,
         'uri': '',
-        'icontrol_version': '',
+        'icontrol_version': ''
     }
     FakeService._meta_data['bigip'] = mock_bigip
     mock_base_uri = mock.MagicMock()

--- a/f5/bigip/test/test___init__.py
+++ b/f5/bigip/test/test___init__.py
@@ -14,6 +14,7 @@
 
 import mock
 import pytest
+import urlparse
 
 from f5.bigip import BigIP
 
@@ -30,6 +31,13 @@ def FakeBigIP():
     return FBIP
 
 
+@pytest.fixture
+def FakeBigIPWithPort():
+    FBIP = BigIP('FakeHostName', 'admin', 'admin', port='10443')
+    FBIP.icontrol = mock.MagicMock()
+    return FBIP
+
+
 def test___get__attr(FakeBigIP):
     bigip_dot_ltm = FakeBigIP.ltm
     assert isinstance(bigip_dot_ltm, Ltm)
@@ -42,3 +50,8 @@ def test___get__attr(FakeBigIP):
     with pytest.raises(AttributeError):
         FakeBigIP.this_is_not_a_real_attribute
     assert FakeBigIP.hostname == 'FakeHostName'
+
+
+def test_non_default_port_number(FakeBigIPWithPort):
+    uri = urlparse.urlsplit(FakeBigIPWithPort._meta_data['uri'])
+    assert uri.port == 10443

--- a/f5/bigip/test/test_resource.py
+++ b/f5/bigip/test/test_resource.py
@@ -125,13 +125,16 @@ def test__activate_URI():
     r = Resource(mock.MagicMock())
     r._meta_data['allowed_lazy_attributes'] = []
     r._meta_data['attribute_registry'] = {u"tm:": u"SPAM"}
-    r._meta_data['bigip']._meta_data = {'hostname': 'TESTDOMAIN'}
-    TURI = 'https://localhost/mgmt/tm/'\
+    r._meta_data['bigip']._meta_data = {
+        'hostname': 'TESTDOMAIN',
+        'uri': 'https://TESTDOMAIN:443/mgmt/tm/'
+    }
+    TURI = 'https://localhost:443/mgmt/tm/'\
            'ltm/nat/~Common~testnat/?ver=11.5&a=b#FOO'
     assert r._meta_data['allowed_lazy_attributes'] == []
     r._activate_URI(TURI)
     assert r._meta_data['uri'] ==\
-        'https://TESTDOMAIN/mgmt/tm/ltm/nat/~Common~testnat/'
+        'https://TESTDOMAIN:443/mgmt/tm/ltm/nat/~Common~testnat/'
     assert r._meta_data['creation_uri_qargs'] ==\
         {'a': ['b'], 'ver': ['11.5']}
     assert r._meta_data['creation_uri_frag'] == 'FOO'
@@ -254,7 +257,8 @@ class TestCollection_get_collection(object):
         mock_session = mock.MagicMock(**attrs)
         c._meta_data['bigip']._meta_data =\
             {'icr_session': mock_session,
-             'hostname': 'TESTDOMAINNAME'}
+             'hostname': 'TESTDOMAINNAME',
+             'uri': 'https://TESTDOMAIN:443/mgmt/tm/'}
         c.generation = 0
         c.get_collection()
 
@@ -270,7 +274,8 @@ class TestCollection_get_collection(object):
         mock_session = mock.MagicMock(**attrs)
         c._meta_data['bigip']._meta_data =\
             {'icr_session': mock_session,
-             'hostname': 'TESTDOMAINNAME'}
+             'hostname': 'TESTDOMAINNAME',
+             'uri': 'https://TESTDOMAIN:443/mgmt/tm/'}
         c.generation = 0
         with pytest.raises(UnregisteredKind) as UKEIO:
             c.get_collection()
@@ -332,16 +337,16 @@ class TestResource_load(object):
     def test_success(self):
         r = Resource(mock.MagicMock())
         r._meta_data['allowed_lazy_attributes'] = []
-        mockuri = "https://localhost/mgmt/tm/ltm/nat/~Common~test_load"
+        mockuri = "https://localhost:443/mgmt/tm/ltm/nat/~Common~test_load"
         attrs = {'get.return_value':
                  MockResponse({u"generation": 0, u"selfLink": mockuri})}
         mock_session = mock.MagicMock(**attrs)
         r._meta_data['bigip']._meta_data =\
             {'icr_session': mock_session,
-             'hostname': 'TESTDOMAINNAME'}
+             'hostname': 'TESTDOMAINNAME',
+             'uri': 'https://TESTDOMAIN:443/mgmt/tm/'}
         r.generation = 0
         r.load(partition='Common', name='test_load')
-        r.raw
         assert r.selfLink == mockuri
 
 
@@ -349,7 +354,7 @@ class TestResource_exists(object):
     def test_loadable(self):
         r = Resource(mock.MagicMock())
         r._meta_data['allowed_lazy_attributes'] = []
-        mockuri = "https://localhost/mgmt/tm/ltm/nat/~Common~test_exists"
+        mockuri = "https://localhost:443/mgmt/tm/ltm/nat/~Common~test_exists"
         attrs = {'get.return_value':
                  MockResponse({u"generation": 0, u"selfLink": mockuri})}
         mock_session = mock.MagicMock(**attrs)


### PR DESCRIPTION
Issues:
Fixes #347

Problem:
The f5-sdk makes the assumption that all BIG-IPs are accessed on
port 443. While this may be true in most cases, there are cases
where the BIG-IP's web ui may be accessed through a port-forward
and therefore the f5-sdk would need to specify the forwarded port
instead of assuming the default.

Analysis:
I added a port argument to the BigIP constructor. By default this
value is the standard port that the web ui is accessed on; 443.

Whether the port is specified or not, the string formatting performed
for the self._meta_data['uri'] value will include the port value.
The new format of the 'uri' value will resemble the following

```
https://FakeHostName:443/mgmt/tm
```

If a port is specified, for instance 10443, it would then look like

```
https://FakeHostName:10443/mgmt/tm
```

This change allows BIG-IPs to be accessed on off-numbered ports

Tests:
- FakeBigIPWithPort
- test_meta_data_uri
