### PR TITLE
Unnamedresource.fixes command fixes2

### DIFF
--- a/f5/bigip/__init__.py
+++ b/f5/bigip/__init__.py
@@ -45,6 +45,7 @@ class ManagementRoot(OrganizingCollection):
         self._meta_data = {
             'allowed_lazy_attributes': [Tm, Cm, Shared],
             'hostname': hostname,
+            'port': port,
             'uri': 'https://%s:%s/mgmt/' % (hostname, port),
             'icr_session': iCRS,
             'device_name': None,

--- a/f5/bigip/mixins.py
+++ b/f5/bigip/mixins.py
@@ -172,10 +172,6 @@ class UnnamedResourceMixin(object):
         return self
 
     def _get_meta_data_uri(self):
-        endpoint = self.__class__.__name__.lower()
-        return self._meta_data['container']._meta_data['uri'] + endpoint + '/'
-
-    def _get_meta_data_uri_hyphens(self):
         endpoint = self.__class__.__name__.lower().replace('_', '-')
         return self._meta_data['container']._meta_data['uri'] + endpoint + '/'
 
@@ -274,3 +270,19 @@ class FileUploadMixin(object):
                               'verify': False}
                 session.post(self.file_bound_uri, requests_params=req_params)
                 start += current_bytes
+
+
+class DeviceMixin(object):
+    '''Manage BigIP device cluster in a general way.'''
+
+    def get_device_info(self, bigip):
+        '''Get device information about a specific BigIP device.
+
+        :param bigip: bigip object --- device to inspect
+        :returns: bigip object
+        '''
+
+        coll = bigip.cm.devices.get_collection()
+        device = [device for device in coll if device.selfDevice == 'true']
+        assert len(device) == 1
+        return device[0]

--- a/f5/bigip/tm/auth/password_policy.py
+++ b/f5/bigip/tm/auth/password_policy.py
@@ -47,4 +47,4 @@ class Password_Policy(UnnamedResourceMixin, Resource):
         self._meta_data['required_load_parameters'] = set()
         self._meta_data['required_json_kind'] = \
             'tm:auth:password-policy:password-policystate'
-        self._meta_data['uri'] = self._get_meta_data_uri_hyphens()
+        self._meta_data['uri'] = self._get_meta_data_uri()

