### PR TITLE
Dnsresolver.patch

### DIFF
--- a/f5/bigip/tm/net/__init__.py
+++ b/f5/bigip/tm/net/__init__.py
@@ -29,6 +29,7 @@ REST Kind
 
 from f5.bigip.resource import OrganizingCollection
 from f5.bigip.tm.net.arp import Arps
+from f5.bigip.tm.net.dns_resolver import Dns_Resolvers
 from f5.bigip.tm.net.fdb import Fdbs
 from f5.bigip.tm.net.interface import Interfaces
 from f5.bigip.tm.net.route import Routes
@@ -43,6 +44,7 @@ class Net(OrganizingCollection):
         super(Net, self).__init__(tm)
         self._meta_data['allowed_lazy_attributes'] = [
             Arps,
+            Dns_Resolvers,
             Fdbs,
             Interfaces,
             Routes,

--- a/f5/bigip/tm/net/dns_resolver.py
+++ b/f5/bigip/tm/net/dns_resolver.py
@@ -1,0 +1,51 @@
+# coding=utf-8
+#
+#  Copyright 2016 F5 Networks Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""BIG-IP® Network ARP module.
+
+REST URI
+    ``http://localhost/mgmt/tm/net/arp``
+
+GUI Path
+    ``Network --> Dns Resolvers``
+
+REST Kind
+    ``tm:net:dns:*``
+"""
+
+from f5.bigip.resource import Collection
+from f5.bigip.resource import Resource
+
+
+class Dns_Resolvers(Collection):
+    """BIG-IP® network Dns Resolver collection"""
+    def __init__(self, net):
+        super(Dns_Resolvers, self).__init__(net)
+        self._meta_data['allowed_lazy_attributes'] = [Dns_Resolver]
+        self._meta_data['attribute_registry'] = {
+            'tm:net:dns-resolver:dns-resolverstate': Dns_Resolver
+        }
+
+class Dns_Resolver(Resource):
+    """BIG-IP® Dns Resolver resource."""
+    def __init__(self, Dns_Resolvers):
+        super(Dns_Resolver, self).__init__(Dns_Resolvers)
+        fixed = self._meta_data['uri'].replace('_', '-')
+        self._meta_data['uri'] = fixed
+        self._meta_data['allowed_lazy_attributes'] = [Dns_Resolver]
+        self._meta_data['required_json_kind'] = \
+            'tm:net:dns-resolver:dns-resolverstate'

--- a/f5/bigip/tm/net/dns_resolver.py
+++ b/f5/bigip/tm/net/dns_resolver.py
@@ -35,17 +35,18 @@ class Dns_Resolvers(Collection):
     """BIG-IP® network Dns Resolver collection"""
     def __init__(self, net):
         super(Dns_Resolvers, self).__init__(net)
+        fixed = self._meta_data['uri'].replace('_', '-')
+        self._meta_data['uri'] = fixed
         self._meta_data['allowed_lazy_attributes'] = [Dns_Resolver]
         self._meta_data['attribute_registry'] = {
             'tm:net:dns-resolver:dns-resolverstate': Dns_Resolver
         }
 
+
 class Dns_Resolver(Resource):
     """BIG-IP® Dns Resolver resource."""
     def __init__(self, Dns_Resolvers):
         super(Dns_Resolver, self).__init__(Dns_Resolvers)
-        fixed = self._meta_data['uri'].replace('_', '-')
-        self._meta_data['uri'] = fixed
         self._meta_data['allowed_lazy_attributes'] = [Dns_Resolver]
         self._meta_data['required_json_kind'] = \
             'tm:net:dns-resolver:dns-resolverstate'

--- a/test/functional/tm/net/test_dns_resolver.py
+++ b/test/functional/tm/net/test_dns_resolver.py
@@ -13,34 +13,36 @@
 # limitations under the License.
 #
 
+
 def setup_test(request, bigip, name):
     def teardown():
-        if dns1.exists():
+        if dns1.exists(name=name):
             dns1.delete()
 
     request.addfinalizer(teardown)
     dc1 = bigip.net.dns_resolvers
     dr1 = dc1.dns_resolver
     dns1 = dr1.create(name=name)
-    return dr1, dns1
+    return dc1, dns1
+
 
 class TestDnsResolver(object):
     def test_CURDL(self, request, bigip):
 
         # Test create
-        dr1, dns1 = setup_test(request, bigip, name='test_dns_resolver')
+        dc1, dns1 = setup_test(request, bigip, name='test_dns_resolver')
         assert dns1.name == 'test_dns_resolver'
 
         # Test update
-        dns1.useTcp = 'No'
+        dns1.useTcp = 'no'
         dns1.update()
-        assert dns1.useTcp == 'No'
+        assert dns1.useTcp == 'no'
 
         # Test refresh
-        dns1.useTcp = 'Yes'
-        dns.refresh()
-        assert dns1.useTcp == 'No'
+        dns1.useTcp = 'yes'
+        dns1.refresh()
+        assert dns1.useTcp == 'no'
 
         # Test Load
-        dns2 = dr1.load(name='test_dns_resolver')
+        dns2 = dc1.dns_resolver.load(name='test_dns_resolver')
         assert dns2.useTcp == dns1.useTcp

--- a/test/functional/tm/net/test_dns_resolver.py
+++ b/test/functional/tm/net/test_dns_resolver.py
@@ -1,0 +1,46 @@
+# Copyright 2016 F5 Networks Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+def setup_test(request, bigip, name):
+    def teardown():
+        if dns1.exists():
+            dns1.delete()
+
+    request.addfinalizer(teardown)
+    dc1 = bigip.net.dns_resolvers
+    dr1 = dc1.dns_resolver
+    dns1 = dr1.create(name=name)
+    return dr1, dns1
+
+class TestDnsResolver(object):
+    def test_CURDL(self, request, bigip):
+
+        # Test create
+        dr1, dns1 = setup_test(request, bigip, name='test_dns_resolver')
+        assert dns1.name == 'test_dns_resolver'
+
+        # Test update
+        dns1.useTcp = 'No'
+        dns1.update()
+        assert dns1.useTcp == 'No'
+
+        # Test refresh
+        dns1.useTcp = 'Yes'
+        dns.refresh()
+        assert dns1.useTcp == 'No'
+
+        # Test Load
+        dns2 = dr1.load(name='test_dns_resolver')
+        assert dns2.useTcp == dns1.useTcp


### PR DESCRIPTION
Fixes #384 

What's this change do?
Implements API for DNS resolver configuration

Any background context?
DNS resolver was not configurable via the SDK, ability to configure the DNS resolver other than adding functionality, is a requirement for some LTM profiles, and lack of implementation would block #349 from implementation.

Where should the reviewer start?
tm/net/dns_resolver.py
test/functional/tm/net/test_dns_resolver.py
