### PR TITLE
Add the HTTPD API to the SDK

### DIFF
--- a/f5/bigip/sys/__init__.py
+++ b/f5/bigip/sys/__init__.py
@@ -35,6 +35,7 @@ from f5.bigip.sys.dns import Dns
 from f5.bigip.sys.failover import Failover
 from f5.bigip.sys.folder import Folders
 from f5.bigip.sys.global_settings import Global_Settings
+from f5.bigip.sys.httpd import Httpd
 from f5.bigip.sys.ntp import Ntp
 from f5.bigip.sys.performance import Performance
 from f5.bigip.sys.sshd import Sshd
@@ -53,5 +54,6 @@ class Sys(OrganizingCollection):
             Ntp,
             Failover,
             Dns,
-            Sshd
+            Sshd,
+            Httpd
         ]

--- a/f5/bigip/sys/httpd.py
+++ b/f5/bigip/sys/httpd.py
@@ -1,0 +1,49 @@
+# coding=utf-8
+#
+# Copyright 2016 F5 Networks Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+
+"""BIG-IP® system dns module
+
+REST URI
+    ``http://localhost/mgmt/tm/sys/dns``
+
+tmsh Path
+    ``sys --> httpd --> all-properties``
+
+GUI Path
+    ``various``
+
+REST Kind
+    ``tm:sys:httpd:*``
+"""
+
+from f5.bigip.mixins import UnnamedResourceMixin
+from f5.bigip.resource import Resource
+
+
+class Httpd(UnnamedResourceMixin, Resource):
+    """BIG-IP® system HTTPD unnamed resource
+
+        .. note::
+
+        This is an unnamed resource so it has no ~Partition~Name pattern
+        at the end of its URI.
+    """
+    def __init__(self, sys):
+        super(Httpd, self).__init__(sys)
+        self._meta_data['required_load_parameters'] = set()
+        self._meta_data['required_json_kind'] = 'tm:sys:httpd:httpdstate'
+        self._meta_data['uri'] = self._get_meta_data_uri()

--- a/f5/bigip/sys/test/test_httpd.py
+++ b/f5/bigip/sys/test/test_httpd.py
@@ -1,0 +1,38 @@
+# Copyright 2016 F5 Networks Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import mock
+import pytest
+
+from f5.bigip.mixins import UnsupportedMethod
+from f5.bigip.sys.httpd import Httpd
+
+
+@pytest.fixture
+def FakeHttpd():
+    fake_sys = mock.MagicMock()
+    return Httpd(fake_sys)
+
+
+def test_create_raises(FakeHttpd):
+    with pytest.raises(UnsupportedMethod) as EIO:
+        FakeHttpd.create()
+    assert EIO.value.message == "Httpd does not support the create method"
+
+
+def test_delete_raises(FakeHttpd):
+    with pytest.raises(UnsupportedMethod) as EIO:
+        FakeHttpd.delete()
+    assert EIO.value.message == "Httpd does not support the delete method"

--- a/test/functional/sys/test_httpd.py
+++ b/test/functional/sys/test_httpd.py
@@ -1,0 +1,29 @@
+# Copyright 2016 F5 Networks Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+
+class TestHttpd(object):
+    def test_load(self, bigip):
+        httpd = bigip.sys.httpd.load()
+        assert httpd.maxClients == 10
+        httpd.refresh()
+        assert httpd.maxClients == 10
+
+    def test_update(self, bigip):
+        httpd = bigip.sys.httpd.load()
+        httpd.update(maxClients=10)
+        assert httpd.maxClients == 10
+        httpd.update(maxClients=20)
+        assert httpd.maxClients == 20


### PR DESCRIPTION
Issues:
Fixes #372

Problem:
The issue is that the httpd API was not available in the SDK

Analysis:
This change adds the httpd api to the sdk. This API is scattered
throughout the Web UI, but maps neatly to the tmsh api. With this
API you can change various behaviors associated with the Web UI.

Tests:
- f5/bigip/sys/test_httpd.py
- test/functional/sys/test_httpd.py