--- a/f5/bigip/tm/cm/trust.py
+++ b/f5/bigip/tm/cm/trust.py
@@ -31,7 +31,7 @@ class Add_To_Trust(UnnamedResourceMixin, ExclusiveAttributesMixin,
 
     def __init__(self, cm):
         super(Add_To_Trust, self).__init__(cm)
-        self._meta_data['uri'] = self._get_meta_data_uri_hyphens()
+        self._meta_data['uri'] = self._get_meta_data_uri()
         self._meta_data['exclusive_attributes'].append(
             ('caDevice', 'nonCaDevice'))
         self._meta_data['required_creation_parameters'].update(
@@ -54,7 +54,7 @@ class Remove_From_Trust(UnnamedResourceMixin, CommandExecutionMixin, Resource):
 
     def __init__(self, cm):
         super(Remove_From_Trust, self).__init__(cm)
-        self._meta_data['uri'] = self._get_meta_data_uri_hyphens()
+        self._meta_data['uri'] = self._get_meta_data_uri()
         self._meta_data['required_creation_parameters'].update(
             ('deviceName',))
         self._meta_data['required_json_kind'] = \

--- a/f5/bigip/tm/shared/bigip_failover_state.py
+++ b/f5/bigip/tm/shared/bigip_failover_state.py
@@ -47,8 +47,7 @@ class Bigip_Failover_State(UnnamedResourceMixin, Resource):
         super(Bigip_Failover_State, self).__init__(shared)
         self._meta_data['required_load_parameters'] = set()
         self._meta_data['required_json_kind'] = ''
-        uri = self._get_meta_data_uri()
-        self._meta_data['uri'] = uri.replace('_', '-')
+        self._meta_data['uri'] = self._get_meta_data_uri_hyphens()
 
     def update(self, **kwargs):
         '''Update is not supported for BIG-IP® failover state.

--- a/f5/bigip/tm/shared/bigip_failover_state.py
+++ b/f5/bigip/tm/shared/bigip_failover_state.py
@@ -47,7 +47,7 @@ class Bigip_Failover_State(UnnamedResourceMixin, Resource):
         super(Bigip_Failover_State, self).__init__(shared)
         self._meta_data['required_load_parameters'] = set()
         self._meta_data['required_json_kind'] = ''
-        self._meta_data['uri'] = self._get_meta_data_uri_hyphens()
+        self._meta_data['uri'] = self._get_meta_data_uri()
 
     def update(self, **kwargs):
         '''Update is not supported for BIG-IP® failover state.

--- a/f5/bigip/tm/shared/licensing.py
+++ b/f5/bigip/tm/shared/licensing.py
@@ -27,6 +27,7 @@ REST Kind
 """
 
 from f5.bigip.mixins import UnnamedResourceMixin
+from f5.bigip.mixins import UnsupportedMethod
 from f5.bigip.resource import PathElement
 from f5.bigip.resource import Resource
 
@@ -81,7 +82,7 @@ class Activation(UnnamedResourceMixin, Resource):
 
         :raises: UnsupportedOperation
         '''
-        raise self.UnsupportedMethod(
+        raise UnsupportedMethod(
             "%s does not support the update method" % self.__class__.__name__
         )
 
@@ -111,6 +112,6 @@ class Registration(UnnamedResourceMixin, Resource):
 
         :raises: UnsupportedOperation
         '''
-        raise self.UnsupportedMethod(
+        raise UnsupportedMethod(
             "%s does not support the update method" % self.__class__.__name__
         )

--- a/f5/bigip/tm/sys/config.py
+++ b/f5/bigip/tm/sys/config.py
@@ -33,11 +33,9 @@ from f5.bigip.resource import Resource
 class Config(UnnamedResourceMixin, Resource):
     def __init__(self, sys):
         super(Config, self).__init__(sys)
-        endpoint = self.__class__.__name__.lower()
         self._meta_data['allowed_lazy_attributes'] = []
         self._meta_data['attribute_registry'] = {}
-        self._meta_data['uri'] =\
-            self._meta_data['container']._meta_data['uri'] + endpoint + '/'
+        self._meta_data['uri'] = self._get_meta_data_uri()
 
     def update(self, **kwargs):
         '''Update is not supported for Config

--- a/f5/bigip/tm/sys/failover.py
+++ b/f5/bigip/tm/sys/failover.py
@@ -48,12 +48,10 @@ class Failover(UnnamedResourceMixin, Resource):
     '''
     def __init__(self, sys):
         super(Failover, self).__init__(sys)
-        endpoint = self.__class__.__name__.lower()
         self._meta_data['required_load_parameters'] = set()
         self._meta_data['required_json_kind'] =\
             'tm:sys:failover:failoverstats'
-        self._meta_data['uri'] =\
-            self._meta_data['container']._meta_data['uri'] + endpoint + '/'
+        self._meta_data['uri'] = self._get_meta_data_uri()
 
     def update(self, **kwargs):
         '''Update is not supported for Failover

--- a/f5/bigip/tm/sys/global_settings.py
+++ b/f5/bigip/tm/sys/global_settings.py
@@ -47,4 +47,4 @@ class Global_Settings(UnnamedResourceMixin, Resource):
         self._meta_data['required_load_parameters'] = set()
         self._meta_data['required_json_kind'] =\
             'tm:sys:global-settings:global-settingsstate'
-        self._meta_data['uri'] = self._get_meta_data_uri_hyphens()
+        self._meta_data['uri'] = self._get_meta_data_uri()

--- a/f5/bigip/tm/sys/global_settings.py
+++ b/f5/bigip/tm/sys/global_settings.py
@@ -44,9 +44,7 @@ class Global_Settings(UnnamedResourceMixin, Resource):
     """
     def __init__(self, sys):
         super(Global_Settings, self).__init__(sys)
-        endpoint = self.__class__.__name__.lower().replace('_', '-')
         self._meta_data['required_load_parameters'] = set()
         self._meta_data['required_json_kind'] =\
             'tm:sys:global-settings:global-settingsstate'
-        self._meta_data['uri'] =\
-            self._meta_data['container']._meta_data['uri'] + endpoint + '/'
+        self._meta_data['uri'] = self._get_meta_data_uri_hyphens()

--- a/f5/bigip/tm/sys/ntp.py
+++ b/f5/bigip/tm/sys/ntp.py
@@ -42,11 +42,9 @@ class Ntp(UnnamedResourceMixin, Resource):
     """
     def __init__(self, sys):
         super(Ntp, self).__init__(sys)
-        endpoint = self.__class__.__name__.lower()
         self._meta_data['required_load_parameters'] = set()
         self._meta_data['required_json_kind'] = 'tm:sys:ntp:ntpstate'
-        self._meta_data['uri'] =\
-            self._meta_data['container']._meta_data['uri'] + endpoint + '/'
+        self._meta_data['uri'] = self._get_meta_data_uri()
         self._meta_data['attribute_registry'] = {
             'tm:sys:ntp:restrict:restrictcollectionstate': Restricts
         }

--- a/f5/bigip/tm/sys/performance.py
+++ b/f5/bigip/tm/sys/performance.py
@@ -59,8 +59,7 @@ class All_Stats(UnnamedResourceMixin, Resource):
         self._meta_data['required_load_parameters'] = set()
         self._meta_data['required_json_kind'] =\
             'tm:sys:performance:all-stats:all-statsstats'
-        self._meta_data['uri'] =\
-            self._get_meta_data_uri() + "all-stats/"
+        self._meta_data['uri'] = self._get_meta_data_uri()
 
     def update(self, **kwargs):
         '''Update is not supported for statistics.

--- a/f5/bigip/tm/sys/performance.py
+++ b/f5/bigip/tm/sys/performance.py
@@ -38,7 +38,7 @@ class Performance(Collection):
     def __init__(self, sys):
         super(Performance, self).__init__(sys)
         self._meta_data['allowed_lazy_attributes'] = [All_Stats]
-        self._meta_data['uri'] =\
+        self._meta_data['uri'] = \
             self._meta_data['container']._meta_data['uri'] + "performance/"
 
     def get_collection(self):
@@ -60,7 +60,7 @@ class All_Stats(UnnamedResourceMixin, Resource):
         self._meta_data['required_json_kind'] =\
             'tm:sys:performance:all-stats:all-statsstats'
         self._meta_data['uri'] =\
-            self._meta_data['container']._meta_data['uri'] + "all-stats/"
+            self._get_meta_data_uri() + "all-stats/"
 
     def update(self, **kwargs):
         '''Update is not supported for statistics.

--- a/test/functional/cm/test_device_group.py
+++ b/test/functional/cm/test_device_group.py
@@ -63,10 +63,11 @@ class TestDeviceGroup(object):
             request, bigip, name='test-group', partition='Common')
         devices = bigip.cm.devices.get_collection()
         this_device = devices[0]
+        assert this_device.selfDevice == 'true'
         d1 = dg1.devices_s.devices.create(
             name=this_device.name, partition=this_device.partition)
         assert len(dg1.devices_s.get_collection()) == 1
-        assert d1.name != this_device.name
+        assert d1.name == this_device.name
 
     def test_cm_sync_to_group(self, request, bigip):
         dg1, dgs = setup_device_group_test(

--- a/test/functional/shared/test_licensing.py
+++ b/test/functional/shared/test_licensing.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from pprint import pprint as pp
 import pytest
 
 from f5.bigip.mixins import UnsupportedMethod
@@ -33,5 +34,6 @@ class TestRegistration(object):
         assert hasattr(reg, 'generation')
 
     def test_update(self, request, bigip):
+        pp(bigip.shared.raw)
         with pytest.raises(UnsupportedMethod):
             bigip.shared.licensing.registration.update()

--- a/test/functional/sys/test_httpd.py
+++ b/test/functional/sys/test_httpd.py
@@ -13,15 +13,26 @@
 # limitations under the License.
 #
 
+import pytest
+
+
+@pytest.fixture
+def cleaner(request, bigip):
+    initial_httpd = bigip.sys.httpd.load()
+
+    def teardown():
+        initial_httpd.update()
+    request.addfinalizer(teardown)
+
 
 class TestHttpd(object):
-    def test_load(self, bigip):
+    def test_load(self, cleaner, bigip):
         httpd = bigip.sys.httpd.load()
-        assert httpd.maxClients == 10
+        assert httpd.maxClients == 20
         httpd.refresh()
-        assert httpd.maxClients == 10
+        assert httpd.maxClients == 20
 
-    def test_update(self, bigip):
+    def test_update(self, cleaner, bigip):
         httpd = bigip.sys.httpd.load()
         httpd.update(maxClients=10)
         assert httpd.maxClients == 10

--- a/test/functional/test_requests_params.py
+++ b/test/functional/test_requests_params.py
@@ -38,7 +38,6 @@ def test_get_collection(request, bigip, pool_factory, opt_release):
 
 
 def test_get_dollar_filtered_collection(request, bigip, pool_factory):
-    hostname = bigip._meta_data['hostname']
     if bigip.sys.folders.folder.exists(name='za', partition=''):
         bigip.sys.folders.folder.load(name='za', partition='')
     else:
@@ -51,4 +50,4 @@ def test_get_dollar_filtered_collection(request, bigip, pool_factory):
     rp = {'params': {'$filter': 'partition eq za'}}
     pools_in_za = bigip.ltm.pools.get_collection(requests_params=rp)
     muri = pools_in_za[0]._meta_data['uri']
-    assert muri == 'https://'+hostname+'/mgmt/tm/ltm/pool/~za~TEST/'
+    assert muri.endswith('/mgmt/tm/ltm/pool/~za~TEST/')


### PR DESCRIPTION
This version of the code:
1.  moves "hyphen" logic into the `_get_meta_data_uri` method.
2.  fixes _all_ test failures
3.  has a clean "on top of `0.1`" commit history 
