### PR TITLE
Add file upload (image and other) to SDK

### DIFF
--- a/f5/bigip/__init__.py
+++ b/f5/bigip/__init__.py
@@ -17,12 +17,14 @@
 #
 
 
+from f5.bigip.cm import Cm
 from f5.bigip.resource import OrganizingCollection
-from f5.bigip.tm.auth import Auth
-from f5.bigip.tm.cm import Cm
+from f5.bigip.shared import Shared
+from f5.bigip.tm.auth import Auth as TmAuth
+from f5.bigip.tm.cm import Cm as TmCm
 from f5.bigip.tm.ltm import Ltm
 from f5.bigip.tm.net import Net
-from f5.bigip.tm.shared import Shared
+from f5.bigip.tm.shared import Shared as TmShared
 from f5.bigip.tm.sys import Sys
 from f5.bigip.tm import Tm
 from f5.bigip.transaction import Transactions
@@ -41,7 +43,7 @@ class ManagementRoot(OrganizingCollection):
         iCRS = iControlRESTSession(username, password, timeout=timeout)
         # define _meta_data
         self._meta_data = {
-            'allowed_lazy_attributes': [Tm],
+            'allowed_lazy_attributes': [Tm, Cm, Shared],
             'hostname': hostname,
             'uri': 'https://%s:%s/mgmt/' % (hostname, port),
             'icr_session': iCRS,
@@ -65,10 +67,8 @@ class BigIP(ManagementRoot):
 
     This class is solely implemented for backwards compatibility.
     """
-
     def __init__(self, hostname, username, password, **kwargs):
         super(BigIP, self).__init__(hostname, username, password, **kwargs)
-        self._meta_data['uri'] =\
-            self._meta_data['uri'] + 'tm/'
+        self._meta_data['uri'] = self._meta_data['uri'] + 'tm/'
         self._meta_data['allowed_lazy_attributes'] =\
-            [Auth, Cm, Ltm, Net, Shared, Sys, Transactions]
+            [TmAuth, TmCm, Ltm, Net, TmShared, Sys, Transactions]

--- a/f5/bigip/cm/__init__.py
+++ b/f5/bigip/cm/__init__.py
@@ -1,3 +1,6 @@
+# coding=utf-8
+#
+"""Classes and functions for configuring BIG-IP"""
 # Copyright 2016 F5 Networks Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,10 +15,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-'''A base exception for all exceptions in this library.'''
+
+from f5.bigip.cm.autodeploy import Autodeploy
+from f5.bigip.resource import OrganizingCollection
 
 
-class F5SDKError(Exception):
-    '''Import and subclass this exception in all exceptions in this library.'''
-    def __init__(self, *args, **kwargs):
-        super(F5SDKError, self).__init__(*args, **kwargs)
+class Cm(OrganizingCollection):
+    """An organizing collection for CM resources."""
+    def __init__(self, bigip):
+        super(Cm, self).__init__(bigip)
+        self._meta_data['allowed_lazy_attributes'] = [
+            Autodeploy
+        ]

--- a/f5/bigip/cm/autodeploy/__init__.py
+++ b/f5/bigip/cm/autodeploy/__init__.py
@@ -1,0 +1,31 @@
+# coding=utf-8
+#
+"""Classes and functions for configuring BIG-IP"""
+# Copyright 2016 F5 Networks Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# from f5.bigip.cm.autodeploy.software_images import Software_Image_Downloads
+from f5.bigip.cm.autodeploy.software_images import Software_Image_Uploads
+from f5.bigip.resource import OrganizingCollection
+
+
+class Autodeploy(OrganizingCollection):
+    """An organizing collection for Autodeploy resources."""
+    def __init__(self, cm):
+        super(Autodeploy, self).__init__(cm)
+        self._meta_data['allowed_lazy_attributes'] = [
+            Software_Image_Uploads,
+            # Software_Image_Downloads
+        ]

--- a/f5/bigip/cm/autodeploy/software_images.py
+++ b/f5/bigip/cm/autodeploy/software_images.py
@@ -1,0 +1,103 @@
+# coding=utf-8
+#
+"""Classes and functions for configuring BIG-IP"""
+# Copyright 2016 F5 Networks Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import os
+
+from f5.bigip.mixins import FileUploadMixin
+from f5.bigip.resource import PathElement
+from f5.sdk_exception import F5SDKError
+
+
+class ImageFilesMustHaveDotISOExtension(F5SDKError):
+    def __init__(self, filename):
+        super(ImageFilesMustHaveDotISOExtension, self).__init__(filename)
+
+
+class Software_Image_Uploads(PathElement, FileUploadMixin):
+    """Software image upload resource."""
+    def __init__(self, autodeploy):
+        super(Software_Image_Uploads, self).__init__(autodeploy)
+
+    def upload_image(self, filepathname, **kwargs):
+        filename = os.path.basename(filepathname)
+        if os.path.splitext(filename)[-1] != '.iso':
+            raise ImageFilesMustHaveDotISOExtension(filename)
+        self.file_bound_uri = self._meta_data['uri'] + filename
+        self._upload(filepathname, **kwargs)
+#
+#
+# class Software_Image_Downloads(PathElement):
+#    """Software image download resource."""
+#    def __init__(self, autodeploy):
+#        super(Software_Image_Downloads, self).__init__(autodeploy)
+#
+#    def download_image(self, filepathname, **kwargs):
+#        filename = os.path.basename(filepathname)
+#        session = self._meta_data['icr_session']
+#        chunk_size = kwargs.pop('chunk_size', 512 * 1024)
+#        self.file_bound_uri = self._meta_data['uri'] + filename
+#        with open(filepathname, 'wb') as writefh:
+#            start = 0
+#            end = chunk_size - 1
+#            size = 0
+#            current_bytes = 0
+#
+#            while True:
+#                content_range = "%s-%s/%s" % (start, end, size)
+#                headers = {'Content-Range': content_range,
+#                           'Content-Type': 'application/octet-stream'}
+#                req_params = {'headers': headers,
+#                              'verify': False,
+#                              'stream': True}
+#                response = session.get(self.file_bound_uri,
+#                                       requests_params=req_params)
+#                if response.status_code == 200:
+#                    # If the size is zero, then this is the first time through
+#                    # the loop and we don't want to write data because we
+#                    # haven't yet figured out the total size of the file.
+#                    if size > 0:
+#                        current_bytes += chunk_size
+#                        for chunk in response.iter_content(chunk_size):
+#                            writefh.write(chunk)
+#
+#                # Once we've downloaded the entire file, we can break out of
+#                # the loop
+#                if end == size:
+#                    break
+#
+#                crange = response.headers['Content-Range']
+#
+#                #Determine the total number of bytes to read.
+#                if size == 0:
+#                    size = int(crange.split('/')[-1]) - 1
+#
+#                    # If the file is smaller than the chunk_size, the BigIP
+#                    # will return an HTTP 400. Adjust the chunk_size down to
+#                    # the total file size...
+#                    if chunk_size > size:
+#                        end = size
+#
+#                    # ...and pass on the rest of the code.
+#                    continue
+#
+#                start += chunk_size
+#
+#                if (current_bytes + chunk_size) > size:
+#                    end = size
+#                else:
+#                    end = start + chunk_size - 1

--- a/f5/bigip/cm/autodeploy/test/test_software_image_uploads.py
+++ b/f5/bigip/cm/autodeploy/test/test_software_image_uploads.py
@@ -1,0 +1,62 @@
+# Copyright 2016 F5 Networks Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import mock
+import pytest
+
+from f5.bigip.cm.autodeploy.software_images import\
+    ImageFilesMustHaveDotISOExtension
+from f5.bigip import ManagementRoot
+
+
+CHUNKSIZE = 20
+
+
+def test_software_image_uploads_80a(tmpdir):
+    filepath = tmpdir.mkdir('testdir').join('eightya.iso')
+    filepath.write(80*'a')
+    mr = ManagementRoot('FAKENETLOC', 'FAKENAME', 'FAKEPASSWORD')
+    mr._meta_data['icr_session'] = mock.MagicMock()
+    sius = mr.cm.autodeploy.software_image_uploads
+    sius.upload_image(str(filepath), chunk_size=CHUNKSIZE)
+    session_mock = mr._meta_data['icr_session']
+    for i in range(4):
+        d = session_mock.post.call_args_list[i][1]['requests_params']['data']
+        assert d == 'a'*CHUNKSIZE
+
+
+def test_software_image_uploads_70a(tmpdir):
+    filepath = tmpdir.mkdir('testdir').join('seventya.iso')
+    filepath.write(70*'a')
+    mr = ManagementRoot('FAKENETLOC', 'FAKENAME', 'FAKEPASSWORD')
+    mr._meta_data['icr_session'] = mock.MagicMock()
+    sius = mr.cm.autodeploy.software_image_uploads
+    session_mock = mr._meta_data['icr_session']
+    sius.upload_image(str(filepath), chunk_size=CHUNKSIZE)
+    for i in range(3):
+        print(i)
+        d = session_mock.post.call_args_list[i][1]['requests_params']['data']
+        assert d == 'a'*CHUNKSIZE
+    lchunk = session_mock.post.call_args_list[3][1]['requests_params']['data']
+    assert 10*'a' == lchunk
+
+
+def test_non_ISO_extension(tmpdir):
+    filepath = tmpdir.mkdir('testdir').join('wrong.name')
+    mr = ManagementRoot('FAKENETLOC', 'FAKENAME', 'FAKEPASSWORD')
+    sius = mr.cm.autodeploy.software_image_uploads
+    with pytest.raises(ImageFilesMustHaveDotISOExtension) as EIO:
+        sius.upload_image(str(filepath), chunk_size=CHUNKSIZE)
+    assert EIO.value.message == 'wrong.name'

--- a/f5/bigip/resource.py
+++ b/f5/bigip/resource.py
@@ -157,6 +157,7 @@ class PathElement(LazyAttributeMixin):
         self._meta_data = {
             'container': container,
             'bigip': container._meta_data['bigip'],
+            'icr_session': container._meta_data['icr_session'],
             'icontrol_version': container._meta_data['icontrol_version']
         }
         base_uri = self.__class__.__name__.lower() + '/'
@@ -362,12 +363,12 @@ class OrganizingCollection(ResourceBase):
     * provide a list of dictionaries that contain uri's to other
       resources on the device.
     """
-    def __init__(self, bigip):
+    def __init__(self, container):
         """Call this to construct an OC. It should be an attribute of BIG-IP®.
 
         :param bigip: all OCs are attributes of a BIG-IP® instance
         """
-        super(OrganizingCollection, self).__init__(bigip)
+        super(OrganizingCollection, self).__init__(container)
 
     def get_collection(self, **kwargs):
         """Call to obtain a list of the reference dicts in the instance `items`

--- a/f5/bigip/shared/__init__.py
+++ b/f5/bigip/shared/__init__.py
@@ -1,3 +1,6 @@
+# coding=utf-8
+#
+"""Classes and functions for configuring BIG-IP"""
 # Copyright 2016 F5 Networks Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,10 +15,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-'''A base exception for all exceptions in this library.'''
+
+from f5.bigip.resource import OrganizingCollection
+from f5.bigip.shared.file_transfer import File_Transfer
 
 
-class F5SDKError(Exception):
-    '''Import and subclass this exception in all exceptions in this library.'''
-    def __init__(self, *args, **kwargs):
-        super(F5SDKError, self).__init__(*args, **kwargs)
+class Shared(OrganizingCollection):
+    """An organizing collection for Shared resources."""
+    def __init__(self, mgmt):
+        super(Shared, self).__init__(mgmt)
+        self._meta_data['allowed_lazy_attributes'] = [
+            File_Transfer
+        ]

--- a/f5/bigip/shared/file_transfer.py
+++ b/f5/bigip/shared/file_transfer.py
@@ -1,0 +1,50 @@
+# coding=utf-8
+#
+"""Classes and functions for configuring BIG-IP"""
+# Copyright 2016 F5 Networks Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import os
+
+from f5.bigip.mixins import FileUploadMixin
+from f5.bigip.resource import PathElement
+from f5.sdk_exception import F5SDKError
+
+
+class FileMustNotHaveDotISOExtension(F5SDKError):
+    def __init__(self, filename):
+        super(FileMustNotHaveDotISOExtension, self).__init__(filename)
+
+
+class File_Transfer(PathElement):
+    """A PathElement for File_Transfer resources."""
+    def __init__(self, shared):
+        super(File_Transfer, self).__init__(shared)
+        self._meta_data['allowed_lazy_attributes'] = [
+            Uploads
+        ]
+
+
+class Uploads(PathElement, FileUploadMixin):
+    """A file upload resource."""
+    def __init__(self, file_transfer):
+        super(Uploads, self).__init__(file_transfer)
+
+    def upload_file(self, filepathname, **kwargs):
+        filename = os.path.basename(filepathname)
+        if os.path.splitext(filename)[-1] == '.iso':
+            raise FileMustNotHaveDotISOExtension(filename)
+        self.file_bound_uri = self._meta_data['uri'] + filename
+        self._upload(filepathname, **kwargs)

--- a/f5/bigip/shared/test/test_file_uploads.py
+++ b/f5/bigip/shared/test/test_file_uploads.py
@@ -1,0 +1,60 @@
+# Copyright 2016 F5 Networks Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import mock
+
+import pytest
+
+from f5.bigip import ManagementRoot
+from f5.bigip.shared.file_transfer import FileMustNotHaveDotISOExtension
+
+
+def test_file_upload_80a(tmpdir):
+    filepath = tmpdir.mkdir('testdir').join('eightya.txt')
+    filepath.write(80*'a')
+    mr = ManagementRoot('FAKENETLOC', 'FAKENAME', 'FAKEPASSWORD')
+    mr._meta_data['icr_session'] = mock.MagicMock()
+    ftu = mr.shared.file_transfer.uploads
+    ftu.upload_file(filepath.__str__(), chunk_size=20)
+    session_mock = mr._meta_data['icr_session']
+    for i in range(4):
+        d = session_mock.post.call_args_list[i][1]['requests_params']['data']
+        assert d == 'aaaaaaaaaaaaaaaaaaaa'
+
+
+def test_file_upload_70a(tmpdir):
+    filepath = tmpdir.mkdir('testdir').join('seventya.txt')
+    filepath.write(70*'a')
+    mr = ManagementRoot('FAKENETLOC', 'FAKENAME', 'FAKEPASSWORD')
+    mr._meta_data['icr_session'] = mock.MagicMock()
+    ftu = mr.shared.file_transfer.uploads
+    ftu.upload_file(filepath.__str__(), chunk_size=20)
+    session_mock = mr._meta_data['icr_session']
+    for i in range(3):
+        print(i)
+        d = session_mock.post.call_args_list[i][1]['requests_params']['data']
+        assert d == 'aaaaaaaaaaaaaaaaaaaa'
+    lchunk = session_mock.post.call_args_list[3][1]['requests_params']['data']
+    assert 10*'a' == lchunk
+
+
+def test_ISO_extension(tmpdir):
+    filepath = tmpdir.mkdir('testdir').join('wrongname.iso')
+    filepath.write('fake')
+    mr = ManagementRoot('FAKENETLOC', 'FAKENAME', 'FAKEPASSWORD')
+    ftu = mr.shared.file_transfer.uploads
+    with pytest.raises(FileMustNotHaveDotISOExtension) as EIO:
+        ftu.upload_file(filepath.__str__(), chunk_size=21)
+    assert EIO.value.message == 'wrongname.iso'

--- a/f5/bigip/test/test_resource.py
+++ b/f5/bigip/test/test_resource.py
@@ -442,7 +442,8 @@ def test_collection_s():
     MC._meta_data = {
         'bigip': 'bigip',
         'uri': 'BASEURI/',
-        'icontrol_version': ''
+        'icontrol_version': '',
+        'icr_session': 'FAKEICRSESSION'
     }
     tc_s = Under_s(MC)
     assert tc_s._meta_data['uri'] == 'BASEURI/under/'

--- a/f5/bigip/tm/cm/__init__.py
+++ b/f5/bigip/tm/cm/__init__.py
@@ -39,8 +39,8 @@ from f5.bigip.tm.cm.trust_domain import Trust_Domains
 
 class Cm(OrganizingCollection, CommandExecutionMixin):
     """BIG-IP® Cluster Organizing Collection."""
-    def __init__(self, tm):
-        super(Cm, self).__init__(tm)
+    def __init__(self, cm):
+        super(Cm, self).__init__(cm)
         self._meta_data['allowed_lazy_attributes'] = [
             Devices, Device_Groups, Traffic_Groups, Trust_Domains,
             Sync_Status, Add_To_Trust, Remove_From_Trust,


### PR DESCRIPTION
Issues:
Fixes #346

Problem: file upload URIs weren't implemented

Analysis:  Now they are by porting parts of this example:

https://devcentral.f5.com/articles/demystifying-icontrol-rest-part-5-transferring-files?adbsc=social_default55359446&adbid=666661582995255298&adbpl=tw&adbpr=8232052

Tests: bigip/cm/autodeploy/test and bigip/shared/test
