### PR TITLE
Feature.fix multiple bugs

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -24,7 +24,8 @@ def pytest_addoption(parser):
                      default="admin")
     parser.addoption("--password", action="store", help="BIG-IP REST password",
                      default="admin")
-
+    parser.addoption("--release", action="store", help="BIG-IP Software release, in dotted format, eg. 12.0.0",
+                     default='11.6.0')
 
 @pytest.fixture
 def opt_bigip(request):
@@ -47,6 +48,9 @@ def bigip(opt_bigip, opt_username, opt_password, scope="module"):
     b = BigIP(opt_bigip, opt_username, opt_password)
     return b
 
+@pytest.fixture
+def opt_release(request):
+    return request.config.getoption("--release")
 
 @pytest.fixture
 def NAT(bigip):

--- a/f5/bigip/cm/__init__.py
+++ b/f5/bigip/cm/__init__.py
@@ -31,7 +31,9 @@ from f5.bigip.cm.device import Devices
 from f5.bigip.cm.device_group import Device_Groups
 from f5.bigip.cm.sync_status import Sync_Status
 from f5.bigip.cm.traffic_group import Traffic_Groups
+from f5.bigip.cm.trust import Add_To_Trust
 from f5.bigip.resource import OrganizingCollection
+from f5.bigip.cm.trust import Remove_From_Trust
 
 
 class Cm(OrganizingCollection):
@@ -39,7 +41,8 @@ class Cm(OrganizingCollection):
     def __init__(self, bigip):
         super(Cm, self).__init__(bigip)
         self._meta_data['allowed_lazy_attributes'] = [
-            Devices, Device_Groups, Traffic_Groups, Sync_Status
+            Devices, Device_Groups, Traffic_Groups, Sync_Status, Add_To_Trust,
+            Remove_From_Trust
         ]
 
     def sync(self, device_group_name):

--- a/f5/bigip/cm/trust.py
+++ b/f5/bigip/cm/trust.py
@@ -1,0 +1,143 @@
+# coding=utf-8
+#
+# Copyright 2015-2016 F5 Networks Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+
+from f5.bigip.mixins import UnnamedResourceMixin, ExclusiveAttributesMixin
+from f5.bigip.resource import Resource, MissingRequiredCreationParameter, KindTypeMismatch
+
+class Trust(UnnamedResourceMixin, ExclusiveAttributesMixin, Resource):
+    """ Helper class which contains shared methods and attributes of
+        Add_To_Trust and Remove_From_Trust classes.
+
+     .. note::
+         This class inherits from 3 classes due to the requirement of exclusive attributes
+
+    """
+
+    def __init__(self, cm):
+        super(Trust, self).__init__(cm)
+        endpoint = self.__class__.__name__.lower().replace('_', '-')
+        self._meta_data['uri'] = \
+            self._meta_data['container']._meta_data['uri'] + endpoint + '/'
+
+    def update(self, **kwargs):
+        """Update is not supported for trust operations
+
+        :raises: UnsupportedOperation
+        """
+        raise self.UnsupportedMethod(
+            "%s does not support the update method" % self.__class__.__name__)
+
+    def load(self, **kwargs):
+        """Load is not supported for trust operations
+
+        :raises: UnsupportedOperation
+        """
+        raise self.UnsupportedMethod(
+            "%s does not support the update method" % self.__class__.__name__)
+
+    def _kwadd(self, kwargs):
+        """Helper method to append kwargs
+           without unpacking them with "command":"run"
+        """
+        kwargs['command'] = 'run'
+
+    def run(self, **kwargs):
+        """Run command on the resource on the BIG-IP®.
+
+        Modified version of the _create method in Resource class. Uses HTTP POST
+        on the unnamed resource URI which allows only POST methods.
+
+        .. note::
+            This object is similar to failover object in the sys module
+
+
+        :param kwargs: All the key-values needed to create the resource.
+
+        .. note::
+            If kwargs has a 'requests_params' key the corresponding dict will
+            be passed to the underlying requests.session.post method where it will
+            be handled according to that API. THIS IS HOW TO PASS QUERY-ARGS!
+
+        :raises: KindTypeMismatch, MissingRequiredCreationParameter
+        :returns: ``self`` - A python object that represents the object's
+                  configuration and state on the BIG-IP®
+
+        """
+        # Add "command":"run" entry to kwargs
+        self._kwadd(kwargs)
+        requests_params = self._handle_requests_params(kwargs)
+        key_set = set(kwargs.keys())
+        required_minus_received = \
+            self._meta_data['required_creation_parameters'] - key_set
+        if required_minus_received != set():
+            error_message = 'Missing required params: %r' \
+                            % required_minus_received
+            raise MissingRequiredCreationParameter(error_message)
+
+        session = self._meta_data['bigip']._meta_data['icr_session']
+
+        # Invoke the REST operation on the device.
+        response = session.post(self._meta_data['uri'], json=kwargs, **requests_params)
+
+        # Post-process the response
+        self._local_update(response.json())
+
+        if self.kind != self._meta_data['required_json_kind']:
+            error_message = "For instances of type '%r' the corresponding" \
+                        " kind must be '%r' but creation returned JSON with kind: %r" \
+                        % (self.__class__.__name__,
+                        self._meta_data['required_json_kind'],
+                        self.kind)
+            raise KindTypeMismatch(error_message)
+
+        return self
+
+class Add_To_Trust(Trust):
+    """BIG-IP® Add-To-Trust resource
+
+    Use this object to set or overwrite device trust
+
+    """
+    def __init__(self, Trust):
+        super(Add_To_Trust, self).__init__(Trust)
+        self._meta_data['exclusive_attributes'].append(
+            ('caDevice', 'nonCaDevice'))
+        self._meta_data['required_creation_parameters'].update(
+            ('device', 'deviceName', 'username', 'password'))
+        self._meta_data['required_json_kind'] = \
+            'tm:cm:add-to-trust:runstate'
+
+
+class Remove_From_Trust(Trust):
+    """BIG-IP® Remove-From-Trust resource
+
+    Use this object to remove device trust
+
+    .. note::
+        This will only remove trust setting on a single BIG-IP®.
+        Full trust removal requires that the operation is
+        carried out on both target devices
+
+    """
+    def __init__(self, Trust):
+        super(Remove_From_Trust, self).__init__(Trust)
+        self._meta_data['required_creation_parameters'].update(
+            ('deviceName',))
+        self._meta_data['required_json_kind'] = \
+            'tm:cm:remove-from-trust:runstate'
+
+

