### PR TITLE
Add the user/auth API to the SDK

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -61,6 +61,12 @@ def NAT(bigip):
     return n
 
 
+@pytest.fixture
+def USER(bigip):
+    n = bigip.auth.users.user
+    return n
+
+
 def _delete_pools_members(bigip, pool_records):
     for pr in pool_records:
         if bigip.ltm.pools.pool.exists(partition=pr.partition, name=pr.name):

--- a/f5/bigip/tm/auth/__init__.py
+++ b/f5/bigip/tm/auth/__init__.py
@@ -30,6 +30,7 @@ REST Kind
 
 from f5.bigip.resource import OrganizingCollection
 from f5.bigip.tm.auth.password_policy import Password_Policy
+from f5.bigip.tm.auth.user import Users
 
 
 class Auth(OrganizingCollection):
@@ -37,4 +38,5 @@ class Auth(OrganizingCollection):
         super(Auth, self).__init__(tm)
         self._meta_data['allowed_lazy_attributes'] = [
             Password_Policy,
+            Users
         ]

--- a/f5/bigip/tm/auth/test/test_user.py
+++ b/f5/bigip/tm/auth/test/test_user.py
@@ -1,0 +1,60 @@
+# Copyright 2015 F5 Networks Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import mock
+import pytest
+
+from f5.bigip import BigIP
+from f5.bigip.resource import MissingRequiredCreationParameter
+from f5.bigip.tm.auth.user import User
+
+
+@pytest.fixture
+def FakeUser():
+    fake_user_s = mock.MagicMock()
+    fake_user = User(fake_user_s)
+    return fake_user
+
+
+class TestCreate(object):
+    def test_create_two(self):
+        b = BigIP('localhost', 'admin', 'admin')
+        n1 = b.auth.users.user
+        n2 = b.auth.users.user
+        assert n1 is not n2
+
+    def test_create_no_args(self, FakeUser):
+        with pytest.raises(MissingRequiredCreationParameter):
+            FakeUser.create()
+
+    def test_create_descriptiom(self, FakeUser):
+        with pytest.raises(MissingRequiredCreationParameter):
+            FakeUser.create(description='description')
+
+    def test_create_encrypted_password(self, FakeUser):
+        with pytest.raises(MissingRequiredCreationParameter):
+            FakeUser.create(encryptedPassword='JGE#)$GJ#$G#')
+
+    def test_create_partition_access(self, FakeUser):
+        with pytest.raises(MissingRequiredCreationParameter):
+            FakeUser.create(partitionAccess='description')
+
+    def test_create_prompt_for_password(self, FakeUser):
+        with pytest.raises(MissingRequiredCreationParameter):
+            FakeUser.create(promptForPassword='bash')
+
+    def test_create_shell(self, FakeUser):
+        with pytest.raises(MissingRequiredCreationParameter):
+            FakeUser.create(shell='bash')

