### PR TITLE
Adds TrustDomain support

### DIFF
--- a/f5/bigip/tm/cm/__init__.py
+++ b/f5/bigip/tm/cm/__init__.py
@@ -32,6 +32,7 @@ from f5.bigip.tm.cm.sync_status import Sync_Status
 from f5.bigip.tm.cm.traffic_group import Traffic_Groups
 from f5.bigip.tm.cm.trust import Add_To_Trust
 from f5.bigip.tm.cm.trust import Remove_From_Trust
+from f5.bigip.tm.cm.trust_domain import Trust_Domains
 
 
 class Cm(OrganizingCollection):
@@ -39,8 +40,8 @@ class Cm(OrganizingCollection):
     def __init__(self, tm):
         super(Cm, self).__init__(tm)
         self._meta_data['allowed_lazy_attributes'] = [
-            Devices, Device_Groups, Traffic_Groups, Sync_Status, Add_To_Trust,
-            Remove_From_Trust
+            Devices, Device_Groups, Traffic_Groups, Trust_Domains,
+            Sync_Status, Add_To_Trust, Remove_From_Trust,
         ]
 
     def sync(self, device_group_name):

--- a/f5/bigip/tm/cm/trust_domain.py
+++ b/f5/bigip/tm/cm/trust_domain.py
@@ -1,0 +1,53 @@
+# coding=utf-8
+#
+#  Copyright 2016 F5 Networks Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""BIG-IP® cluster trust-domain submodule
+
+REST URI
+    ``http://localhost/mgmt/tm/cm/trust-domain``
+
+GUI Path
+    ``Device Management --> Device Trust``
+
+REST Kind
+    ``tm:cm:device-group:*``
+"""
+
+from f5.bigip.resource import Collection
+from f5.bigip.resource import Resource
+
+
+class Trust_Domains(Collection):
+    """BIG-IP® cluster trust-domain collection."""
+
+    def __init__(self, cm):
+        super(Trust_Domains, self).__init__(cm)
+        endpoint = 'trust-domain'
+        self._meta_data['uri'] =\
+            self._meta_data['container']._meta_data['uri'] + endpoint + '/'
+        self._meta_data['allowed_lazy_attributes'] = [Trust_Domain]
+        self._meta_data['attribute_registry'] = \
+            {'tm:cm:trust-domain:trust-domainstate': Trust_Domain}
+
+
+class Trust_Domain(Resource):
+    """BIG-IP® cluster trust-domain resource"""
+    def __init__(self, trust_domains):
+        super(Trust_Domain, self).__init__(trust_domains)
+        self._meta_data['required_json_kind'] =\
+            'tm:cm:trust-domain:trust-domainstate'
+        self._meta_data['required_creation_parameters'].update(('partition',))

--- a/f5/bigip/tm/ltm/virtual.py
+++ b/f5/bigip/tm/ltm/virtual.py
@@ -46,7 +46,7 @@ class Virtual(Resource):
         super(Virtual, self).__init__(virtual_s)
         self._meta_data['allowed_lazy_attributes'] = [Profiles_s]
         self._meta_data['required_json_kind'] = 'tm:ltm:virtual:virtualstate'
-	self._meta_data['attribute_registry'] =\
+        self._meta_data['attribute_registry'] =\
             {'tm:ltm:virtual:profiles:profilescollectionstate': Profiles_s}
 
 

--- a/test/functional/cm/test_trust_domain.py
+++ b/test/functional/cm/test_trust_domain.py
@@ -1,0 +1,63 @@
+# Copyright 2016 F5 Networks Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+from requests import HTTPError
+
+
+def setup_trust_domain_test(request, bigip, name, partition, **kwargs):
+    def teardown():
+        try:
+            td.delete()
+        except HTTPError as err:
+            if err.response.status_code is not 404:
+                raise
+    request.addfinalizer(teardown)
+    td = bigip.cm.trust_domains.trust_domain.create(
+        name=name, partition=partition, **kwargs)
+    return td
+
+
+# Obtaining device name for tests to work
+def check_device(request, bigip):
+    dvcs = bigip.cm.devices.get_collection()
+    devname = str(dvcs[0].fullPath)
+    return devname
+
+
+class TestTrustDomain(object):
+    def test_curdl(self, request, bigip):
+
+        # Create and delete are done with teardown
+        td1 = setup_trust_domain_test(request, bigip,
+                                      'test_trust', 'Common')
+        assert td1.name == 'test_trust'
+
+        # Load
+        td2 = bigip.cm.trust_domains.trust_domain.load(name=td1.name,
+                                                       partition=td1.partition)
+        assert td1.generation == td2.generation
+
+        # Update
+        devname = check_device(request, bigip)
+        td1.caDevices = [devname, ]
+        td1.update()
+        assert td1.caDevices == [devname, ]
+        assert not hasattr(td2, 'caDevices')
+        assert td1.generation > td2.generation
+
+        # Refresh
+        td2.refresh()
+        assert td2.caDevices == [devname, ]
+        assert td1.generation == td2.generation


### PR DESCRIPTION
Fixes #385

Problem:
Trust_Domains and Trust_Domain should be supported in the cm/trust module

Analysis:
Added collection and resource for the Trust_Domain API

Tests:
- Functional Test
- Flake8