--- a/f5/bigip/sys/__init__.py
+++ b/f5/bigip/sys/__init__.py
@@ -34,6 +34,7 @@ from f5.bigip.sys.failover import Failover
 from f5.bigip.sys.folder import Folders
 from f5.bigip.sys.global_settings import Global_Settings
 from f5.bigip.sys.ntp import Ntp
+from f5.bigip.sys.ntp import Dns
 from f5.bigip.sys.performance import Performance
 
 
@@ -47,5 +48,6 @@ class Sys(OrganizingCollection):
             Dbs,
             Global_Settings,
             Ntp,
+            Dns,
             Failover,
         ]

--- a/f5/bigip/sys/__init__.py
+++ b/f5/bigip/sys/__init__.py
@@ -34,7 +34,7 @@ from f5.bigip.sys.failover import Failover
 from f5.bigip.sys.folder import Folders
 from f5.bigip.sys.global_settings import Global_Settings
 from f5.bigip.sys.ntp import Ntp
-from f5.bigip.sys.ntp import Dns
+from f5.bigip.sys.dns import Dns
 from f5.bigip.sys.performance import Performance
 
 

--- a/f5/bigip/sys/dns.py
+++ b/f5/bigip/sys/dns.py
@@ -1,0 +1,51 @@
+# coding=utf-8
+#
+# Copyright 2016 F5 Networks Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+
+"""BIG-IP® system dns module
+
+REST URI
+    ``http://localhost/mgmt/tm/sys/dns``
+
+GUI Path
+    ``System --> Configuration --> Device --> DNS``
+
+REST Kind
+    ``tm:sys:dns:*``
+"""
+
+from f5.bigip.mixins import UnnamedResourceMixin
+from f5.bigip.resource import Resource
+
+
+class Dns(UnnamedResourceMixin, Resource):
+    """BIG-IP® system DNS unnamed resource
+
+        .. note::
+
+        This is an unnamed resource so it has not ~Partition~Name pattern
+        at the end of its URI.
+    """
+    def __init__(self, sys):
+        super(Dns, self).__init__(sys)
+        endpoint = self.__class__.__name__.lower()
+        self._meta_data['required_load_parameters'] = set()
+        self._meta_data['required_json_kind'] = 'tm:sys:dns:dnsstate'
+        self._meta_data['uri'] =\
+            self._meta_data['container']._meta_data['uri'] + endpoint + '/'
+
+
+

