### PR TITLE
WIP: Add Transaction class to BIG-IP

### DIFF
--- a/f5/bigip/__init__.py
+++ b/f5/bigip/__init__.py
@@ -23,9 +23,10 @@ from f5.bigip.net import Net
 from f5.bigip.resource import OrganizingCollection
 from f5.bigip.shared import Shared
 from f5.bigip.sys import Sys
+from f5.bigip.transaction import Transactions
 from icontrol.session import iControlRESTSession
 
-allowed_lazy_attributes = [Cm, Ltm, Net, Shared, Sys]
+allowed_lazy_attributes = [Cm, Ltm, Net, Shared, Sys, Transactions]
 
 
 class BigIP(OrganizingCollection):

--- a/f5/bigip/contexts.py
+++ b/f5/bigip/contexts.py
@@ -1,0 +1,79 @@
+# coding=utf-8
+#
+# Copyright 2014 F5 Networks Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+
+import copy
+import logging
+
+from f5.sdk_exception import F5SDKError
+
+
+class TransactionSubmitException(F5SDKError):
+    pass
+
+
+class TransactionContextManager(object):
+    def __init__(self, transaction):
+        self.transaction = transaction
+        self.bigip = transaction._meta_data['bigip']
+        self.icr = self.bigip._meta_data['icr_session']
+        self.original_headers = copy.deepcopy(self.icr.session.headers)
+
+    def __enter__(self):
+        """Begins a new transaction context
+
+        When a transaction begins, this method will automatically be called
+        to set up the transaction.
+
+        Transaction IDs are automatically retrieved for you and the
+        appropriate headers are set so that operations in the Transaction
+        Context will reference the transaction.
+
+        Headers are preserved so that after you exit the transaction, you will
+        be able to use the API object as you normally would.
+        """
+
+        self.transaction.create()
+        self.icr.session.headers.update({
+            'X-F5-REST-Coordination-Id': self.transaction.transId
+        })
+        return self.bigip
+
+    def __exit__(self, exc_type, exc_value, exc_tb):
+        """Commit a transaction upon Context Manager exit
+
+        Upon exit, the transaction will attempt to be committed. If the commit
+        fails, the transaction will automatically be rolled back by the server
+        performing the transaction.
+
+        :param exc_type: The type of exception raised
+        :param exc_value: Value of the exception raised
+        :param exc_tb: Traceback
+        NOTE: If the context exits without an exception, all three of the
+        parameters will be None
+        :returns: void
+        """
+        self.icr.session.headers = dict()
+        if exc_tb is None:
+            try:
+                self.transaction.update(state="VALIDATING")
+            except Exception as e:
+                logging.debug(e)
+                raise TransactionSubmitException(e)
+            finally:
+                self.icr.session.headers = self.original_headers
+        self.icr.session.headers = self.original_headers

--- a/f5/bigip/resource.py
+++ b/f5/bigip/resource.py
@@ -532,6 +532,7 @@ class Resource(ResourceBase):
         :param selfLinkuri: the server provided selfLink (contains localhost)
         :raises: URICreationCollision
         """
+
         # netloc local alias
         uri = urlparse.urlsplit(self._meta_data['bigip']._meta_data['uri'])
 
@@ -575,7 +576,8 @@ class Resource(ResourceBase):
         # Post-process the response
         self._local_update(response.json())
 
-        if self.kind != self._meta_data['required_json_kind']:
+        if self.kind != self._meta_data['required_json_kind'] \
+           and self.kind != "tm:transaction:commandsstate":
             error_message = "For instances of type '%r' the corresponding"\
                 " kind must be '%r' but creation returned JSON with kind: %r"\
                 % (self.__class__.__name__,

--- a/f5/bigip/transaction/__init__.py
+++ b/f5/bigip/transaction/__init__.py
@@ -1,0 +1,60 @@
+# coding=utf-8
+#
+# Copyright 2014 F5 Networks Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""BIG-IP® system dns module
+
+REST URI
+    ``http://localhost/mgmt/tm/transaction``
+
+REST Kind
+    ``tm:transaction*``
+"""
+
+from f5.bigip.resource import Collection
+from f5.bigip.resource import Resource
+
+
+class Transactions(Collection):
+    """This class is a context manager for iControl transactions.
+
+    Upon successful exit of the with statement, the transaction will be
+    submitted, otherwise it will be rolled back.
+
+    NOTE: This feature was added to BIGIP in version 11.0.0.
+
+    Example:
+    > bigip = BigIP(<args>)
+    > tx = bigip.transactions.transaction
+    > with TransactionContextManager(tx) as api:
+    >     api.net.pools.pool.create(name="foo")
+    >     api.sys.dbs.db.update(name="setup.run", value="false")
+    >     <perform actions inside a transaction>
+    >
+    > # transaction is committed when you exit the "with" statement.
+    """
+    def __init__(self, api):
+        super(Transactions, self).__init__(api)
+        self._meta_data['allowed_lazy_attributes'] = [Transaction]
+        self._meta_data['attribute_registry'] = \
+            {'tm:transactionstate': Transaction}
+
+
+class Transaction(Resource):
+    def __init__(self, transactions):
+        super(Transaction, self).__init__(transactions)
+        self._meta_data['required_json_kind'] = 'tm:transactionstate'
+        self._meta_data['required_creation_parameters'] = set()


### PR DESCRIPTION
Issues:
Fixes #359

Problem:
The REST API supports a transaction feature that allows you to modify
many config objects and commit them all at once. if the modifications
fail, then the entire set is rolled back. This allows you to do atomic
operations on many objects without commiting something that would leave
the BIG-IP in an inconsistent state

Analysis:
The REST API supports transactions that, if they fail, will automatically
rollback all of the operations. I need to use this for some functional
use cases where individual modification of Configuration could result
in a BIG-IP being left in an inconsistent state.

I have modeled this feature off of Context Managers in python. You provide
an API object inside of a transaction, and then use that API object to change
whatever you want. When the block finishes, the entire thing is either committed
or rolled back

Tests:
None yet as this is a WIP and needs feedback from core developers.
