### PR TITLE
Adds System DNS API to the SDK

### DIFF
--- a/f5/bigip/sys/__init__.py
+++ b/f5/bigip/sys/__init__.py
@@ -31,6 +31,7 @@ from f5.bigip.resource import OrganizingCollection
 from f5.bigip.sys.application import Applications
 from f5.bigip.sys.config import Config
 from f5.bigip.sys.db import Dbs
+from f5.bigip.sys.dns import Dns
 from f5.bigip.sys.failover import Failover
 from f5.bigip.sys.folder import Folders
 from f5.bigip.sys.global_settings import Global_Settings
@@ -50,4 +51,5 @@ class Sys(OrganizingCollection):
             Global_Settings,
             Ntp,
             Failover,
+            Dns
         ]

--- a/f5/bigip/sys/dns.py
+++ b/f5/bigip/sys/dns.py
@@ -1,0 +1,46 @@
+# coding=utf-8
+#
+# Copyright 2016 F5 Networks Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+
+"""BIG-IP® system dns module
+
+REST URI
+    ``http://localhost/mgmt/tm/sys/dns``
+
+GUI Path
+    ``System --> Configuration --> Device --> DNS``
+
+REST Kind
+    ``tm:sys:dns:*``
+"""
+
+from f5.bigip.mixins import UnnamedResourceMixin
+from f5.bigip.resource import Resource
+
+
+class Dns(UnnamedResourceMixin, Resource):
+    """BIG-IP® system DNS unnamed resource
+
+        .. note::
+
+        This is an unnamed resource so it has not ~Partition~Name pattern
+        at the end of its URI.
+    """
+    def __init__(self, sys):
+        super(Dns, self).__init__(sys)
+        self._meta_data['required_load_parameters'] = set()
+        self._meta_data['required_json_kind'] = 'tm:sys:dns:dnsstate'
+        self._meta_data['uri'] = self._get_meta_data_uri()

--- a/f5/bigip/sys/test/test_dns.py
+++ b/f5/bigip/sys/test/test_dns.py
@@ -1,0 +1,38 @@
+# Copyright 2016 F5 Networks Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import mock
+import pytest
+
+from f5.bigip.mixins import UnnamedResourceMixin
+from f5.bigip.sys.dns import Dns
+
+
+@pytest.fixture
+def FakeDns():
+    fake_sys = mock.MagicMock()
+    return Dns(fake_sys)
+
+
+def test_create_raises(FakeDns):
+    with pytest.raises(UnnamedResourceMixin.UnsupportedMethod) as EIO:
+        FakeDns.create()
+    assert EIO.value.message == "Dns does not support the create method"
+
+
+def test_delete_raises(FakeDns):
+    with pytest.raises(UnnamedResourceMixin.UnsupportedMethod) as EIO:
+        FakeDns.delete()
+    assert EIO.value.message == "Dns does not support the delete method"


### PR DESCRIPTION
@zancas @swormke 
#### What issues does this address?

Fixes #353 
#### What's this change do?

This patch adds the System DNS API
#### Where should the reviewer start?

f5/bigip/sys/dns.py or f5/bigip/sys/test_dns.py

The System DNS settings can be changed in the UI as well as the API. In particular, if you have access to 12.0.0, you can access /mgmt/toc to navigate to the provided location and check that the settings there are modified accordingly.
#### Any background context?

This patch adds the DNS API so that you can set the system DNS settings
such as DNS search list and DNS cache options
