### PR TITLE
Implement client-ssl profile creation

### DIFF
--- a/f5/bigip/cm/autodeploy/test/test_software_image_uploads.py
+++ b/f5/bigip/cm/autodeploy/test/test_software_image_uploads.py
@@ -33,7 +33,7 @@ def test_software_image_uploads_80a(tmpdir):
     sius.upload_image(str(filepath), chunk_size=CHUNKSIZE)
     session_mock = mr._meta_data['icr_session']
     for i in range(4):
-        d = session_mock.post.call_args_list[i][1]['requests_params']['data']
+        d = session_mock.post.call_args_list[i][1]['data']
         assert d == 'a'*CHUNKSIZE
 
 
@@ -47,9 +47,9 @@ def test_software_image_uploads_70a(tmpdir):
     sius.upload_image(str(filepath), chunk_size=CHUNKSIZE)
     for i in range(3):
         print(i)
-        d = session_mock.post.call_args_list[i][1]['requests_params']['data']
+        d = session_mock.post.call_args_list[i][1]['data']
         assert d == 'a'*CHUNKSIZE
-    lchunk = session_mock.post.call_args_list[3][1]['requests_params']['data']
+    lchunk = session_mock.post.call_args_list[3][1]['data']
     assert 10*'a' == lchunk
 
 

--- a/f5/bigip/mixins.py
+++ b/f5/bigip/mixins.py
@@ -16,6 +16,7 @@
 #
 # NOTE:  Code taken from Effective Python Item 26
 
+import logging
 import os
 
 from f5.sdk_exception import F5SDKError
@@ -245,6 +246,7 @@ class CommandExecutionMixin(object):
 
 class FileUploadMixin(object):
     def _upload(self, filepathname, **kwargs):
+        requests_params = self._handle_requests_params(kwargs)
         session = self._meta_data['icr_session']
         chunk_size = kwargs.pop('chunk_size', 512 * 1024)
         size = os.path.getsize(filepathname)
@@ -263,8 +265,11 @@ class FileUploadMixin(object):
                 headers = {
                     'Content-Range': '%s-%s/%s' % (start, end - 1, size),
                     'Content-Type': 'application/octet-stream'}
-                req_params = {'data': file_slice,
-                              'headers': headers,
-                              'verify': False}
-                session.post(self.file_bound_uri, requests_params=req_params)
+                data = {'data': file_slice,
+                        'headers': headers,
+                        'verify': False}
+                logging.debug(data)
+                requests_params.update(data)
+                session.post(self.file_bound_uri,
+                             **requests_params)
                 start += current_bytes

--- a/f5/bigip/shared/test/test_file_uploads.py
+++ b/f5/bigip/shared/test/test_file_uploads.py
@@ -18,7 +18,8 @@ import mock
 import pytest
 
 from f5.bigip import ManagementRoot
-from f5.bigip.shared.file_transfer import FileMustNotHaveDotISOExtension
+from f5.bigip.shared.file_transfer import\
+    FileMustNotHaveDotISOExtension
 
 
 def test_file_upload_80a(tmpdir):
@@ -30,7 +31,7 @@ def test_file_upload_80a(tmpdir):
     ftu.upload_file(filepath.__str__(), chunk_size=20)
     session_mock = mr._meta_data['icr_session']
     for i in range(4):
-        d = session_mock.post.call_args_list[i][1]['requests_params']['data']
+        d = session_mock.post.call_args_list[i][1]['data']
         assert d == 'aaaaaaaaaaaaaaaaaaaa'
 
 
@@ -44,9 +45,9 @@ def test_file_upload_70a(tmpdir):
     session_mock = mr._meta_data['icr_session']
     for i in range(3):
         print(i)
-        d = session_mock.post.call_args_list[i][1]['requests_params']['data']
+        d = session_mock.post.call_args_list[i][1]['data']
         assert d == 'aaaaaaaaaaaaaaaaaaaa'
-    lchunk = session_mock.post.call_args_list[3][1]['requests_params']['data']
+    lchunk = session_mock.post.call_args_list[3][1]['data']
     assert 10*'a' == lchunk
 
 