--- a/f5/bigip/tm/auth/user.py
+++ b/f5/bigip/tm/auth/user.py
@@ -1,0 +1,47 @@
+# coding=utf-8
+#
+# Copyright 2016 F5 Networks Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""BIG-IP® user module
+
+REST URI
+    ``http://localhost/mgmt/auth/user/``
+
+GUI Path
+    ``System --> Users``
+
+REST Kind
+    ``tm:auth:user:*``
+"""
+
+from f5.bigip.resource import Collection
+from f5.bigip.resource import Resource
+
+
+class Users(Collection):
+    """BIG-IP® user collection"""
+    def __init__(self, auth):
+        super(Users, self).__init__(auth)
+        self._meta_data['allowed_lazy_attributes'] = [User]
+        self._meta_data['attribute_registry'] = \
+            {'tm:auth:user:userstate': User}
+
+
+class User(Resource):
+    """BIG-IP® user resource"""
+    def __init__(self, users):
+        super(User, self).__init__(users)
+        self._meta_data['required_json_kind'] = 'tm:auth:user:userstate'

--- a/test/functional/auth/test_user.py
+++ b/test/functional/auth/test_user.py
@@ -1,0 +1,159 @@
+# Copyright 2016 F5 Networks Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import pytest
+
+from f5.bigip.resource import MissingRequiredCreationParameter
+from requests.exceptions import HTTPError
+
+
+def delete_user(bigip, name):
+    user = bigip.auth.users.user
+    try:
+        user.load(name=name)
+    except HTTPError as err:
+        if err.response.status_code != 404:
+            raise
+        return
+    user.delete()
+
+
+def setup_loadable_user_test(request, bigip, user):
+    def teardown():
+        delete_user(bigip, 'user1')
+
+    request.addfinalizer(teardown)
+
+    user.create(name='user1')
+    assert user.name == 'user1'
+
+
+def setup_create_test(request, bigip):
+    def teardown():
+        delete_user(bigip, 'user1')
+    request.addfinalizer(teardown)
+
+
+def setup_create_two(request, bigip):
+    def teardown():
+        for name in ['user1', 'user2']:
+            delete_user(bigip, name)
+    request.addfinalizer(teardown)
+
+
+class TestCreate(object):
+    def test_create_two(self, request, bigip):
+        setup_create_two(request, bigip)
+
+        n1 = bigip.auth.users.user.create(name='user1')
+        n2 = bigip.auth.users.user.create(name='user2')
+
+        assert n1 is not n2
+        assert n2.name != n1.name
+
+    def test_create_no_args(self, bigip):
+        '''Test that user.create() with no options throws a ValueError '''
+        user1 = bigip.auth.users.user
+        with pytest.raises(MissingRequiredCreationParameter):
+            user1.create()
+
+    def test_create_min_args(self, request, bigip):
+        '''Test that user.create() with only required arguments work.
+
+        This will also test that the default values are set correctly and are
+        part of the user object after creating the instance on the BigIP
+        '''
+        setup_create_test(request, bigip)
+
+        user1 = bigip.auth.users.user.create(name='user1')
+
+        assert user1.name == 'user1'
+        assert user1.generation is not None \
+            and isinstance(user1.generation, int)
+        assert user1.fullPath == 'user1'
+        assert user1.selfLink.startswith(
+            'https://localhost/mgmt/tm/auth/user/user1')
+
+        # Default Values
+        assert user1.description == 'user1'
+        assert user1.encryptedPassword == '!!'
+        assert user1.partitionAccess == [dict(
+            name='all-partitions',
+            role='no-access'
+        )]
+
+    def test_create_description(self, request, bigip, USER):
+        setup_create_test(request, bigip)
+        USER.create(name='user1', description='foo')
+        assert USER.description == 'foo'
+
+
+class TestLoad(object):
+    def test_load_no_object(self, USER):
+        with pytest.raises(HTTPError) as err:
+            USER.load(name='user10')
+            assert err.response.status == 404
+
+    def test_load(self, request, bigip, USER):
+        setup_loadable_user_test(request, bigip, USER)
+        n1 = bigip.auth.users.user.load(name='user1')
+        assert n1.name == 'user1'
+        assert n1.description == 'user1'
+        assert isinstance(n1.generation, int)
+
+
+class TestRefresh(object):
+    def test_refresh(self, request, bigip, USER):
+        setup_loadable_user_test(request, bigip, USER)
+
+        n1 = bigip.auth.users.user.load(name='user1')
+        n2 = bigip.auth.users.user.load(name='user1')
+        assert n1.description == 'user1'
+        assert n2.description == 'user1'
+
+        n2.update(description='foobaz')
+        assert n2.description == 'foobaz'
+        assert n1.description == 'user1'
+
+        n1.refresh()
+        assert n1.description == 'foobaz'
+
+
+class TestDelete(object):
+    def test_delete(self, request, bigip, USER):
+        setup_loadable_user_test(request, bigip, USER)
+        n1 = bigip.auth.users.user.load(name='user1')
+        n1.delete()
+        del(n1)
+        with pytest.raises(HTTPError) as err:
+            bigip.auth.users.user.load(name='user1')
+            assert err.response.status_code == 404
+
+
+class TestUpdate(object):
+    def test_update_with_args(self, request, bigip, USER):
+        setup_loadable_user_test(request, bigip, USER)
+        n1 = bigip.auth.users.user.load(name='user1')
+        assert n1.description == 'user1'
+        n1.update(description='foobar')
+        assert n1.description == 'foobar'
+
+    def test_update_parameters(self, request, bigip, USER):
+        setup_loadable_user_test(request, bigip, USER)
+        n1 = bigip.auth.users.user.load(name='user1')
+        assert n1.description == 'user1'
+        n1.description = 'foobar'
+        n1.update()
+        assert n1.description == 'foobar'


### PR DESCRIPTION
Issues:
Fixes #396

Problem:
The SDK did not include support for the auth API used to create
new user accounts on the system.

Analysis:
This change adds the api for the user creation on BIG-IP. With this
patch you will be able to CRUD users.

Tests:
- test/functional/auth/test_user.py
- f5/bigip/tm/auth/test/test_user.py