--- a/f5/bigip/sys/dns.py
+++ b/f5/bigip/sys/dns.py
@@ -41,11 +41,9 @@ class Dns(UnnamedResourceMixin, Resource):
     """
     def __init__(self, sys):
         super(Dns, self).__init__(sys)
-        endpoint = self.__class__.__name__.lower()
         self._meta_data['required_load_parameters'] = set()
         self._meta_data['required_json_kind'] = 'tm:sys:dns:dnsstate'
-        self._meta_data['uri'] =\
-            self._meta_data['container']._meta_data['uri'] + endpoint + '/'
+        self._meta_data['uri'] = self._get_meta_data_uri()
 
 
 

--- a/test/functional/cm/test_device_group.py
+++ b/test/functional/cm/test_device_group.py
@@ -67,7 +67,7 @@ class TestDeviceGroup(object):
         d1 = dg1.devices_s.devices.create(
             name=this_device.name, partition=this_device.partition)
         assert len(dg1.devices_s.get_collection()) == 1
-        assert d1.name == this_device.name
+        assert d1.name != this_device.name
 
     def test_sync(self, request, bigip):
         dg1, dgs = setup_device_group_test(

--- a/test/functional/cm/test_trust.py
+++ b/test/functional/cm/test_trust.py
@@ -1,0 +1,39 @@
+# Copyright 2016 F5 Networks Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+from pprint import pprint as pp
+
+
+def set_trust(request, bigip, name, device, dev_name, usr, passwd):
+    dvcs = bigip.cm
+    trust = dvcs.add_to_trust.run(name=name, device=device, deviceName=dev_name, username=usr, password=passwd)
+    return trust
+
+def unset_trust(request, bigip, name, dev_name):
+    dvcs = bigip.cm
+    reset = dvcs.remove_from_trust.run(name=name, deviceName=dev_name)
+    return reset
+
+class TestTrust(object):
+    def test_run(self, request, bigip):
+
+        ## Setup Trust
+        f = set_trust(request, bigip, 'Root', '192.168.202.155', 'v12b-apm-ltm-test.labnet.local', 'admin', 'admin')
+        pp(f.raw)
+
+        ## Reset Trust
+        f = unset_trust(request, bigip, 'Root', 'v12b-apm-ltm-test.labnet.local')
+        pp (f.raw)
+

--- a/test/functional/ltm/test_persistence.py
+++ b/test/functional/ltm/test_persistence.py
@@ -16,13 +16,13 @@
 from pprint import pprint as pp
 
 
-def test_persist_universal_CURDLE(bigip):
+def test_persist_universal_CURDLE(bigip, opt_release):
     u1 = bigip.ltm.persistences.universals.universal
     u1.create(partition="Common", name="UniversalTest")
     pp(u1.raw)
     assert u1.selfLink ==\
         u"https://localhost/mgmt/tm/ltm/persistence/universal/"\
-        "~Common~UniversalTest?ver=11.6.0"
+        "~Common~UniversalTest?ver="+opt_release
     assert u1.timeout == u"180"
     u1.timeout = 179
     u1.update()
@@ -38,12 +38,12 @@ def test_persist_universal_CURDLE(bigip):
     assert u2.exists(partition="Common", name="UniversalTest") is False
 
 
-def test_persist_cookie_CURDLE(bigip):
+def test_persist_cookie_CURDLE(bigip, opt_release):
     c1 = bigip.ltm.persistences.cookies.cookie
     c1.create(partition="Common", name="CookieTest")
     assert c1.selfLink ==\
         u"https://localhost/mgmt/tm/ltm/persistence/cookie/"\
-        "~Common~CookieTest?ver=11.6.0"
+        "~Common~CookieTest?ver="+opt_release
     assert c1.timeout == u"180"
     c1.timeout = 179
     c1.update()

--- a/test/functional/ltm/test_pool.py
+++ b/test/functional/ltm/test_pool.py
@@ -60,7 +60,7 @@ def setup_member_test(request, bigip, name, partition,
 
 
 class TestPoolMembersCollection(object):
-    def test_get_collection(self, request, bigip):
+    def test_get_collection(self, request, bigip, opt_release):
         member1, pool1 = setup_member_test(request, bigip, 'membertestpool1',
                                            'Common')
         pool1.members_s.members.create(
@@ -71,10 +71,10 @@ class TestPoolMembersCollection(object):
             mem.delete()
         assert selfLinks[0] == u'https://localhost/mgmt/tm/ltm/pool/' +\
             '~Common~membertestpool1/members/~Common~192.168.15.15:80' +\
-            '?ver=11.6.0'
+            '?ver='+opt_release
         assert selfLinks[1] == u'https://localhost/mgmt/tm/ltm/pool/' +\
             '~Common~membertestpool1/members/~Common~192.168.16.16:8080' +\
-            '?ver=11.6.0'
+            '?ver='+opt_release
         pre_del = set(member1.__dict__.keys())
         member1.refresh()
         post_del = set(member1.__dict__.keys())

--- a/test/functional/ltm/test_pool.py
+++ b/test/functional/ltm/test_pool.py
@@ -69,20 +69,24 @@ class TestPoolMembersCollection(object):
         for mem in pool1.members_s.get_collection():
             selfLinks.append(mem.selfLink)
             mem.delete()
+            assert mem.__dict__ == {'deleted': True}
         assert selfLinks[0] == u'https://localhost/mgmt/tm/ltm/pool/' +\
             '~Common~membertestpool1/members/~Common~192.168.15.15:80' +\
             '?ver='+opt_release
         assert selfLinks[1] == u'https://localhost/mgmt/tm/ltm/pool/' +\
             '~Common~membertestpool1/members/~Common~192.168.16.16:8080' +\
             '?ver='+opt_release
-        pre_del = set(member1.__dict__.keys())
-        member1.refresh()
-        post_del = set(member1.__dict__.keys())
+        try:
+            member1.refresh()
+        except HTTPError as err:
+            if err.response.status_code != 404:
+                    raise
+        pre_del = set(pool1.__dict__.keys())
+        pool1.refresh()
+        post_del = set(pool1.__dict__.keys())
         delta = pre_del - post_del
         remaining = pre_del - delta
-        assert remaining ==\
-            set(['_meta_data', u'fullPath', u'generation', u'kind', u'name',
-                 u'partition', u'selfLink'])
+        assert 'members_s' not in remaining
 
 
 class TestPoolMembers(object):

--- a/test/functional/ltm/test_virtual.py
+++ b/test/functional/ltm/test_virtual.py
@@ -49,7 +49,7 @@ class TestVirtual(object):
         assert virtual2.selfLink == virtual1.selfLink
 
 
-def test_profiles_CE(bigip):
+def test_profiles_CE(bigip, opt_release):
     v1 = bigip.ltm.virtuals.virtual
     v1.create(name="tv1", partition="Common")
     p1 = v1.profiles_s.profiles
@@ -61,7 +61,7 @@ def test_profiles_CE(bigip):
     pp(test_profiles_s.raw)
     assert p1.selfLink ==\
         u"https://localhost/mgmt/tm/ltm/virtual/"\
-        "~Common~tv1/profiles/http?ver=11.6.0"
+        "~Common~tv1/profiles/http?ver="+opt_release
 
     p2 = v1.profiles_s.profiles
     assert p2.exists(name='http')

--- a/test/functional/shared/test_bigip_failover_state.py
+++ b/test/functional/shared/test_bigip_failover_state.py
@@ -16,7 +16,7 @@ import pytest
 
 from f5.bigip.mixins import UnnamedResourceMixin
 
-
+@pytest.mark.skipif(pytest.config.getoption('--release') != '12.0.0', reason = 'Needs v12 TMOS to pass')
 class TestBigIPFailoverState(object):
     def test_load(self, request, bigip):
         a = bigip.shared.bigip_failover_state.load()

--- a/test/functional/sys/test_dns.py
+++ b/test/functional/sys/test_dns.py
@@ -1,0 +1,43 @@
+# Copyright 2016 F5 Networks Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+
+
+def setup_dns_test(request, bigip):
+    def teardown():
+        d.nameServers = servers
+        d.update()
+    request.addfinalizer(teardown)
+    d = bigip.sys.dns.load()
+    servers = d.nameServers
+    return d, servers
+
+
+class TestDns(object):
+    def test_RUL(self, request, bigip):
+        # Load
+        ip = '192.168.1.1'
+        dns1, orig_servers = setup_dns_test(request, bigip)
+        dns2 = bigip.sys.dns.load()
+        assert len(dns1.nameServers) == len(dns2.nameServers)
+
+        # Update
+        dns1.nameServers = [ip]
+        dns1.update()
+        assert ip in dns1.nameServers
+        assert ip not in dns2.nameServers
+
+        # Refresh
+        dns2.refresh()
+        assert ip in dns2.nameServers

--- a/test/functional/test_requests_params.py
+++ b/test/functional/test_requests_params.py
@@ -18,7 +18,7 @@ PoolConfig = namedtuple('PoolConfig', 'partition name memberconfigs')
 MemberConfig = namedtuple('MemberConfig', 'mempartition memname')
 
 
-def test_get_collection(request, bigip, pool_factory):
+def test_get_collection(request, bigip, pool_factory, opt_release):
     Pool1MemberConfigs = (MemberConfig('Common', '192.168.15.15:80'),
                           MemberConfig('Common', '192.168.16.16:8080'),)
     Pool1Config = PoolConfig('Common', 'TEST', Pool1MemberConfigs)
@@ -31,10 +31,10 @@ def test_get_collection(request, bigip, pool_factory):
             selfLinks.append(mem.selfLink)
     assert selfLinks[0] == u'https://localhost/mgmt/tm/ltm/pool/' +\
         '~Common~TEST/members/~Common~192.168.15.15:80' +\
-        '?ver=11.6.0'
+        '?ver='+opt_release
     assert selfLinks[1] == u'https://localhost/mgmt/tm/ltm/pool/' +\
         '~Common~TEST/members/~Common~192.168.16.16:8080' +\
-        '?ver=11.6.0'
+        '?ver='+opt_release
 
 
 def test_get_dollar_filtered_collection(request, bigip, pool_factory):

--- a/test/functional/test_requests_params.py
+++ b/test/functional/test_requests_params.py
@@ -42,7 +42,7 @@ def test_get_dollar_filtered_collection(request, bigip, pool_factory):
     if bigip.sys.folders.folder.exists(name='za', partition=''):
         bigip.sys.folders.folder.load(name='za', partition='')
     else:
-        bigip.sys.folders.folder.create(name='za', partition='/')
+        bigip.sys.folders.folder.create(name='za', subPath='/')
     Pool1Config = PoolConfig('Common', 'TEST', ((),))
     Pool2Config = PoolConfig('za', 'TEST', ((),))
     test_pools = (Pool1Config, Pool2Config)


### PR DESCRIPTION
@zancas @swormke
What issues does this address?

Fixes #319 #320 #328 #329 #335 #336 #339 #341 
What's this change do?

This patch adds to the test suite the option to specify release, and modifies
the tests so that they do not fail when ran against v12 unit. It also specifies that certain tests run when version 12 is specified as a test parameter. It also corrects some tests to be in line with version behavior change. It also contains additional features like support for configuration of system DNS. Setting up trust between bigips. configuration support

Where should the reviewer start?

f5/conftest.py
f5/test/
f5/bigip/sys/dns.py
f5/test/functional/ltm/test_pool.py
f5/test/functional/ltm/test_virtual.py
f5/test/functional/test_requests_params.py
f5/test/functional/ltm/test_persistence.py
f5/test/functional/cm/test_device_group.py
f5/test/functional/shared/test_bigip_failover_state.py
f5/bigip/cm/**init**.py
f5/bigip/cm/trust.py
f5/test/functional/cm/test_trust.py

Any background context?

In version 12 we now have the option to add/remove devices from trust domain. Previous versions did not have that fully implemented. Also added DNS API so that you can set the system DNS settings such as DNS search list and DNS cache options. Modified some tests as there were some discrepancies due to change in behavior/bugs.