--- a/f5/bigip/tm/ltm/__init__.py
+++ b/f5/bigip/tm/ltm/__init__.py
@@ -35,6 +35,7 @@ from f5.bigip.tm.ltm.node import Nodes
 from f5.bigip.tm.ltm.persistence import Persistences
 from f5.bigip.tm.ltm.policy import Policys
 from f5.bigip.tm.ltm.pool import Pools
+from f5.bigip.tm.ltm.profile import Profile
 from f5.bigip.tm.ltm.rule import Rules
 from f5.bigip.tm.ltm.snat import Snats
 from f5.bigip.tm.ltm.snat_translation import Snat_Translations
@@ -54,6 +55,7 @@ class Ltm(OrganizingCollection):
             Persistences,
             Policys,
             Pools,
+            Profile,
             Rules,
             Snats,
             Snatpools,

--- a/f5/bigip/tm/ltm/profile.py
+++ b/f5/bigip/tm/ltm/profile.py
@@ -1,0 +1,64 @@
+# coding=utf-8
+#
+# Copyright 2016 F5 Networks Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+"""BIG-IP® system config module
+
+REST URI
+    ``http://localhost/mgmt/tm/ltm/profile``
+
+GUI Path
+    ``System``
+
+REST Kind
+    ``tm:sys:*``
+"""
+import logging
+
+from f5.bigip.resource import Collection
+from f5.bigip.resource import OrganizingCollection
+from f5.bigip.resource import Resource
+
+
+class Profile(OrganizingCollection):
+    def __init__(self, ltm):
+        super(Profile, self).__init__(ltm)
+        self._meta_data['allowed_lazy_attributes'] = [
+            Client_Ssls
+        ]
+
+
+class Client_Ssls(Collection):
+    def __init__(self, profile):
+        super(Client_Ssls, self).__init__(profile)
+        self._meta_data['allowed_lazy_attributes'] = [
+            Client_Ssl
+        ]
+        self._meta_data['attribute_registry'] =\
+            {'tm:ltm:profile:client-ssl:client-sslstate': Client_Ssl}
+
+
+class Client_Ssl(Resource):
+    def __init__(self, client_ssls):
+        super(Client_Ssl, self).__init__(client_ssls)
+        self._meta_data['required_json_kind'] =\
+            'tm:ltm:profile:client-ssl:client-sslstate'
+
+    def create(self, certname, keyname):
+        payload = {"name": certname[:-4],
+                   "cert": certname,
+                   "key": keyname}
+        logging.debug(payload)
+        return self._create(**payload)

--- a/f5/bigip/tm/sys/__init__.py
+++ b/f5/bigip/tm/sys/__init__.py
@@ -30,6 +30,7 @@ REST Kind
 from f5.bigip.resource import OrganizingCollection
 from f5.bigip.tm.sys.application import Applications
 from f5.bigip.tm.sys.config import Config
+from f5.bigip.tm.sys.crypto import Crypto
 from f5.bigip.tm.sys.db import Dbs
 from f5.bigip.tm.sys.dns import Dns
 from f5.bigip.tm.sys.failover import Failover
@@ -46,6 +47,7 @@ class Sys(OrganizingCollection):
         super(Sys, self).__init__(tm)
         self._meta_data['allowed_lazy_attributes'] = [
             Config,
+            Crypto,
             Folders,
             Applications,
             Performances,

--- a/f5/bigip/tm/sys/crypto.py
+++ b/f5/bigip/tm/sys/crypto.py
@@ -1,0 +1,88 @@
+# coding=utf-8
+#
+# Copyright 2016 F5 Networks Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+"""BIG-IP® system config module
+
+REST URI
+    ``http://localhost/mgmt/tm/sys/config``
+
+GUI Path
+    N/A
+
+REST Kind
+    ``tm:sys:config:*``
+"""
+
+from f5.bigip.resource import Collection
+from f5.bigip.resource import OrganizingCollection
+from f5.bigip.resource import Resource
+
+
+class Crypto(OrganizingCollection):
+    def __init__(self, sys):
+        super(Crypto, self).__init__(sys)
+        self._meta_data['allowed_lazy_attributes'] = [
+            Certs,
+            Keys
+        ]
+
+
+class Keys(Collection):
+    def __init__(self, crypto):
+        super(Keys, self).__init__(crypto)
+        self._meta_data['allowed_lazy_attributes'] = [
+            Key
+        ]
+        self._meta_data['attribute_registry'] =\
+            {'tm:sys:crypto:key:keystate': Key}
+
+    def install_key(self, certfilename, keyfilename):
+        payload =\
+            {"from-local-file": "/var/config/rest/downloads/%s" % keyfilename,
+             "command": "install",
+             "name": certfilename[:-4]}
+        self._meta_data['icr_session'].post(self._meta_data['uri'],
+                                            json=payload)
+
+
+class Key(Resource):
+    def __init__(self, keys):
+        super(Key, self).__init__(keys)
+        self._meta_data['required_json_kind'] = 'tm:sys:crypto:key:keystate'
+
+
+class Certs(Collection):
+    def __init__(self, crypto):
+        super(Certs, self).__init__(crypto)
+        self._meta_data['allowed_lazy_attributes'] = [
+            Cert
+        ]
+        self._meta_data['attribute_registry'] =\
+            {'tm:sys:crypto:cert:certstate': Cert}
+
+    def install_cert(self, certfilename):
+        payload =\
+            {"from-local-file": "/var/config/rest/downloads/%s" % certfilename,
+             "command": "install",
+             "name": certfilename[:-4]}
+        self._meta_data['icr_session'].post(self._meta_data['uri'],
+                                            json=payload)
+
+
+class Cert(Resource):
+    def __init__(self, certs):
+        super(Cert, self).__init__(certs)
+        self._meta_data['required_json_kind'] = 'tm:sys:crypto:cert:certstate'

--- a/test/functional/ssl_profile_creation/test_ssl_profile_creation.py
+++ b/test/functional/ssl_profile_creation/test_ssl_profile_creation.py
@@ -1,0 +1,93 @@
+# Copyright 2016 F5 Networks Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+from pprint import pprint as pp
+import pytest
+
+from f5.bigip import ManagementRoot
+
+FAKE_CERT = """-----BEGIN CERTIFICATE-----
+MIIBozCCAQwCAQEwDQYJKoZIhvcNAQEFBQAwGjEYMBYGA1UEAxQPY2EtaW50QGFj
+bWUuY29tMB4XDTE2MDUxMTE2MjcyN1oXDTI2MDUwOTE2MjcyN1owGjEYMBYGA1UE
+AxQPc2VydmVyQGFjbWUuY29tMIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQCn
+48EdxKMaBvd2nBY4Pt3UI9OhWfDt0JHF/FnE0MOR1DYEP9WqlRlDorojVSignlne
+febsSOFxciUGkeYvGTycR58/aAcWfp6lz6gLoTydfi7/XdReQt4JLzH9f0HYdKzz
+z06PjNTOGKtcBipUQjAjtH8HRIfOyatIAiUAHHBrBwIDAQABMA0GCSqGSIb3DQEB
+BQUAA4GBACvhrSKPtZVMvTUz4I0oxpl85IeM6p2X1qNjlSreCtLLp8o55HF1BEdI
+gLdNgzCs1x9/Mi7ZIwA0FySS4s6E8hMA3OG5Z/42aKGCJyHybeoWXsiVYIwkQi/J
+7293ACoLewtjwaGAFeSijukgyHooJUkqWi/oG8qc+K2GwZ8yeYYi
+-----END CERTIFICATE-----"""
+
+FAKE_KEY = """-----BEGIN RSA PRIVATE KEY-----
+MIICXQIBAAKBgQCn48EdxKMaBvd2nBY4Pt3UI9OhWfDt0JHF/FnE0MOR1DYEP9Wq
+lRlDorojVSignlnefebsSOFxciUGkeYvGTycR58/aAcWfp6lz6gLoTydfi7/XdRe
+Qt4JLzH9f0HYdKzzz06PjNTOGKtcBipUQjAjtH8HRIfOyatIAiUAHHBrBwIDAQAB
+AoGBAIKTPZBEbkIA5xhlv1ZRdr/WeXNFe3/KtoWQhdTwNRrHPJfDeg+o1LRo7HIs
+emOppOXJb/+Xk1djWm6orKk27I6wgIGcLJv61jRq9mOG3Hlfs9ZSkVsQIqutUSVm
+amhp3uwK3KIk3k7yv16+VTGfsXsPWsT1oWd4CWmWNAjMol9JAkEA3IloSbt+orEf
+x36qv//jsq87gOr5eUmwXTySMHaxbXmkIjaCjZHAb70/kWewXZMoj7k6c1Pj9i3T
+Tdfhgl3eLQJBAMLjFS1xIqXKLeBzMjcBfVlDF/ZJa4e2EZd1OOJreGkllx3j23fU
+NBdsN71XGr16RuxkLo/4HozequTCh5fU4oMCQAfFG5SFc5e9z9XSg6eSF26jN+B5
+5uI8E2eli60DcYre30aJTx43xWTqcQPpeFBDsAkoSIPpr71rrecvNPXH4t0CQGGB
+JbZPlUsnZV6Xo/b7StCfDd0ODLugbxq87lHx/RN2WC3/M223gLx7S0Py0ZEdHWDm
+GpmzRO2r9gpv/VEMlKsCQQCV+EffCQ4wKBIYeCchdntop1/A9PWWCS+pjUNdIJNR
+CKxlxUfEZw9yNfLw9g0FKxrdSZiHCAw7fwN7s+CszjT4
+-----END RSA PRIVATE KEY-----"""
+
+
+@pytest.fixture
+def cleaner(request, symbols):
+    mr = ManagementRoot(symbols.bigip_netloc,
+                        symbols.bigip_username,
+                        symbols.bigip_password,
+                        port=symbols.bigip_port)
+    initsslclientprofiles = mr.tm.ltm.profile.client_ssls.get_collection()
+    initfullpaths = [iscp.fullPath for iscp in initsslclientprofiles]
+
+    def cleaner():
+        sslclientprofiles = mr.tm.ltm.profile.client_ssls.get_collection()
+        for sscp in sslclientprofiles:
+            pp(sscp.raw)
+            if sscp.fullPath not in initfullpaths:
+                sscp.delete()
+    request.addfinalizer(cleaner)
+
+
+def test_ssl_profile_creation(cleaner, symbols, tmpdir):
+    testdatadir = tmpdir.mkdir('testdir')
+    FAKEKEYFILENAME = 'fakekey.key'
+    CERTFILENAME = 'NEWTESTCLIENTPROFILENAME.crt'
+    certpath = testdatadir.join(CERTFILENAME)
+    certpath.write(FAKE_CERT)
+    keypath = testdatadir.join(FAKEKEYFILENAME)
+    keypath.write(FAKE_KEY)
+    mr = ManagementRoot(symbols.bigip_netloc,
+                        symbols.bigip_username,
+                        symbols.bigip_password,
+                        port=symbols.bigip_port)
+    uploader = mr.shared.file_transfer.uploads
+    cert_registrar = mr.tm.sys.crypto.certs
+    pp(cert_registrar.raw)
+    key_registrar = mr.tm.sys.crypto.keys
+    ssl_client_profile = mr.tm.ltm.profile.client_ssls.client_ssl
+    uploader.upload_file(str(certpath))
+    uploader.upload_file(str(keypath))
+    cert_registrar.install_cert(CERTFILENAME)
+    pp([cert.raw for cert in cert_registrar.get_collection()])
+    key_registrar.install_key(CERTFILENAME, FAKEKEYFILENAME)
+    pp([key.raw for key in key_registrar.get_collection()])
+    ssl_client_profile.create(certname='/Common/NEWTESTCLIENTPROFILENAME.crt',
+                              keyname='/Common/NEWTESTCLIENTPROFILENAME.key')
+    pp(ssl_client_profile.raw)


### PR DESCRIPTION
@caphrim007
Issues:
Fixes #49

Problem: The SDK didn't support ssl-client profile creation

Analysis: Add necessary code to support it.

Tests:
- f5/bigip/cm/autodeploy/test/test_software_image_uploads.py
- f5/bigip/shared/test/test_file_uploads.py
- test/functional/ssl_profile_creation/
