### PR TITLE
Add SSHD API to the SDK

### DIFF
--- a/f5/bigip/sys/__init__.py
+++ b/f5/bigip/sys/__init__.py
@@ -37,6 +37,7 @@ from f5.bigip.sys.folder import Folders
 from f5.bigip.sys.global_settings import Global_Settings
 from f5.bigip.sys.ntp import Ntp
 from f5.bigip.sys.performance import Performance
+from f5.bigip.sys.sshd import Sshd
 
 
 class Sys(OrganizingCollection):
@@ -51,5 +52,6 @@ class Sys(OrganizingCollection):
             Global_Settings,
             Ntp,
             Failover,
-            Dns
+            Dns,
+            Sshd
         ]

--- a/f5/bigip/sys/sshd.py
+++ b/f5/bigip/sys/sshd.py
@@ -1,0 +1,46 @@
+# coding=utf-8
+#
+# Copyright 2016 F5 Networks Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+
+"""BIG-IP® system sshd module
+
+REST URI
+    ``http://localhost/mgmt/tm/sys/sshd``
+
+GUI Path
+    ``System --> Configuration --> Device --> SSHD``
+
+REST Kind
+    ``tm:sys:sshd:sshdstate``
+"""
+
+from f5.bigip.mixins import UnnamedResourceMixin
+from f5.bigip.resource import Resource
+
+
+class Sshd(UnnamedResourceMixin, Resource):
+    """BIG-IP® system SSHD unnamed resource
+
+        .. note::
+
+        This is an unnamed resource so it has not ~Partition~Name pattern
+        at the end of its URI.
+    """
+    def __init__(self, sys):
+        super(Sshd, self).__init__(sys)
+        self._meta_data['required_load_parameters'] = set()
+        self._meta_data['required_json_kind'] = 'tm:sys:sshd:sshdstate'
+        self._meta_data['uri'] = self._get_meta_data_uri()

--- a/f5/bigip/sys/test/test_sshd.py
+++ b/f5/bigip/sys/test/test_sshd.py
@@ -1,0 +1,38 @@
+# Copyright 2016 F5 Networks Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import mock
+import pytest
+
+from f5.bigip.mixins import UnsupportedMethod
+from f5.bigip.sys.sshd import Sshd
+
+
+@pytest.fixture
+def FakeSshd():
+    fake_sys = mock.MagicMock()
+    return Sshd(fake_sys)
+
+
+def test_create_raises(FakeSshd):
+    with pytest.raises(UnsupportedMethod) as EIO:
+        FakeSshd.create()
+    assert EIO.value.message == "Sshd does not support the create method"
+
+
+def test_delete_raises(FakeSshd):
+    with pytest.raises(UnsupportedMethod) as EIO:
+        FakeSshd.delete()
+    assert EIO.value.message == "Sshd does not support the delete method"


### PR DESCRIPTION
Issues:
Fixes #362

Problem:
This change addresses missing API functionality needed to set the BIG-IP
SSHD configuration

Analysis:
This change adds the API endpoints necessary to configure the SSHD settings
on a BIG-IP. This functionality is needed to easily meet the requirements
of STIG/SRG configuration which (among other things) requires that the
SSH MOTD be set to a predefined value.

Tests:
    \* f5/bigip/sys/test/test_sshd.py
