### PR TITLE
Fixes a broken link in the docs for further reading

### DIFF
--- a/docs/userguide/further_reading.rst
+++ b/docs/userguide/further_reading.rst
@@ -7,7 +7,6 @@ Further Reading
 
 * `F5 iControl REST API Reference (PDF) <https://devcentral.f5.com/d/icontrol-rest-api-reference-version-120?download=true>`_
 
-* `F5 iControl REST API Guide (PDF) <https://devcentral.f5
-.com/d/the-user-guide-for-the-icontrol-rest-interface-in-big-ip-version-1160?download=true>`_
+* `F5 iControl REST API Guide (PDF) <https://devcentral.f5.com/d/the-user-guide-for-the-icontrol-rest-interface-in-big-ip-version-1160?download=true>`_
 
 


### PR DESCRIPTION
@caphrim007
#### What issues does this address?

Fixes #351 
#### What's this change do?

This change fixes the rst so that the docs on read-the-docs are correct and the link works.
