### PR TITLE
Ltm.profiles

### DIFF
--- a/f5/bigip/tm/ltm/__init__.py
+++ b/f5/bigip/tm/ltm/__init__.py
@@ -33,7 +33,6 @@ from f5.bigip.tm.ltm.monitor import Monitor
 from f5.bigip.tm.ltm.nat import Nats
 from f5.bigip.tm.ltm.node import Nodes
 from f5.bigip.tm.ltm.persistence import Persistences
-from f5.bigip.tm.ltm.profile import Profile
 from f5.bigip.tm.ltm.policy import Policys
 from f5.bigip.tm.ltm.pool import Pools
 from f5.bigip.tm.ltm.profile import Profile

--- a/f5/bigip/tm/ltm/__init__.py
+++ b/f5/bigip/tm/ltm/__init__.py
@@ -53,7 +53,7 @@ class Ltm(OrganizingCollection):
             Nats,
             Nodes,
             Persistences,
-            Profiles,
+            Profile,
             Policys,
             Pools,
             Rules,

--- a/f5/bigip/tm/ltm/__init__.py
+++ b/f5/bigip/tm/ltm/__init__.py
@@ -33,9 +33,9 @@ from f5.bigip.tm.ltm.monitor import Monitor
 from f5.bigip.tm.ltm.nat import Nats
 from f5.bigip.tm.ltm.node import Nodes
 from f5.bigip.tm.ltm.persistence import Persistences
-from f5.bigip.tm.ltm.profile import Profile
 from f5.bigip.tm.ltm.policy import Policys
 from f5.bigip.tm.ltm.pool import Pools
+from f5.bigip.tm.ltm.profile import Profile
 from f5.bigip.tm.ltm.rule import Rules
 from f5.bigip.tm.ltm.snat import Snats
 from f5.bigip.tm.ltm.snat_translation import Snat_Translations

--- a/f5/bigip/tm/ltm/__init__.py
+++ b/f5/bigip/tm/ltm/__init__.py
@@ -33,6 +33,7 @@ from f5.bigip.tm.ltm.monitor import Monitor
 from f5.bigip.tm.ltm.nat import Nats
 from f5.bigip.tm.ltm.node import Nodes
 from f5.bigip.tm.ltm.persistence import Persistences
+from f5.bigip.tm.ltm.profile import Profile
 from f5.bigip.tm.ltm.policy import Policys
 from f5.bigip.tm.ltm.pool import Pools
 from f5.bigip.tm.ltm.rule import Rules
@@ -52,6 +53,7 @@ class Ltm(OrganizingCollection):
             Nats,
             Nodes,
             Persistences,
+            Profiles,
             Policys,
             Pools,
             Rules,

--- a/f5/bigip/tm/ltm/profile.py
+++ b/f5/bigip/tm/ltm/profile.py
@@ -1094,6 +1094,14 @@ class Web_Security(Resource):
         raise UnsupportedOperation(
             "%s does not support the update method" % self.__class__.__name__
         )
+    def refresh(self, **kwargs):
+        """Refresh is not supported for Web Security
+
+        :raises: UnsupportedOperation
+        """
+        raise UnsupportedOperation(
+            "%s does not support the refresh method" % self.__class__.__name__
+        )
 
     def delete(self, **kwargs):
         """Delete is not supported for Web Security

--- a/f5/bigip/tm/ltm/profile.py
+++ b/f5/bigip/tm/ltm/profile.py
@@ -15,11 +15,23 @@
 # limitations under the License.
 #
 
+"""BIG-IP® LTM profile submodule.
+
+REST URI
+    ``http://localhost/mgmt/tm/ltm/profile/``
+
+GUI Path
+    ``Local Traffic --> Profiles``
+
+REST Kind
+    ``tm:ltm:profile*``
+"""
 
 from f5.bigip.resource import Collection
 from f5.bigip.resource import OrganizingCollection
 from f5.bigip.resource import Resource
 from f5.bigip.resource import UnsupportedOperation
+
 
 class Profile(OrganizingCollection):
     def __init__(self, ltm):
@@ -99,11 +111,15 @@ class Analytics(Resource):
     """BIG-IP® Analytics profile resource."""
     def __init__(self, Analytics_s):
         super(Analytics, self).__init__(Analytics_s)
-        self._meta_data['allowed_lazy_attributes'] = [Alerts_s, Traffic_Captures]
-        self._meta_data['required_json_kind'] = 'tm:ltm:profile:analytics:analyticsstate'
+        self._meta_data['allowed_lazy_attributes'] = [Alerts_s,
+                                                      Traffic_Captures]
+        self._meta_data['required_json_kind'] = \
+            'tm:ltm:profile:analytics:analyticsstate'
         self._meta_data['attribute_registry'] = \
             {'tm:ltm:profile:analytics:alerts:alertscollectionstate': Alerts_s,
-             'tm:ltm:profile:analytics:traffic-capture:traffic-capturecollectionstate': Traffic_Captures}
+             'tm:ltm:profile:analytics:traffic-capture:\
+             traffic-capturecollectionstate':
+                 Traffic_Captures}
 
 
 class Alerts_s(Collection):
@@ -121,7 +137,8 @@ class Traffic_Captures(Collection):
         super(Traffic_Captures, self).__init__(Analytics)
         self._meta_data['allowed_lazy_attributes'] = [Traffic_Capture]
         self._meta_data['attribute_registry'] = \
-            {'tm:ltm:profile:analytics:traffic-capture:traffic-capturestate': Traffic_Capture}
+            {'tm:ltm:profile:analytics:traffic-capture:\
+            traffic-capturestate': Traffic_Capture}
 
 
 class Alerts(Resource):
@@ -146,7 +163,8 @@ class Certificate_Authoritys(Collection):
         super(Certificate_Authoritys, self).__init__(profile)
         self._meta_data['allowed_lazy_attributes'] = [Certificate_Authority]
         self._meta_data['attribute_registry'] = \
-            {'tm:ltm:profile:certificate-authority:certificate-authoritystate': Certificate_Authority}
+            {'tm:ltm:profile:certificate-authority:\
+            certificate-authoritystate': Certificate_Authority}
 
 
 class Certificate_Authority(Resource):
@@ -163,7 +181,8 @@ class Classifications(Collection):
         super(Classifications, self).__init__(profile)
         self._meta_data['allowed_lazy_attributes'] = [Classification]
         self._meta_data['attribute_registry'] = \
-            {'tm:ltm:profile:classification:classificationstate' : Classification}
+            {'tm:ltm:profile:classification:\
+            classificationstate': Classification}
 
 
 class Classification(Resource):
@@ -206,7 +225,7 @@ class Client_Ldap(Resource):
     def __init__(self, Client_Ldaps):
         super(Client_Ldap, self).__init__(Client_Ldaps)
         self._meta_data['required_json_kind'] = \
-        'tm:ltm:profile:client-ldap:client-ldapstate'
+            'tm:ltm:profile:client-ldap:client-ldapstate'
 
 
 class Client_Ssls(Collection):
@@ -327,7 +346,7 @@ class Fasthttp(Resource):
     def __init__(self, Fasthttps):
         super(Fasthttp, self).__init__(Fasthttps)
         self._meta_data['required_json_kind'] = \
-             'tm:ltm:profile:fasthttp:fasthttpstate'
+            'tm:ltm:profile:fasthttp:fasthttpstate'
 
 
 class Fastl4s(Collection):
@@ -344,7 +363,7 @@ class Fastl4(Resource):
     def __init__(self, Fastl4s):
         super(Fastl4, self).__init__(Fastl4s)
         self._meta_data['required_json_kind'] = \
-             'tm:ltm:profile:fastl4:fastl4state'
+            'tm:ltm:profile:fastl4:fastl4state'
 
 
 class Fixs(Collection):
@@ -361,7 +380,7 @@ class Fix(Resource):
     def __init__(self, Fixs):
         super(Fix, self).__init__(Fixs)
         self._meta_data['required_json_kind'] = \
-             'tm:ltm:profile:fix:fixstate'
+            'tm:ltm:profile:fix:fixstate'
 
 
 class Ftps(Collection):
@@ -378,7 +397,7 @@ class Ftp(Resource):
     def __init__(self, Ftps):
         super(Ftp, self).__init__(Ftps)
         self._meta_data['required_json_kind'] = \
-             'tm:ltm:profile:ftp:ftpstate'
+            'tm:ltm:profile:ftp:ftpstate'
 
 
 class Gtps(Collection):
@@ -395,7 +414,7 @@ class Gtp(Resource):
     def __init__(self, Gtps):
         super(Gtp, self).__init__(Gtps)
         self._meta_data['required_json_kind'] = \
-             'tm:ltm:profile:gtp:gtpstate'
+            'tm:ltm:profile:gtp:gtpstate'
 
 
 class Htmls(Collection):
@@ -412,7 +431,7 @@ class Html(Resource):
     def __init__(self, Htmls):
         super(Html, self).__init__(Htmls)
         self._meta_data['required_json_kind'] = \
-             'tm:ltm:profile:html:htmlstate'
+            'tm:ltm:profile:html:htmlstate'
 
 
 class Https(Collection):
@@ -429,7 +448,7 @@ class Http(Resource):
     def __init__(self, Https):
         super(Http, self).__init__(Https)
         self._meta_data['required_json_kind'] = \
-             'tm:ltm:profile:http:httpstate'
+            'tm:ltm:profile:http:httpstate'
 
 
 class Http_Compressions(Collection):
@@ -437,16 +456,19 @@ class Http_Compressions(Collection):
     def __init__(self, profile):
         super(Http_Compressions, self).__init__(profile)
         self._meta_data['allowed_lazy_attributes'] = [Http_Compression]
-        self._meta_data['attribute_registry'] = \
-            {'tm:ltm:profile:http-compression:http-compressionstate': Http_Compression}
+        temp = \
+            {'tm:ltm:profile:http-compression:http-compressionstate':
+                Http_Compression}
+        self._meta_data['attribute_registry'] = temp
 
 
 class Http_Compression(Resource):
     """BIG-IP® Http_Compression resource."""
     def __init__(self, Http_Compressions):
         super(Http_Compression, self).__init__(Http_Compressions)
-        self._meta_data['required_json_kind'] = \
-             'tm:ltm:profile:http-compression:http-compressionstate'
+        temp = \
+            'tm:ltm:profile:http-compression:http-compressionstate'
+        self._meta_data['required_json_kind'] = temp
 
 
 class Http2s(Collection):
@@ -463,7 +485,7 @@ class Http2(Resource):
     def __init__(self, Http2s):
         super(Http2, self).__init__(Http2s)
         self._meta_data['required_json_kind'] = \
-             'tm:ltm:profile:http2:http2state'
+            'tm:ltm:profile:http2:http2state'
 
 
 class Icaps(Collection):
@@ -480,7 +502,7 @@ class Icap(Resource):
     def __init__(self, Icaps):
         super(Icap, self).__init__(Icaps)
         self._meta_data['required_json_kind'] = \
-             'tm:ltm:profile:icap:icapstate'
+            'tm:ltm:profile:icap:icapstate'
 
 
 class Iiops(Collection):
@@ -497,7 +519,7 @@ class Iiop(Resource):
     def __init__(self, Iiops):
         super(Iiop, self).__init__(Iiops)
         self._meta_data['required_json_kind'] = \
-             'tm:ltm:profile:iiop:iiopstate'
+            'tm:ltm:profile:iiop:iiopstate'
 
 
 class Ipothers(Collection):
@@ -514,7 +536,7 @@ class Ipother(Resource):
     def __init__(self, Ipothers):
         super(Ipother, self).__init__(Ipothers)
         self._meta_data['required_json_kind'] = \
-             'tm:ltm:profile:ipother:ipotherstate'
+            'tm:ltm:profile:ipother:ipotherstate'
 
 
 class Mblbs(Collection):
@@ -531,7 +553,7 @@ class Mblb(Resource):
     def __init__(self, Mblbs):
         super(Mblb, self).__init__(Mblbs)
         self._meta_data['required_json_kind'] = \
-             'tm:ltm:profile:mblb:mblbstate'
+            'tm:ltm:profile:mblb:mblbstate'
 
 
 class Mssqls(Collection):
@@ -548,7 +570,7 @@ class Mssql(Resource):
     def __init__(self, Mssqls):
         super(Mssql, self).__init__(Mssqls)
         self._meta_data['required_json_kind'] = \
-             'tm:ltm:profile:mssql:mssqlstate'
+            'tm:ltm:profile:mssql:mssqlstate'
 
 
 class Ntlms(Collection):
@@ -565,7 +587,7 @@ class Ntlm(Resource):
     def __init__(self, Ntlms):
         super(Ntlm, self).__init__(Ntlms)
         self._meta_data['required_json_kind'] = \
-             'tm:ltm:profile:ntlm:ntlmstate'
+            'tm:ltm:profile:ntlm:ntlmstate'
 
 
 class Ocsp_Stapling_Params_s(Collection):
@@ -573,8 +595,10 @@ class Ocsp_Stapling_Params_s(Collection):
     def __init__(self, profile):
         super(Ocsp_Stapling_Params_s, self).__init__(profile)
         self._meta_data['allowed_lazy_attributes'] = [Ocsp_Stapling_Params]
-        self._meta_data['attribute_registry'] = \
-            {'tm:ltm:profile:ocsp-stapling-params:ocsp-stapling-paramsstate': Ocsp_Stapling_Params}
+        temp = \
+            {'tm:ltm:profile:ocsp-stapling-params:ocsp-stapling-paramsstate':
+                Ocsp_Stapling_Params}
+        self._meta_data['attribute_registry'] = temp
 
 
 class Ocsp_Stapling_Params(Resource):
@@ -582,9 +606,10 @@ class Ocsp_Stapling_Params(Resource):
 
     def __init__(self, Ocsp_Stapling_Params_s):
         super(Ocsp_Stapling_Params, self).__init__(Ocsp_Stapling_Params_s)
-        self._meta_data['exclusive_attributes'].append(('proxyServerPool', 'dnsResolver'))
+        self._meta_data['exclusive_attributes'].append(
+            ('proxyServerPool', 'dnsResolver'))
         self._meta_data['required_json_kind'] = \
-             'tm:ltm:profile:ocsp-stapling-params:ocsp-stapling-paramsstate'
+            'tm:ltm:profile:ocsp-stapling-params:ocsp-stapling-paramsstate'
 
     def create(self, **kwargs):
         """Create the resource on the BIG-IP®.
@@ -622,7 +647,7 @@ class One_Connect(Resource):
     def __init__(self, One_Connects):
         super(One_Connect, self).__init__(One_Connects)
         self._meta_data['required_json_kind'] = \
-             'tm:ltm:profile:one-connect:one-connectstate'
+            'tm:ltm:profile:one-connect:one-connectstate'
 
 
 class Pcps(Collection):
@@ -639,7 +664,7 @@ class Pcp(Resource):
     def __init__(self, Pcps):
         super(Pcp, self).__init__(Pcps)
         self._meta_data['required_json_kind'] = \
-             'tm:ltm:profile:pcp:pcpstate'
+            'tm:ltm:profile:pcp:pcpstate'
 
 
 class Pptps(Collection):
@@ -656,7 +681,7 @@ class Pptp(Resource):
     def __init__(self, Pptps):
         super(Pptp, self).__init__(Pptps)
         self._meta_data['required_json_kind'] = \
-             'tm:ltm:profile:pptp:pptpstate'
+            'tm:ltm:profile:pptp:pptpstate'
 
 
 class Qoes(Collection):
@@ -673,7 +698,7 @@ class Qoe(Resource):
     def __init__(self, Qoes):
         super(Qoe, self).__init__(Qoes)
         self._meta_data['required_json_kind'] = \
-             'tm:ltm:profile:qoe:qoestate'
+            'tm:ltm:profile:qoe:qoestate'
 
 
 class Radius_s(Collection):
@@ -690,17 +715,17 @@ class Radius(Resource):
     def __init__(self, Radius_s):
         super(Radius, self).__init__(Radius_s)
         self._meta_data['required_json_kind'] = \
-             'tm:ltm:profile:radius:radiusstate'
+            'tm:ltm:profile:radius:radiusstate'
 
 
-###Ramcache is special case needs some careful thought, supports get and DELETE only
 class Ramcaches(Collection):
     """BIG-IP® Ramcache profile collection."""
     pass
+
+
 class Ramcache(Resource):
     """BIG-IP® Ramcache resource."""
     pass
-###End of Ramcache
 
 
 class Request_Adapts(Collection):
@@ -717,7 +742,7 @@ class Request_Adapt(Resource):
     def __init__(self, Request_Adapts):
         super(Request_Adapt, self).__init__(Request_Adapts)
         self._meta_data['required_json_kind'] = \
-             'tm:ltm:profile:request-adapt:request-adaptstate'
+            'tm:ltm:profile:request-adapt:request-adaptstate'
 
 
 class Request_Logs(Collection):
@@ -734,7 +759,7 @@ class Request_Log(Resource):
     def __init__(self, Request_Logs):
         super(Request_Log, self).__init__(Request_Logs)
         self._meta_data['required_json_kind'] = \
-             'tm:ltm:profile:request-log:request-logstate'
+            'tm:ltm:profile:request-log:request-logstate'
 
 
 class Response_Adapts(Collection):
@@ -743,7 +768,8 @@ class Response_Adapts(Collection):
         super(Response_Adapts, self).__init__(profile)
         self._meta_data['allowed_lazy_attributes'] = [Response_Adapt]
         self._meta_data['attribute_registry'] = \
-            {'tm:ltm:profile:response-adapt:response-adaptstate': Response_Adapt}
+            {'tm:ltm:profile:response-adapt:\
+            response-adaptstate': Response_Adapt}
 
 
 class Response_Adapt(Resource):
@@ -751,7 +777,7 @@ class Response_Adapt(Resource):
     def __init__(self, Response_Adapts):
         super(Response_Adapt, self).__init__(Response_Adapts)
         self._meta_data['required_json_kind'] = \
-             'tm:ltm:profile:response-adapt:response-adaptstate'
+            'tm:ltm:profile:response-adapt:response-adaptstate'
 
 
 class Rewrites(Collection):
@@ -769,7 +795,7 @@ class Rewrite(Resource):
         super(Rewrite, self).__init__(Rewrites)
         self._meta_data['allowed_lazy_attributes'] = []
         self._meta_data['required_json_kind'] = \
-             'tm:ltm:profile:rewrite:rewritestate'
+            'tm:ltm:profile:rewrite:rewritestate'
         self._meta_data['attribute_registry'] = \
             {'tm:ltm:profile:rewrite:uri-rules:uri-rulescollectionstate':
              Uri_Rules_s}
@@ -783,12 +809,13 @@ class Uri_Rules_s(Collection):
         self._meta_data['attribute_registry'] = \
             {'tm:ltm:profile:rewrite:uri-rules:uri-rulesstate': Uri_Rules}
 
+
 class Uri_Rules(Resource):
     """BIG-IP® URI Rules resource"""
     def __init__(self, Uri_Rules_s):
         super(Uri_Rules, self).__init__(Uri_Rules_s)
         self._meta_data['required_json_kind'] = \
-            'tm:ltm:profile:analytics:alerts:alertsstate'
+            'tm:ltm:profile:rewrite:uri-rules:uri-rulesstate'
 
 
 class Rtsps(Collection):
@@ -805,7 +832,7 @@ class Rtsp(Resource):
     def __init__(self, Rtsps):
         super(Rtsp, self).__init__(Rtsps)
         self._meta_data['required_json_kind'] = \
-             'tm:ltm:profile:rtsp:rtspstate'
+            'tm:ltm:profile:rtsp:rtspstate'
 
 
 class Sctps(Collection):
@@ -822,7 +849,7 @@ class Sctp(Resource):
     def __init__(self, Sctps):
         super(Sctp, self).__init__(Sctps)
         self._meta_data['required_json_kind'] = \
-             'tm:ltm:profile:sctp:sctpstate'
+            'tm:ltm:profile:sctp:sctpstate'
 
 
 class Server_Ldaps(Collection):
@@ -839,7 +866,7 @@ class Server_Ldap(Resource):
     def __init__(self, Server_Ldaps):
         super(Server_Ldap, self).__init__(Server_Ldaps)
         self._meta_data['required_json_kind'] = \
-             'tm:ltm:profile:server-ldap:server-ldapstate'
+            'tm:ltm:profile:server-ldap:server-ldapstate'
 
 
 class Server_Ssls(Collection):
@@ -856,7 +883,7 @@ class Server_Ssl(Resource):
     def __init__(self, Server_Ssls):
         super(Server_Ssl, self).__init__(Server_Ssls)
         self._meta_data['required_json_kind'] = \
-             'tm:ltm:profile:server-ssl:server-sslstate'
+            'tm:ltm:profile:server-ssl:server-sslstate'
 
 
 class Sips(Collection):
@@ -873,7 +900,7 @@ class Sip(Resource):
     def __init__(self, Sips):
         super(Sip, self).__init__(Sips)
         self._meta_data['required_json_kind'] = \
-             'tm:ltm:profile:sip:sipstate'
+            'tm:ltm:profile:sip:sipstate'
 
 
 class Smtps(Collection):
@@ -894,16 +921,16 @@ class Smtp(Resource):
     def __init__(self, Smtps):
         super(Smtp, self).__init__(Smtps)
         self._meta_data['required_json_kind'] = \
-             'tm:ltm:profile:smtp:smtpstate'
+            'tm:ltm:profile:smtp:smtpstate'
 
 
 class Smtps_s(Collection):
     """BIG-IP® Smtps profile collection."""
     def __init__(self, profile):
         super(Smtps_s, self).__init__(profile)
-        self._meta_data['allowed_lazy_attributes'] = [Smtps]
+        self._meta_data['allowed_lazy_attributes'] = [SmtpS]
         self._meta_data['attribute_registry'] = \
-            {'tm:ltm:profile:smtps:smtpsstate': Smtps}
+            {'tm:ltm:profile:smtps:smtpsstate': SmtpS}
 
 
 class SmtpS(Resource):
@@ -911,7 +938,7 @@ class SmtpS(Resource):
     def __init__(self, Smtps_s):
         super(SmtpS, self).__init__(Smtps_s)
         self._meta_data['required_json_kind'] = \
-             'tm:ltm:profile:smtps:smtpsstate'
+            'tm:ltm:profile:smtps:smtpsstate'
 
 
 class Socks_s(Collection):
@@ -928,7 +955,7 @@ class Socks(Resource):
     def __init__(self, Socks_s):
         super(Socks, self).__init__(Socks_s)
         self._meta_data['required_json_kind'] = \
-             'tm:ltm:profile:socks:socksstate'
+            'tm:ltm:profile:socks:socksstate'
         self._meta_data['required_creation_parameters'].update(
             ('dnsResolver',))
 
@@ -947,7 +974,7 @@ class Spdy(Resource):
     def __init__(self, Spdys):
         super(Spdy, self).__init__(Spdys)
         self._meta_data['required_json_kind'] = \
-             'tm:ltm:profile:spdy:spdystate'
+            'tm:ltm:profile:spdy:spdystate'
 
 
 class Statistics_s(Collection):
@@ -964,7 +991,7 @@ class Statistics(Resource):
     def __init__(self, Statistics_s):
         super(Statistics, self).__init__(Statistics_s)
         self._meta_data['required_json_kind'] = \
-             'tm:ltm:profile:statistics:statisticsstate'
+            'tm:ltm:profile:statistics:statisticsstate'
 
 
 class Streams(Collection):
@@ -981,7 +1008,7 @@ class Stream(Resource):
     def __init__(self, Streams):
         super(Stream, self).__init__(Streams)
         self._meta_data['required_json_kind'] = \
-             'tm:ltm:profile:stream:streamstate'
+            'tm:ltm:profile:stream:streamstate'
 
 
 class Tcps(Collection):
@@ -998,7 +1025,7 @@ class Tcp(Resource):
     def __init__(self, Tcps):
         super(Tcp, self).__init__(Tcps)
         self._meta_data['required_json_kind'] = \
-             'tm:ltm:profile:tcp:tcpstate'
+            'tm:ltm:profile:tcp:tcpstate'
 
 
 class Tftps(Collection):
@@ -1015,7 +1042,7 @@ class Tftp(Resource):
     def __init__(self, Tftps):
         super(Tftp, self).__init__(Tftps)
         self._meta_data['required_json_kind'] = \
-             'tm:ltm:profile:tftp:tftpstate'
+            'tm:ltm:profile:tftp:tftpstate'
 
 
 class Udps(Collection):
@@ -1032,17 +1059,18 @@ class Udp(Resource):
     def __init__(self, Udps):
         super(Udp, self).__init__(Udps)
         self._meta_data['required_json_kind'] = \
-             'tm:ltm:profile:udp:udpstate'
+            'tm:ltm:profile:udp:udpstate'
 
-###This one does not allow GET, probably requires data to allow query
 
 class Wa_Caches(Collection):
     """BIG-IP® Wa_Cache profile collection."""
     pass
+
+
 class Wa_Cache(Resource):
     """BIG-IP® Wa_Cache resource."""
     pass
-###
+
 
 class Web_Accelerations(Collection):
     """BIG-IP® Web_Acceleration profile collection."""
@@ -1050,7 +1078,8 @@ class Web_Accelerations(Collection):
         super(Web_Accelerations, self).__init__(profile)
         self._meta_data['allowed_lazy_attributes'] = [Web_Acceleration]
         self._meta_data['attribute_registry'] = \
-            {'tm:ltm:profile:web-acceleration:web-accelerationstate': Web_Acceleration}
+            {'tm:ltm:profile:web-acceleration:\
+            web-accelerationstate': Web_Acceleration}
 
 
 class Web_Acceleration(Resource):
@@ -1058,7 +1087,7 @@ class Web_Acceleration(Resource):
     def __init__(self, Web_Accelerations):
         super(Web_Acceleration, self).__init__(Web_Accelerations)
         self._meta_data['required_json_kind'] = \
-             'tm:ltm:profile:web-acceleration:web-accelerationstate'
+            'tm:ltm:profile:web-acceleration:web-accelerationstate'
 
 
 class Web_Securitys(Collection):
@@ -1075,7 +1104,7 @@ class Web_Security(Resource):
     def __init__(self, Web_Securitys):
         super(Web_Security, self).__init__(Web_Securitys)
         self._meta_data['required_json_kind'] = \
-             'tm:ltm:profile:web-security:web-securitystate'
+            'tm:ltm:profile:web-security:web-securitystate'
 
     def create(self, **kwargs):
         """Create is not supported for Web Security
@@ -1086,7 +1115,6 @@ class Web_Security(Resource):
             "%s does not support the create method" % self.__class__.__name__
         )
 
-
     def update(self, **kwargs):
         """Update is not supported for Web Security
 
@@ -1095,6 +1123,7 @@ class Web_Security(Resource):
         raise UnsupportedOperation(
             "%s does not support the update method" % self.__class__.__name__
         )
+
     def refresh(self, **kwargs):
         """Refresh is not supported for Web Security
 
@@ -1128,5 +1157,4 @@ class Xml(Resource):
     def __init__(self, Xmls):
         super(Xml, self).__init__(Xmls)
         self._meta_data['required_json_kind'] = \
-             'tm:ltm:profile:xml:xmlstate'
-
+            'tm:ltm:profile:xml:xmlstate'

--- a/f5/bigip/tm/ltm/profile.py
+++ b/f5/bigip/tm/ltm/profile.py
@@ -301,6 +301,8 @@ class Dns_Logging(Resource):
         super(Dns_Logging, self).__init__(Dns_Loggings)
         self._meta_data['required_json_kind'] = \
             'tm:ltm:profile:dns-logging:dns-loggingstate'
+        self._meta_data['required_creation_parameters'].update(
+            ('logPublisher',))
 
 
 class Fasthttps(Collection):
@@ -914,6 +916,8 @@ class Socks(Resource):
         super(Socks, self).__init__(Socks_s)
         self._meta_data['required_json_kind'] = \
              'tm:ltm:profile:socks:socksstate'
+        self._meta_data['required_creation_parameters'].update(
+            ('dnsResolver',))
 
 
 class Spdys(Collection):

--- a/f5/bigip/tm/ltm/profile.py
+++ b/f5/bigip/tm/ltm/profile.py
@@ -1,0 +1,1069 @@
+# coding=utf-8
+#
+#  Copyright 2014-2016 F5 Networks Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+
+from f5.bigip.resource import Collection
+from f5.bigip.resource import OrganizingCollection
+from f5.bigip.resource import Resource
+from f5.bigip.resource import UnsupportedOperation
+
+class Profile(OrganizingCollection):
+    def __init__(self, ltm):
+        super(Profile, self).__init__(ltm)
+        self._meta_data['allowed_lazy_attributes'] = [
+            Analytics_s,
+            Certificate_Authoritys,
+            Classifications,
+            Client_Ldaps,
+            Client_Ssls,
+            Dhcpv4s,
+            Dhcpv6s,
+            Diameters,
+            Dns_s,
+            Dns_Loggings,
+            Fasthttps,
+            Fastl4s,
+            Fixs,
+            Ftps,
+            Gtps,
+            Htmls,
+            Https,
+            Http_Compressions,
+            Http2s,
+            Icaps,
+            Iiops,
+            Ipothers,
+            Mblbs,
+            Mssqls,
+            Ntlms,
+            Ocsp_Stapling_Params_s,
+            One_Connects,
+            Pcps,
+            Pptps,
+            Qoes,
+            Radius_s,
+            Ramcaches,
+            Request_Adapts,
+            Request_Logs,
+            Response_Adapts,
+            Rewrites,
+            Rtsps,
+            Sctps,
+            Server_Ldaps,
+            Server_Ssls,
+            Sips,
+            Smtps,
+            Smtps_s,
+            Socks_s,
+            Spdys,
+            Statistics_s,
+            Streams,
+            Tcps,
+            Tftps,
+            Udps,
+            Wa_Caches,
+            Web_Accelerations,
+            Web_Securitys,
+            Xmls]
+
+
+class Analytics_s(Collection):
+    """BIG-IP® Analytics profile collection.
+
+    .. note::
+         Profile and sub-collections
+         requires AVR provisioned.
+    """
+    def __init__(self, profile):
+        super(Analytics_s, self).__init__(profile)
+        self._meta_data['allowed_lazy_attributes'] = [Analytics]
+        self._meta_data['attribute_registry'] =\
+            {'tm:ltm:profile:analytics:analyticsstate': Analytics}
+
+
+class Analytics(Resource):
+    """BIG-IP® Analytics profile resource."""
+    def __init__(self, Analytics_s):
+        super(Analytics, self).__init__(Analytics_s)
+        self._meta_data['allowed_lazy_attributes'] = [Alerts_s, Traffic_Captures]
+        self._meta_data['required_json_kind'] = 'tm:ltm:profile:analytics:analyticsstate'
+        self._meta_data['attribute_registry'] = \
+            {'tm:ltm:profile:analytics:alerts:alertscollectionstate': Alerts_s,
+             'tm:ltm:profile:analytics:traffic-capture:traffic-capturecollectionstate': Traffic_Captures}
+
+
+class Alerts_s(Collection):
+    """BIG-IP® Alerts sub-collection."""
+    def __init__(self, Analytics):
+        super(Alerts_s, self).__init__(Analytics)
+        self._meta_data['allowed_lazy_attributes'] = [Alerts]
+        self._meta_data['attribute_registry'] = \
+            {'tm:ltm:profile:analytics:alerts:alertsstate': Alerts}
+
+
+class Traffic_Captures(Collection):
+    """BIG-IP® Traffic Capture sub-collection."""
+    def __init__(self, Analytics):
+        super(Traffic_Captures, self).__init__(Analytics)
+        self._meta_data['allowed_lazy_attributes'] = [Traffic_Capture]
+        self._meta_data['attribute_registry'] = \
+            {'tm:ltm:profile:analytics:traffic-capture:traffic-capturestate': Traffic_Capture}
+
+
+class Alerts(Resource):
+    """BIG-IP® Alerts resource."""
+    def __init__(self, Alerts_s):
+        super(Alerts, self).__init__(Alerts_s)
+        self._meta_data['required_json_kind'] = \
+            'tm:ltm:profile:analytics:alerts:alertsstate'
+
+
+class Traffic_Capture(Resource):
+    """BIG-IP® Traffic Capture resource."""
+    def __init__(self, Traffic_Captures):
+        super(Traffic_Capture, self).__init__(Traffic_Captures)
+        self._meta_data['required_json_kind'] = \
+            'tm:ltm:profile:analytics:traffic-capture:traffic-capturestate'
+
+
+class Certificate_Authoritys(Collection):
+    """BIG-IP® Certificate Authority profile collection."""
+    def __init__(self, profile):
+        super(Certificate_Authoritys, self).__init__(profile)
+        self._meta_data['allowed_lazy_attributes'] = [Certificate_Authority]
+        self._meta_data['attribute_registry'] = \
+            {'tm:ltm:profile:certificate-authority:certificate-authoritystate': Certificate_Authority}
+
+
+class Certificate_Authority(Resource):
+    """BIG-IP® Certificate Authority resource."""
+    def __init__(self, Certificate_Authoritys):
+        super(Certificate_Authority, self).__init__(Certificate_Authoritys)
+        self._meta_data['required_json_kind'] = \
+            'tm:ltm:profile:certificate-authority:certificate-authoritystate'
+
+
+class Classifications(Collection):
+    """BIG-IP® Classification profile collection."""
+    def __init__(self, profile):
+        super(Classifications, self).__init__(profile)
+        self._meta_data['allowed_lazy_attributes'] = [Classification]
+        self._meta_data['attribute_registry'] = \
+            {'tm:ltm:profile:classification:classificationstate' : Classification}
+
+
+class Classification(Resource):
+    """BIG-IP® Classification resource."""
+    def __init__(self, Classifications):
+        super(Classification, self).__init__(Classifications)
+        self._meta_data['required_json_kind'] = \
+            'tm:ltm:profile:classification:classificationstate'
+
+
+class Client_Ldaps(Collection):
+    """BIG-IP® Client Ldap profile collection."""
+    def __init__(self, profile):
+        super(Client_Ldaps, self).__init__(profile)
+        self._meta_data['allowed_lazy_attributes'] = [Client_Ldap]
+        self._meta_data['attribute_registry'] = \
+            {'tm:ltm:profile:client-ldap:client-ldapstate': Client_Ldap}
+
+
+class Client_Ldap(Resource):
+    """BIG-IP® Client Ldap resource."""
+    def __init__(self, Client_Ldaps):
+        super(Client_Ldap, self).__init__(Client_Ldaps)
+        self._meta_data['required_json_kind'] = \
+        'tm:ltm:profile:client-ldap:client-ldapstate'
+
+
+class Client_Ssls(Collection):
+    """BIG-IP® Client SSL profile collection."""
+    def __init__(self, profile):
+        super(Client_Ssls, self).__init__(profile)
+        self._meta_data['allowed_lazy_attributes'] = [Client_Ssl]
+        self._meta_data['attribute_registry'] = \
+            {'tm:ltm:profile:client-ssl:client-sslstate': Client_Ssl}
+
+
+class Client_Ssl(Resource):
+    """BIG-IP® Client SSL resource."""
+    def __init__(self, Client_Ssls):
+        super(Client_Ssl, self).__init__(Client_Ssls)
+        self._meta_data['required_json_kind'] = \
+            'tm:ltm:profile:client-ssl:client-sslstate'
+
+
+class Dhcpv4s(Collection):
+    """BIG-IP® Dhcpv4 profile collection."""
+    def __init__(self, profile):
+        super(Dhcpv4s, self).__init__(profile)
+        self._meta_data['allowed_lazy_attributes'] = [Dhcpv4]
+        self._meta_data['attribute_registry'] = \
+            {'tm:ltm:profile:dhcpv4:dhcpv4state': Dhcpv4}
+
+
+class Dhcpv4(Resource):
+    """BIG-IP® Dhcpv4 resource."""
+    def __init__(self, Dhcpv4s):
+        super(Dhcpv4, self).__init__(Dhcpv4s)
+        self._meta_data['required_json_kind'] = \
+            'tm:ltm:profile:dhcpv4:dhcpv4state'
+
+
+class Dhcpv6s(Collection):
+    """BIG-IP® Dhcpv6 profile collection."""
+    def __init__(self, profile):
+        super(Dhcpv6s, self).__init__(profile)
+        self._meta_data['allowed_lazy_attributes'] = [Dhcpv6]
+        self._meta_data['attribute_registry'] = \
+            {'tm:ltm:profile:dhcpv6:dhcpv6state': Dhcpv6}
+
+
+class Dhcpv6(Resource):
+    """BIG-IP® Dhcpv6 resource."""
+    def __init__(self, Dhcpv6s):
+        super(Dhcpv6, self).__init__(Dhcpv6s)
+        self._meta_data['required_json_kind'] = \
+            'tm:ltm:profile:dhcpv6:dhcpv6state'
+
+
+class Diameters(Collection):
+    """BIG-IP® Diameter profile collection."""
+    def __init__(self, profile):
+        super(Diameters, self).__init__(profile)
+        self._meta_data['allowed_lazy_attributes'] = [Diameter]
+        self._meta_data['attribute_registry'] = \
+            {'tm:ltm:profile:diameter:diameterstate': Diameter}
+
+
+class Diameter(Resource):
+    """BIG-IP® Diameter resource."""
+    def __init__(self, Diameters):
+        super(Diameter, self).__init__(Diameters)
+        self._meta_data['required_json_kind'] = \
+            'tm:ltm:profile:diameter:diameterstate'
+
+
+class Dns_s(Collection):
+    """BIG-IP® DNS profile collection."""
+    def __init__(self, profile):
+        super(Dns_s, self).__init__(profile)
+        self._meta_data['allowed_lazy_attributes'] = [Dns]
+        self._meta_data['attribute_registry'] = \
+            {'tm:ltm:profile:dns:dnsstate': Dns}
+
+
+class Dns(Resource):
+    """BIG-IP® DNS resource."""
+    def __init__(self, Dns_s):
+        super(Dns, self).__init__(Dns_s)
+        self._meta_data['required_json_kind'] = \
+            'tm:ltm:profile:dns:dnsstate'
+
+
+class Dns_Loggings(Collection):
+    """BIG-IP® DNS Logging profile collection."""
+    def __init__(self, profile):
+        super(Dns_Loggings, self).__init__(profile)
+        self._meta_data['allowed_lazy_attributes'] = [Dns_Logging]
+        self._meta_data['attribute_registry'] = \
+            {'tm:ltm:profile:dns-logging:dns-loggingstate': Dns_Logging}
+
+
+class Dns_Logging(Resource):
+    """BIG-IP® DNS Logging resource."""
+    def __init__(self, Dns_Loggings):
+        super(Dns_Logging, self).__init__(Dns_Loggings)
+        self._meta_data['required_json_kind'] = \
+            'tm:ltm:profile:dns-logging:dns-loggingstate'
+
+
+class Fasthttps(Collection):
+    """BIG-IP® Fasthttp profile collection."""
+    def __init__(self, profile):
+        super(Fasthttps, self).__init__(profile)
+        self._meta_data['allowed_lazy_attributes'] = [Fasthttp]
+        self._meta_data['attribute_registry'] = \
+            {'tm:ltm:profile:fasthttp:fasthttpstate': Fasthttp}
+
+
+class Fasthttp(Resource):
+    """BIG-IP® Fasthttp resource."""
+    def __init__(self, Fasthttps):
+        super(Fasthttp, self).__init__(Fasthttps)
+        self._meta_data['required_json_kind'] = \
+             'tm:ltm:profile:fasthttp:fasthttpstate'
+
+
+class Fastl4s(Collection):
+    """BIG-IP® Fastl4 profile collection."""
+    def __init__(self, profile):
+        super(Fastl4s, self).__init__(profile)
+        self._meta_data['allowed_lazy_attributes'] = [Fastl4]
+        self._meta_data['attribute_registry'] = \
+            {'tm:ltm:profile:fastl4:fastl4state': Fastl4}
+
+
+class Fastl4(Resource):
+    """BIG-IP® Fastl4 resource."""
+    def __init__(self, Fastl4s):
+        super(Fastl4, self).__init__(Fastl4s)
+        self._meta_data['required_json_kind'] = \
+             'tm:ltm:profile:fastl4:fastl4state'
+
+
+class Fixs(Collection):
+    """BIG-IP® Fix profile collection."""
+    def __init__(self, profile):
+        super(Fixs, self).__init__(profile)
+        self._meta_data['allowed_lazy_attributes'] = [Fix]
+        self._meta_data['attribute_registry'] = \
+            {'tm:ltm:profile:fix:fixstate': Fix}
+
+
+class Fix(Resource):
+    """BIG-IP® Fix resource."""
+    def __init__(self, Fixs):
+        super(Fix, self).__init__(Fixs)
+        self._meta_data['required_json_kind'] = \
+             'tm:ltm:profile:fix:fixstate'
+
+
+class Ftps(Collection):
+    """BIG-IP® Ftp profile collection."""
+    def __init__(self, profile):
+        super(Ftps, self).__init__(profile)
+        self._meta_data['allowed_lazy_attributes'] = [Ftp]
+        self._meta_data['attribute_registry'] = \
+            {'tm:ltm:profile:ftp:ftpstate': Ftp}
+
+
+class Ftp(Resource):
+    """BIG-IP® Ftp resource."""
+    def __init__(self, Ftps):
+        super(Ftp, self).__init__(Ftps)
+        self._meta_data['required_json_kind'] = \
+             'tm:ltm:profile:ftp:ftpstate'
+
+
+class Gtps(Collection):
+    """BIG-IP® Gtp profile collection."""
+    def __init__(self, profile):
+        super(Gtps, self).__init__(profile)
+        self._meta_data['allowed_lazy_attributes'] = [Gtp]
+        self._meta_data['attribute_registry'] = \
+            {'tm:ltm:profile:gtp:gtpstate': Gtp}
+
+
+class Gtp(Resource):
+    """BIG-IP® Gtp resource."""
+    def __init__(self, Gtps):
+        super(Gtp, self).__init__(Gtps)
+        self._meta_data['required_json_kind'] = \
+             'tm:ltm:profile:gtp:gtpstate'
+
+
+class Htmls(Collection):
+    """BIG-IP® Html profile collection."""
+    def __init__(self, profile):
+        super(Htmls, self).__init__(profile)
+        self._meta_data['allowed_lazy_attributes'] = [Html]
+        self._meta_data['attribute_registry'] = \
+            {'tm:ltm:profile:html:htmlstate': Html}
+
+
+class Html(Resource):
+    """BIG-IP® Html resource."""
+    def __init__(self, Htmls):
+        super(Html, self).__init__(Htmls)
+        self._meta_data['required_json_kind'] = \
+             'tm:ltm:profile:html:htmlstate'
+
+
+class Https(Collection):
+    """BIG-IP® Http profile collection."""
+    def __init__(self, profile):
+        super(Https, self).__init__(profile)
+        self._meta_data['allowed_lazy_attributes'] = [Http]
+        self._meta_data['attribute_registry'] = \
+            {'tm:ltm:profile:http:httpstate': Http}
+
+
+class Http(Resource):
+    """BIG-IP® Http resource."""
+    def __init__(self, Https):
+        super(Http, self).__init__(Https)
+        self._meta_data['required_json_kind'] = \
+             'tm:ltm:profile:http:httpstate'
+
+
+class Http_Compressions(Collection):
+    """BIG-IP® Http_Compression profile collection."""
+    def __init__(self, profile):
+        super(Http_Compressions, self).__init__(profile)
+        self._meta_data['allowed_lazy_attributes'] = [Http_Compression]
+        self._meta_data['attribute_registry'] = \
+            {'tm:ltm:profile:http-compression:http-compressionstate': Http_Compression}
+
+
+class Http_Compression(Resource):
+    """BIG-IP® Http_Compression resource."""
+    def __init__(self, Http_Compressions):
+        super(Http_Compression, self).__init__(Http_Compressions)
+        self._meta_data['required_json_kind'] = \
+             'tm:ltm:profile:http-compression:http-compressionstate'
+
+
+class Http2s(Collection):
+    """BIG-IP® Http2 profile collection."""
+    def __init__(self, profile):
+        super(Http2s, self).__init__(profile)
+        self._meta_data['allowed_lazy_attributes'] = [Http2]
+        self._meta_data['attribute_registry'] = \
+            {'tm:ltm:profile:http2:http2state': Http2}
+
+
+class Http2(Resource):
+    """BIG-IP® Http2 resource."""
+    def __init__(self, Http2s):
+        super(Http2, self).__init__(Http2s)
+        self._meta_data['required_json_kind'] = \
+             'tm:ltm:profile:http2:http2state'
+
+
+class Icaps(Collection):
+    """BIG-IP® Icap profile collection."""
+    def __init__(self, profile):
+        super(Icaps, self).__init__(profile)
+        self._meta_data['allowed_lazy_attributes'] = [Icap]
+        self._meta_data['attribute_registry'] = \
+            {'tm:ltm:profile:icap:icapstate': Icap}
+
+
+class Icap(Resource):
+    """BIG-IP® Icap resource."""
+    def __init__(self, Icaps):
+        super(Icap, self).__init__(Icaps)
+        self._meta_data['required_json_kind'] = \
+             'tm:ltm:profile:icap:icapstate'
+
+
+class Iiops(Collection):
+    """BIG-IP® Iiop profile collection."""
+    def __init__(self, profile):
+        super(Iiops, self).__init__(profile)
+        self._meta_data['allowed_lazy_attributes'] = [Iiop]
+        self._meta_data['attribute_registry'] = \
+            {'tm:ltm:profile:iiop:iiopstate': Iiop}
+
+
+class Iiop(Resource):
+    """BIG-IP® Iiop resource."""
+    def __init__(self, Iiops):
+        super(Iiop, self).__init__(Iiops)
+        self._meta_data['required_json_kind'] = \
+             'tm:ltm:profile:iiop:iiopstate'
+
+
+class Ipothers(Collection):
+    """BIG-IP® Ipother profile collection."""
+    def __init__(self, profile):
+        super(Ipothers, self).__init__(profile)
+        self._meta_data['allowed_lazy_attributes'] = [Ipother]
+        self._meta_data['attribute_registry'] = \
+            {'tm:ltm:profile:ipother:ipotherstate': Ipother}
+
+
+class Ipother(Resource):
+    """BIG-IP® Ipother resource."""
+    def __init__(self, Ipothers):
+        super(Ipother, self).__init__(Ipothers)
+        self._meta_data['required_json_kind'] = \
+             'tm:ltm:profile:ipother:ipotherstate'
+
+
+class Mblbs(Collection):
+    """BIG-IP® Mblb profile collection."""
+    def __init__(self, profile):
+        super(Mblbs, self).__init__(profile)
+        self._meta_data['allowed_lazy_attributes'] = [Mblb]
+        self._meta_data['attribute_registry'] = \
+            {'tm:ltm:profile:mblb:mblbstate': Mblb}
+
+
+class Mblb(Resource):
+    """BIG-IP® Mblb resource."""
+    def __init__(self, Mblbs):
+        super(Mblb, self).__init__(Mblbs)
+        self._meta_data['required_json_kind'] = \
+             'tm:ltm:profile:mblb:mblbstate'
+
+
+class Mssqls(Collection):
+    """BIG-IP® Mssql profile collection."""
+    def __init__(self, profile):
+        super(Mssqls, self).__init__(profile)
+        self._meta_data['allowed_lazy_attributes'] = [Mssql]
+        self._meta_data['attribute_registry'] = \
+            {'tm:ltm:profile:mssql:mssqlstate': Mssql}
+
+
+class Mssql(Resource):
+    """BIG-IP® Mssql resource."""
+    def __init__(self, Mssqls):
+        super(Mssql, self).__init__(Mssqls)
+        self._meta_data['required_json_kind'] = \
+             'tm:ltm:profile:mssql:mssqlstate'
+
+
+class Ntlms(Collection):
+    """BIG-IP® Ntlm profile collection."""
+    def __init__(self, profile):
+        super(Ntlms, self).__init__(profile)
+        self._meta_data['allowed_lazy_attributes'] = [Ntlm]
+        self._meta_data['attribute_registry'] = \
+            {'tm:ltm:profile:ntlm:ntlmstate': Ntlm}
+
+
+class Ntlm(Resource):
+    """BIG-IP® Ntlm resource."""
+    def __init__(self, Ntlms):
+        super(Ntlm, self).__init__(Ntlms)
+        self._meta_data['required_json_kind'] = \
+             'tm:ltm:profile:ntlm:ntlmstate'
+
+
+class Ocsp_Stapling_Params_s(Collection):
+    """BIG-IP® Ocsp_Stapling_Params profile collection."""
+    def __init__(self, profile):
+        super(Ocsp_Stapling_Params_s, self).__init__(profile)
+        self._meta_data['allowed_lazy_attributes'] = [Ocsp_Stapling_Params]
+        self._meta_data['attribute_registry'] = \
+            {'tm:ltm:profile:ocsp-stapling-params:ocsp-stapling-paramsstate': Ocsp_Stapling_Params}
+
+
+class Ocsp_Stapling_Params(Resource):
+    """BIG-IP® Ocsp_Stapling_Params resource."""
+    def __init__(self, Ocsp_Stapling_Params_s):
+        super(Ocsp_Stapling_Params, self).__init__(Ocsp_Stapling_Params_s)
+        self._meta_data['required_json_kind'] = \
+             'tm:ltm:profile:ocsp-stapling-params:ocsp-stapling-paramsstate'
+
+
+class One_Connects(Collection):
+    """BIG-IP® One_Connect profile collection."""
+    def __init__(self, profile):
+        super(One_Connects, self).__init__(profile)
+        self._meta_data['allowed_lazy_attributes'] = [One_Connect]
+        self._meta_data['attribute_registry'] = \
+            {'tm:ltm:profile:one-connect:one-connectstate': One_Connect}
+
+
+class One_Connect(Resource):
+    """BIG-IP® One_Connect resource."""
+    def __init__(self, One_Connects):
+        super(One_Connect, self).__init__(One_Connects)
+        self._meta_data['required_json_kind'] = \
+             'tm:ltm:profile:one-connect:one-connectstate'
+
+
+class Pcps(Collection):
+    """BIG-IP® Pcp profile collection."""
+    def __init__(self, profile):
+        super(Pcps, self).__init__(profile)
+        self._meta_data['allowed_lazy_attributes'] = [Pcp]
+        self._meta_data['attribute_registry'] = \
+            {'tm:ltm:profile:pcp:pcpstate': Pcp}
+
+
+class Pcp(Resource):
+    """BIG-IP® Pcp resource."""
+    def __init__(self, Pcps):
+        super(Pcp, self).__init__(Pcps)
+        self._meta_data['required_json_kind'] = \
+             'tm:ltm:profile:pcp:pcpstate'
+
+
+class Pptps(Collection):
+    """BIG-IP® Pptp profile collection."""
+    def __init__(self, profile):
+        super(Pptps, self).__init__(profile)
+        self._meta_data['allowed_lazy_attributes'] = [Pptp]
+        self._meta_data['attribute_registry'] = \
+            {'tm:ltm:profile:pptp:pptpstate': Pptp}
+
+
+class Pptp(Resource):
+    """BIG-IP® Pptp resource."""
+    def __init__(self, Pptps):
+        super(Pptp, self).__init__(Pptps)
+        self._meta_data['required_json_kind'] = \
+             'tm:ltm:profile:pptp:pptpstate'
+
+
+class Qoes(Collection):
+    """BIG-IP® Qoe profile collection."""
+    def __init__(self, profile):
+        super(Qoes, self).__init__(profile)
+        self._meta_data['allowed_lazy_attributes'] = [Qoe]
+        self._meta_data['attribute_registry'] = \
+            {'tm:ltm:profile:qoe:qoestate': Qoe}
+
+
+class Qoe(Resource):
+    """BIG-IP® Qoe resource."""
+    def __init__(self, Qoes):
+        super(Qoe, self).__init__(Qoes)
+        self._meta_data['required_json_kind'] = \
+             'tm:ltm:profile:qoe:qoestate'
+
+
+class Radius_s(Collection):
+    """BIG-IP® Radius profile collection."""
+    def __init__(self, profile):
+        super(Radius_s, self).__init__(profile)
+        self._meta_data['allowed_lazy_attributes'] = [Radius]
+        self._meta_data['attribute_registry'] = \
+            {'tm:ltm:profile:radius:radiusstate': Radius}
+
+
+class Radius(Resource):
+    """BIG-IP® Radius resource."""
+    def __init__(self, Radius_s):
+        super(Radius, self).__init__(Radius_s)
+        self._meta_data['required_json_kind'] = \
+             'tm:ltm:profile:radius:radiusstate'
+
+
+###Ramcache is special case needs some careful thought, supports get and DELETE only
+class Ramcaches(Collection):
+    """BIG-IP® Ramcache profile collection."""
+    pass
+class Ramcache(Resource):
+    """BIG-IP® Ramcache resource."""
+    pass
+###End of Ramcache
+
+
+class Request_Adapts(Collection):
+    """BIG-IP® Request_Adapt profile collection."""
+    def __init__(self, profile):
+        super(Request_Adapts, self).__init__(profile)
+        self._meta_data['allowed_lazy_attributes'] = [Request_Adapt]
+        self._meta_data['attribute_registry'] = \
+            {'tm:ltm:profile:request-adapt:request-adaptstate': Request_Adapt}
+
+
+class Request_Adapt(Resource):
+    """BIG-IP® Request_Adapt resource."""
+    def __init__(self, Request_Adapts):
+        super(Request_Adapt, self).__init__(Request_Adapts)
+        self._meta_data['required_json_kind'] = \
+             'tm:ltm:profile:request-adapt:request-adaptstate'
+
+
+class Request_Logs(Collection):
+    """BIG-IP® Request_Log profile collection."""
+    def __init__(self, profile):
+        super(Request_Logs, self).__init__(profile)
+        self._meta_data['allowed_lazy_attributes'] = [Request_Log]
+        self._meta_data['attribute_registry'] = \
+            {'tm:ltm:profile:request-log:request-logstate': Request_Log}
+
+
+class Request_Log(Resource):
+    """BIG-IP® Request_Log resource."""
+    def __init__(self, Request_Logs):
+        super(Request_Log, self).__init__(Request_Logs)
+        self._meta_data['required_json_kind'] = \
+             'tm:ltm:profile:request-log:request-logstate'
+
+
+class Response_Adapts(Collection):
+    """BIG-IP® Response_Adapt profile collection."""
+    def __init__(self, profile):
+        super(Response_Adapts, self).__init__(profile)
+        self._meta_data['allowed_lazy_attributes'] = [Response_Adapt]
+        self._meta_data['attribute_registry'] = \
+            {'tm:ltm:profile:response-adapt:response-adaptstate': Response_Adapt}
+
+
+class Response_Adapt(Resource):
+    """BIG-IP® Response_Adapt resource."""
+    def __init__(self, Response_Adapts):
+        super(Response_Adapt, self).__init__(Response_Adapts)
+        self._meta_data['required_json_kind'] = \
+             'tm:ltm:profile:response-adapt:response-adaptstate'
+
+
+class Rewrites(Collection):
+    """BIG-IP® Rewrite profile collection."""
+    def __init__(self, profile):
+        super(Rewrites, self).__init__(profile)
+        self._meta_data['allowed_lazy_attributes'] = [Rewrite]
+        self._meta_data['attribute_registry'] = \
+            {'tm:ltm:profile:rewrite:rewritestate': Rewrite}
+
+
+class Rewrite(Resource):
+    """BIG-IP® Rewrite resource."""
+    def __init__(self, Rewrites):
+        super(Rewrite, self).__init__(Rewrites)
+        self._meta_data['allowed_lazy_attributes'] = []
+        self._meta_data['required_json_kind'] = \
+             'tm:ltm:profile:rewrite:rewritestate'
+        self._meta_data['attribute_registry'] = \
+            {'tm:ltm:profile:rewrite:uri-rules:uri-rulescollectionstate':
+             Uri_Rules_s}
+
+
+class Uri_Rules_s(Collection):
+    """BIG-IP® Rewrite sub-collection."""
+    def __init__(self, Rewrite):
+        super(Uri_Rules_s, self).__init__(Rewrite)
+        self._meta_data['allowed_lazy_attributes'] = [Uri_Rules]
+        self._meta_data['attribute_registry'] = \
+            {'tm:ltm:profile:rewrite:uri-rules:uri-rulesstate': Uri_Rules}
+
+class Uri_Rules(Resource):
+    """BIG-IP® URI Rules resource"""
+    def __init__(self, Uri_Rules_s):
+        super(Uri_Rules, self).__init__(Uri_Rules_s)
+        self._meta_data['required_json_kind'] = \
+            'tm:ltm:profile:analytics:alerts:alertsstate'
+
+
+class Rtsps(Collection):
+    """BIG-IP® Rtsp profile collection."""
+    def __init__(self, profile):
+        super(Rtsps, self).__init__(profile)
+        self._meta_data['allowed_lazy_attributes'] = [Rtsp]
+        self._meta_data['attribute_registry'] = \
+            {'tm:ltm:profile:rtsp:rtspstate': Rtsp}
+
+
+class Rtsp(Resource):
+    """BIG-IP® Rtsp resource."""
+    def __init__(self, Rtsps):
+        super(Rtsp, self).__init__(Rtsps)
+        self._meta_data['required_json_kind'] = \
+             'tm:ltm:profile:rtsp:rtspstate'
+
+
+class Sctps(Collection):
+    """BIG-IP® Sctp profile collection."""
+    def __init__(self, profile):
+        super(Sctps, self).__init__(profile)
+        self._meta_data['allowed_lazy_attributes'] = [Sctp]
+        self._meta_data['attribute_registry'] = \
+            {'tm:ltm:profile:sctp:sctpstate': Sctp}
+
+
+class Sctp(Resource):
+    """BIG-IP® Sctp resource."""
+    def __init__(self, Sctps):
+        super(Sctp, self).__init__(Sctps)
+        self._meta_data['required_json_kind'] = \
+             'tm:ltm:profile:sctp:sctpstate'
+
+
+class Server_Ldaps(Collection):
+    """BIG-IP® Server_Ldap profile collection."""
+    def __init__(self, profile):
+        super(Server_Ldaps, self).__init__(profile)
+        self._meta_data['allowed_lazy_attributes'] = [Server_Ldap]
+        self._meta_data['attribute_registry'] = \
+            {'tm:ltm:profile:server-ldap:server-ldapstate': Server_Ldap}
+
+
+class Server_Ldap(Resource):
+    """BIG-IP® Server_Ldap resource."""
+    def __init__(self, Server_Ldaps):
+        super(Server_Ldap, self).__init__(Server_Ldaps)
+        self._meta_data['required_json_kind'] = \
+             'tm:ltm:profile:server-ldap:server-ldapstate'
+
+
+class Server_Ssls(Collection):
+    """BIG-IP® Server_Ssl profile collection."""
+    def __init__(self, profile):
+        super(Server_Ssls, self).__init__(profile)
+        self._meta_data['allowed_lazy_attributes'] = [Server_Ssl]
+        self._meta_data['attribute_registry'] = \
+            {'tm:ltm:profile:server-ssl:server-sslstate': Server_Ssl}
+
+
+class Server_Ssl(Resource):
+    """BIG-IP® Server_Ssl resource."""
+    def __init__(self, Server_Ssls):
+        super(Server_Ssl, self).__init__(Server_Ssls)
+        self._meta_data['required_json_kind'] = \
+             'tm:ltm:profile:server-ssl:server-sslstate'
+
+
+class Sips(Collection):
+    """BIG-IP® Sip profile collection."""
+    def __init__(self, profile):
+        super(Sips, self).__init__(profile)
+        self._meta_data['allowed_lazy_attributes'] = [Sip]
+        self._meta_data['attribute_registry'] = \
+            {'tm:ltm:profile:sip:sipstate': Sip}
+
+
+class Sip(Resource):
+    """BIG-IP® Sip resource."""
+    def __init__(self, Sips):
+        super(Sip, self).__init__(Sips)
+        self._meta_data['required_json_kind'] = \
+             'tm:ltm:profile:sip:sipstate'
+
+
+class Smtps(Collection):
+    """BIG-IP® Smtp profile collection.
+
+    .. note::
+         Profile requires ASM provisioned.
+    """
+    def __init__(self, profile):
+        super(Smtps, self).__init__(profile)
+        self._meta_data['allowed_lazy_attributes'] = [Smtp]
+        self._meta_data['attribute_registry'] = \
+            {'tm:ltm:profile:smtp:smtpstate': Smtp}
+
+
+class Smtp(Resource):
+    """BIG-IP® Smtp resource."""
+    def __init__(self, Smtps):
+        super(Smtp, self).__init__(Smtps)
+        self._meta_data['required_json_kind'] = \
+             'tm:ltm:profile:smtp:smtpstate'
+
+
+class Smtps_s(Collection):
+    """BIG-IP® Smtps profile collection."""
+    def __init__(self, profile):
+        super(Smtps_s, self).__init__(profile)
+        self._meta_data['allowed_lazy_attributes'] = [Smtps]
+        self._meta_data['attribute_registry'] = \
+            {'tm:ltm:profile:smtps:smtpsstate': Smtps}
+
+
+class SmtpS(Resource):
+    """BIG-IP® Smtps resource."""
+    def __init__(self, Smtps_s):
+        super(SmtpS, self).__init__(Smtps_s)
+        self._meta_data['required_json_kind'] = \
+             'tm:ltm:profile:smtps:smtpsstate'
+
+
+class Socks_s(Collection):
+    """BIG-IP® Socks profile collection."""
+    def __init__(self, profile):
+        super(Socks_s, self).__init__(profile)
+        self._meta_data['allowed_lazy_attributes'] = [Socks]
+        self._meta_data['attribute_registry'] = \
+            {'tm:ltm:profile:socks:socksstate': Socks}
+
+
+class Socks(Resource):
+    """BIG-IP® Socks resource."""
+    def __init__(self, Socks_s):
+        super(Socks, self).__init__(Socks_s)
+        self._meta_data['required_json_kind'] = \
+             'tm:ltm:profile:socks:socksstate'
+
+
+class Spdys(Collection):
+    """BIG-IP® Spdy profile collection."""
+    def __init__(self, profile):
+        super(Spdys, self).__init__(profile)
+        self._meta_data['allowed_lazy_attributes'] = [Spdy]
+        self._meta_data['attribute_registry'] = \
+            {'tm:ltm:profile:spdy:spdystate': Spdy}
+
+
+class Spdy(Resource):
+    """BIG-IP® Spdy resource."""
+    def __init__(self, Spdys):
+        super(Spdy, self).__init__(Spdys)
+        self._meta_data['required_json_kind'] = \
+             'tm:ltm:profile:spdy:spdystate'
+
+
+class Statistics_s(Collection):
+    """BIG-IP® Statistics profile collection."""
+    def __init__(self, profile):
+        super(Statistics_s, self).__init__(profile)
+        self._meta_data['allowed_lazy_attributes'] = [Statistics]
+        self._meta_data['attribute_registry'] = \
+            {'tm:ltm:profile:statistics:statisticsstate': Statistics}
+
+
+class Statistics(Resource):
+    """BIG-IP® Statistics resource."""
+    def __init__(self, Statistics_s):
+        super(Statistics, self).__init__(Statistics_s)
+        self._meta_data['required_json_kind'] = \
+             'tm:ltm:profile:statistics:statisticsstate'
+
+
+class Streams(Collection):
+    """BIG-IP® Stream profile collection."""
+    def __init__(self, profile):
+        super(Streams, self).__init__(profile)
+        self._meta_data['allowed_lazy_attributes'] = [Stream]
+        self._meta_data['attribute_registry'] = \
+            {'tm:ltm:profile:stream:streamstate': Stream}
+
+
+class Stream(Resource):
+    """BIG-IP® Stream resource."""
+    def __init__(self, Streams):
+        super(Stream, self).__init__(Streams)
+        self._meta_data['required_json_kind'] = \
+             'tm:ltm:profile:stream:streamstate'
+
+
+class Tcps(Collection):
+    """BIG-IP® Tcp profile collection."""
+    def __init__(self, profile):
+        super(Tcps, self).__init__(profile)
+        self._meta_data['allowed_lazy_attributes'] = [Tcp]
+        self._meta_data['attribute_registry'] = \
+            {'tm:ltm:profile:tcp:tcpstate': Tcp}
+
+
+class Tcp(Resource):
+    """BIG-IP® Tcp resource."""
+    def __init__(self, Tcps):
+        super(Tcp, self).__init__(Tcps)
+        self._meta_data['required_json_kind'] = \
+             'tm:ltm:profile:tcp:tcpstate'
+
+
+class Tftps(Collection):
+    """BIG-IP® Tftp profile collection."""
+    def __init__(self, profile):
+        super(Tftps, self).__init__(profile)
+        self._meta_data['allowed_lazy_attributes'] = [Tftp]
+        self._meta_data['attribute_registry'] = \
+            {'tm:ltm:profile:tftp:tftpstate': Tftp}
+
+
+class Tftp(Resource):
+    """BIG-IP® Tftp resource."""
+    def __init__(self, Tftps):
+        super(Tftp, self).__init__(Tftps)
+        self._meta_data['required_json_kind'] = \
+             'tm:ltm:profile:tftp:tftpstate'
+
+
+class Udps(Collection):
+    """BIG-IP® Udp profile collection."""
+    def __init__(self, profile):
+        super(Udps, self).__init__(profile)
+        self._meta_data['allowed_lazy_attributes'] = [Udp]
+        self._meta_data['attribute_registry'] = \
+            {'tm:ltm:profile:udp:udpstate': Udp}
+
+
+class Udp(Resource):
+    """BIG-IP® Udp resource."""
+    def __init__(self, Udps):
+        super(Udp, self).__init__(Udps)
+        self._meta_data['required_json_kind'] = \
+             'tm:ltm:profile:udp:udpstate'
+
+###This one does not allow GET, probably requires data to allow query
+
+class Wa_Caches(Collection):
+    """BIG-IP® Wa_Cache profile collection."""
+    pass
+class Wa_Cache(Resource):
+    """BIG-IP® Wa_Cache resource."""
+    pass
+###
+
+class Web_Accelerations(Collection):
+    """BIG-IP® Web_Acceleration profile collection."""
+    def __init__(self, profile):
+        super(Web_Accelerations, self).__init__(profile)
+        self._meta_data['allowed_lazy_attributes'] = [Web_Acceleration]
+        self._meta_data['attribute_registry'] = \
+            {'tm:ltm:profile:web-acceleration:web-accelerationstate': Web_Acceleration}
+
+
+class Web_Acceleration(Resource):
+    """BIG-IP® Web_Acceleration resource."""
+    def __init__(self, Web_Accelerations):
+        super(Web_Acceleration, self).__init__(Web_Accelerations)
+        self._meta_data['required_json_kind'] = \
+             'tm:ltm:profile:web-acceleration:web-accelerationstate'
+
+
+class Web_Securitys(Collection):
+    """BIG-IP® Web_Security profile collection."""
+    def __init__(self, profile):
+        super(Web_Securitys, self).__init__(profile)
+        self._meta_data['allowed_lazy_attributes'] = [Web_Security]
+        self._meta_data['attribute_registry'] = \
+            {'tm:ltm:profile:web-security:web-securitystate': Web_Security}
+
+
+class Web_Security(Resource):
+    """BIG-IP® Web_Security resource."""
+    def __init__(self, Web_Securitys):
+        super(Web_Security, self).__init__(Web_Securitys)
+        self._meta_data['required_json_kind'] = \
+             'tm:ltm:profile:web-security:web-securitystate'
+
+    def update(self, **kwargs):
+        """Update is not supported for Web Security
+
+        :raises: UnsupportedOperation
+        """
+        raise UnsupportedOperation(
+            "%s does not support the update method" % self.__class__.__name__
+        )
+
+    def delete(self, **kwargs):
+        """Delete is not supported for Web Security
+
+        :raises: UnsupportedOperation
+        """
+        raise UnsupportedOperation(
+            "%s does not support the delete method" % self.__class__.__name__
+        )
+
+
+class Xmls(Collection):
+    """BIG-IP® Xml profile collection."""
+    def __init__(self, profile):
+        super(Xmls, self).__init__(profile)
+        self._meta_data['allowed_lazy_attributes'] = [Xml]
+        self._meta_data['attribute_registry'] = \
+            {'tm:ltm:profile:xml:xmlstate': Xml}
+
+
+class Xml(Resource):
+    """BIG-IP® Xml resource."""
+    def __init__(self, Xmls):
+        super(Xml, self).__init__(Xmls)
+        self._meta_data['required_json_kind'] = \
+             'tm:ltm:profile:xml:xmlstate'
+

--- a/f5/bigip/tm/ltm/profile.py
+++ b/f5/bigip/tm/ltm/profile.py
@@ -119,8 +119,6 @@ class Traffic_Captures(Collection):
     """BIG-IP® Traffic Capture sub-collection."""
     def __init__(self, Analytics):
         super(Traffic_Captures, self).__init__(Analytics)
-        fixed = self._meta_data['uri'].replace('_', '-')
-        self._meta_data['uri'] = fixed
         self._meta_data['allowed_lazy_attributes'] = [Traffic_Capture]
         self._meta_data['attribute_registry'] = \
             {'tm:ltm:profile:analytics:traffic-capture:traffic-capturestate': Traffic_Capture}
@@ -146,8 +144,6 @@ class Certificate_Authoritys(Collection):
     """BIG-IP® Certificate Authority profile collection."""
     def __init__(self, profile):
         super(Certificate_Authoritys, self).__init__(profile)
-        fixed = self._meta_data['uri'].replace('_', '-')
-        self._meta_data['uri'] = fixed
         self._meta_data['allowed_lazy_attributes'] = [Certificate_Authority]
         self._meta_data['attribute_registry'] = \
             {'tm:ltm:profile:certificate-authority:certificate-authoritystate': Certificate_Authority}
@@ -200,8 +196,6 @@ class Client_Ldaps(Collection):
     """BIG-IP® Client Ldap profile collection."""
     def __init__(self, profile):
         super(Client_Ldaps, self).__init__(profile)
-        fixed = self._meta_data['uri'].replace('_', '-')
-        self._meta_data['uri'] = fixed
         self._meta_data['allowed_lazy_attributes'] = [Client_Ldap]
         self._meta_data['attribute_registry'] = \
             {'tm:ltm:profile:client-ldap:client-ldapstate': Client_Ldap}
@@ -219,8 +213,6 @@ class Client_Ssls(Collection):
     """BIG-IP® Client SSL profile collection."""
     def __init__(self, profile):
         super(Client_Ssls, self).__init__(profile)
-        fixed = self._meta_data['uri'].replace('_', '-')
-        self._meta_data['uri'] = fixed
         self._meta_data['allowed_lazy_attributes'] = [Client_Ssl]
         self._meta_data['attribute_registry'] = \
             {'tm:ltm:profile:client-ssl:client-sslstate': Client_Ssl}
@@ -306,8 +298,6 @@ class Dns_Loggings(Collection):
     """BIG-IP® DNS Logging profile collection."""
     def __init__(self, profile):
         super(Dns_Loggings, self).__init__(profile)
-        fixed = self._meta_data['uri'].replace('_', '-')
-        self._meta_data['uri'] = fixed
         self._meta_data['allowed_lazy_attributes'] = [Dns_Logging]
         self._meta_data['attribute_registry'] = \
             {'tm:ltm:profile:dns-logging:dns-loggingstate': Dns_Logging}
@@ -446,8 +436,6 @@ class Http_Compressions(Collection):
     """BIG-IP® Http_Compression profile collection."""
     def __init__(self, profile):
         super(Http_Compressions, self).__init__(profile)
-        fixed = self._meta_data['uri'].replace('_', '-')
-        self._meta_data['uri'] = fixed
         self._meta_data['allowed_lazy_attributes'] = [Http_Compression]
         self._meta_data['attribute_registry'] = \
             {'tm:ltm:profile:http-compression:http-compressionstate': Http_Compression}
@@ -584,8 +572,6 @@ class Ocsp_Stapling_Params_s(Collection):
     """BIG-IP® Ocsp_Stapling_Params profile collection."""
     def __init__(self, profile):
         super(Ocsp_Stapling_Params_s, self).__init__(profile)
-        fixed = self._meta_data['uri'].replace('_', '-')
-        self._meta_data['uri'] = fixed
         self._meta_data['allowed_lazy_attributes'] = [Ocsp_Stapling_Params]
         self._meta_data['attribute_registry'] = \
             {'tm:ltm:profile:ocsp-stapling-params:ocsp-stapling-paramsstate': Ocsp_Stapling_Params}
@@ -595,6 +581,9 @@ class Ocsp_Stapling_Params(Resource):
     """BIG-IP® Ocsp_Stapling_Params resource."""
     def __init__(self, Ocsp_Stapling_Params_s):
         super(Ocsp_Stapling_Params, self).__init__(Ocsp_Stapling_Params_s)
+        self._meta_data['required_creation_parameters'].update(
+            'proxyServerPool', 'dnsResolver', 'trustedCa','useProxyServer')
+        self._meta_data['exclusive_attributes'].update('proxyServerPool', 'dnsResolver')
         self._meta_data['required_json_kind'] = \
              'tm:ltm:profile:ocsp-stapling-params:ocsp-stapling-paramsstate'
 
@@ -603,8 +592,6 @@ class One_Connects(Collection):
     """BIG-IP® One_Connect profile collection."""
     def __init__(self, profile):
         super(One_Connects, self).__init__(profile)
-        fixed = self._meta_data['uri'].replace('_', '-')
-        self._meta_data['uri'] = fixed
         self._meta_data['allowed_lazy_attributes'] = [One_Connect]
         self._meta_data['attribute_registry'] = \
             {'tm:ltm:profile:one-connect:one-connectstate': One_Connect}
@@ -700,8 +687,6 @@ class Request_Adapts(Collection):
     """BIG-IP® Request_Adapt profile collection."""
     def __init__(self, profile):
         super(Request_Adapts, self).__init__(profile)
-        fixed = self._meta_data['uri'].replace('_', '-')
-        self._meta_data['uri'] = fixed
         self._meta_data['allowed_lazy_attributes'] = [Request_Adapt]
         self._meta_data['attribute_registry'] = \
             {'tm:ltm:profile:request-adapt:request-adaptstate': Request_Adapt}
@@ -719,8 +704,6 @@ class Request_Logs(Collection):
     """BIG-IP® Request_Log profile collection."""
     def __init__(self, profile):
         super(Request_Logs, self).__init__(profile)
-        fixed = self._meta_data['uri'].replace('_', '-')
-        self._meta_data['uri'] = fixed
         self._meta_data['allowed_lazy_attributes'] = [Request_Log]
         self._meta_data['attribute_registry'] = \
             {'tm:ltm:profile:request-log:request-logstate': Request_Log}
@@ -738,8 +721,6 @@ class Response_Adapts(Collection):
     """BIG-IP® Response_Adapt profile collection."""
     def __init__(self, profile):
         super(Response_Adapts, self).__init__(profile)
-        fixed = self._meta_data['uri'].replace('_', '-')
-        self._meta_data['uri'] = fixed
         self._meta_data['allowed_lazy_attributes'] = [Response_Adapt]
         self._meta_data['attribute_registry'] = \
             {'tm:ltm:profile:response-adapt:response-adaptstate': Response_Adapt}
@@ -778,8 +759,6 @@ class Uri_Rules_s(Collection):
     """BIG-IP® Rewrite sub-collection."""
     def __init__(self, Rewrite):
         super(Uri_Rules_s, self).__init__(Rewrite)
-        fixed = self._meta_data['uri'].replace('_', '-')
-        self._meta_data['uri'] = fixed
         self._meta_data['allowed_lazy_attributes'] = [Uri_Rules]
         self._meta_data['attribute_registry'] = \
             {'tm:ltm:profile:rewrite:uri-rules:uri-rulesstate': Uri_Rules}
@@ -830,8 +809,6 @@ class Server_Ldaps(Collection):
     """BIG-IP® Server_Ldap profile collection."""
     def __init__(self, profile):
         super(Server_Ldaps, self).__init__(profile)
-        fixed = self._meta_data['uri'].replace('_', '-')
-        self._meta_data['uri'] = fixed
         self._meta_data['allowed_lazy_attributes'] = [Server_Ldap]
         self._meta_data['attribute_registry'] = \
             {'tm:ltm:profile:server-ldap:server-ldapstate': Server_Ldap}
@@ -849,8 +826,6 @@ class Server_Ssls(Collection):
     """BIG-IP® Server_Ssl profile collection."""
     def __init__(self, profile):
         super(Server_Ssls, self).__init__(profile)
-        fixed = self._meta_data['uri'].replace('_', '-')
-        self._meta_data['uri'] = fixed
         self._meta_data['allowed_lazy_attributes'] = [Server_Ssl]
         self._meta_data['attribute_registry'] = \
             {'tm:ltm:profile:server-ssl:server-sslstate': Server_Ssl}
@@ -1053,8 +1028,6 @@ class Web_Accelerations(Collection):
     """BIG-IP® Web_Acceleration profile collection."""
     def __init__(self, profile):
         super(Web_Accelerations, self).__init__(profile)
-        fixed = self._meta_data['uri'].replace('_', '-')
-        self._meta_data['uri'] = fixed
         self._meta_data['allowed_lazy_attributes'] = [Web_Acceleration]
         self._meta_data['attribute_registry'] = \
             {'tm:ltm:profile:web-acceleration:web-accelerationstate': Web_Acceleration}
@@ -1072,8 +1045,6 @@ class Web_Securitys(Collection):
     """BIG-IP® Web_Security profile collection."""
     def __init__(self, profile):
         super(Web_Securitys, self).__init__(profile)
-        fixed = self._meta_data['uri'].replace('_', '-')
-        self._meta_data['uri'] = fixed
         self._meta_data['allowed_lazy_attributes'] = [Web_Security]
         self._meta_data['attribute_registry'] = \
             {'tm:ltm:profile:web-security:web-securitystate': Web_Security}
@@ -1085,6 +1056,16 @@ class Web_Security(Resource):
         super(Web_Security, self).__init__(Web_Securitys)
         self._meta_data['required_json_kind'] = \
              'tm:ltm:profile:web-security:web-securitystate'
+
+    def create(self, **kwargs):
+        """Create is not supported for Web Security
+
+        :raises: UnsupportedOperation
+        """
+        raise UnsupportedOperation(
+            "%s does not support the create method" % self.__class__.__name__
+        )
+
 
     def update(self, **kwargs):
         """Update is not supported for Web Security

--- a/f5/bigip/tm/ltm/profile.py
+++ b/f5/bigip/tm/ltm/profile.py
@@ -579,13 +579,33 @@ class Ocsp_Stapling_Params_s(Collection):
 
 class Ocsp_Stapling_Params(Resource):
     """BIG-IP® Ocsp_Stapling_Params resource."""
+
     def __init__(self, Ocsp_Stapling_Params_s):
         super(Ocsp_Stapling_Params, self).__init__(Ocsp_Stapling_Params_s)
-        self._meta_data['required_creation_parameters'].update(
-            'proxyServerPool', 'dnsResolver', 'trustedCa','useProxyServer')
-        self._meta_data['exclusive_attributes'].update('proxyServerPool', 'dnsResolver')
+        self._meta_data['exclusive_attributes'].append(('proxyServerPool', 'dnsResolver'))
         self._meta_data['required_json_kind'] = \
              'tm:ltm:profile:ocsp-stapling-params:ocsp-stapling-paramsstate'
+
+    def create(self, **kwargs):
+        """Create the resource on the BIG-IP®.
+
+        Uses HTTP POST to the `collection` URI to create a resource associated
+        with a new unique URI on the device.
+
+        As proxyServerPool parameter will be required
+        only if useProxyServer is set to 'enabled'
+        we have to use conditional to capture this logic during create.
+
+        """
+        if kwargs['useProxyServer'] == 'enabled':
+            tup_par = ('proxyServerPool', 'trustedCa', 'useProxyServer')
+        else:
+            tup_par = ('dnsResolver', 'trustedCa', 'useProxyServer')
+
+        self._meta_data['required_creation_parameters'].update(tup_par)
+        self._create(**kwargs)
+
+        return self
 
 
 class One_Connects(Collection):

--- a/f5/bigip/tm/ltm/profile.py
+++ b/f5/bigip/tm/ltm/profile.py
@@ -119,6 +119,8 @@ class Traffic_Captures(Collection):
     """BIG-IP® Traffic Capture sub-collection."""
     def __init__(self, Analytics):
         super(Traffic_Captures, self).__init__(Analytics)
+        fixed = self._meta_data['uri'].replace('_', '-')
+        self._meta_data['uri'] = fixed
         self._meta_data['allowed_lazy_attributes'] = [Traffic_Capture]
         self._meta_data['attribute_registry'] = \
             {'tm:ltm:profile:analytics:traffic-capture:traffic-capturestate': Traffic_Capture}
@@ -144,6 +146,8 @@ class Certificate_Authoritys(Collection):
     """BIG-IP® Certificate Authority profile collection."""
     def __init__(self, profile):
         super(Certificate_Authoritys, self).__init__(profile)
+        fixed = self._meta_data['uri'].replace('_', '-')
+        self._meta_data['uri'] = fixed
         self._meta_data['allowed_lazy_attributes'] = [Certificate_Authority]
         self._meta_data['attribute_registry'] = \
             {'tm:ltm:profile:certificate-authority:certificate-authoritystate': Certificate_Authority}
@@ -156,7 +160,7 @@ class Certificate_Authority(Resource):
         self._meta_data['required_json_kind'] = \
             'tm:ltm:profile:certificate-authority:certificate-authoritystate'
 
-
+# Delete/Post usupported - need to amend this
 class Classifications(Collection):
     """BIG-IP® Classification profile collection."""
     def __init__(self, profile):
@@ -178,6 +182,8 @@ class Client_Ldaps(Collection):
     """BIG-IP® Client Ldap profile collection."""
     def __init__(self, profile):
         super(Client_Ldaps, self).__init__(profile)
+        fixed = self._meta_data['uri'].replace('_', '-')
+        self._meta_data['uri'] = fixed
         self._meta_data['allowed_lazy_attributes'] = [Client_Ldap]
         self._meta_data['attribute_registry'] = \
             {'tm:ltm:profile:client-ldap:client-ldapstate': Client_Ldap}
@@ -195,6 +201,8 @@ class Client_Ssls(Collection):
     """BIG-IP® Client SSL profile collection."""
     def __init__(self, profile):
         super(Client_Ssls, self).__init__(profile)
+        fixed = self._meta_data['uri'].replace('_', '-')
+        self._meta_data['uri'] = fixed
         self._meta_data['allowed_lazy_attributes'] = [Client_Ssl]
         self._meta_data['attribute_registry'] = \
             {'tm:ltm:profile:client-ssl:client-sslstate': Client_Ssl}
@@ -280,6 +288,8 @@ class Dns_Loggings(Collection):
     """BIG-IP® DNS Logging profile collection."""
     def __init__(self, profile):
         super(Dns_Loggings, self).__init__(profile)
+        fixed = self._meta_data['uri'].replace('_', '-')
+        self._meta_data['uri'] = fixed
         self._meta_data['allowed_lazy_attributes'] = [Dns_Logging]
         self._meta_data['attribute_registry'] = \
             {'tm:ltm:profile:dns-logging:dns-loggingstate': Dns_Logging}
@@ -416,6 +426,8 @@ class Http_Compressions(Collection):
     """BIG-IP® Http_Compression profile collection."""
     def __init__(self, profile):
         super(Http_Compressions, self).__init__(profile)
+        fixed = self._meta_data['uri'].replace('_', '-')
+        self._meta_data['uri'] = fixed
         self._meta_data['allowed_lazy_attributes'] = [Http_Compression]
         self._meta_data['attribute_registry'] = \
             {'tm:ltm:profile:http-compression:http-compressionstate': Http_Compression}
@@ -552,6 +564,8 @@ class Ocsp_Stapling_Params_s(Collection):
     """BIG-IP® Ocsp_Stapling_Params profile collection."""
     def __init__(self, profile):
         super(Ocsp_Stapling_Params_s, self).__init__(profile)
+        fixed = self._meta_data['uri'].replace('_', '-')
+        self._meta_data['uri'] = fixed
         self._meta_data['allowed_lazy_attributes'] = [Ocsp_Stapling_Params]
         self._meta_data['attribute_registry'] = \
             {'tm:ltm:profile:ocsp-stapling-params:ocsp-stapling-paramsstate': Ocsp_Stapling_Params}
@@ -569,6 +583,8 @@ class One_Connects(Collection):
     """BIG-IP® One_Connect profile collection."""
     def __init__(self, profile):
         super(One_Connects, self).__init__(profile)
+        fixed = self._meta_data['uri'].replace('_', '-')
+        self._meta_data['uri'] = fixed
         self._meta_data['allowed_lazy_attributes'] = [One_Connect]
         self._meta_data['attribute_registry'] = \
             {'tm:ltm:profile:one-connect:one-connectstate': One_Connect}
@@ -664,6 +680,8 @@ class Request_Adapts(Collection):
     """BIG-IP® Request_Adapt profile collection."""
     def __init__(self, profile):
         super(Request_Adapts, self).__init__(profile)
+        fixed = self._meta_data['uri'].replace('_', '-')
+        self._meta_data['uri'] = fixed
         self._meta_data['allowed_lazy_attributes'] = [Request_Adapt]
         self._meta_data['attribute_registry'] = \
             {'tm:ltm:profile:request-adapt:request-adaptstate': Request_Adapt}
@@ -681,6 +699,8 @@ class Request_Logs(Collection):
     """BIG-IP® Request_Log profile collection."""
     def __init__(self, profile):
         super(Request_Logs, self).__init__(profile)
+        fixed = self._meta_data['uri'].replace('_', '-')
+        self._meta_data['uri'] = fixed
         self._meta_data['allowed_lazy_attributes'] = [Request_Log]
         self._meta_data['attribute_registry'] = \
             {'tm:ltm:profile:request-log:request-logstate': Request_Log}
@@ -698,6 +718,8 @@ class Response_Adapts(Collection):
     """BIG-IP® Response_Adapt profile collection."""
     def __init__(self, profile):
         super(Response_Adapts, self).__init__(profile)
+        fixed = self._meta_data['uri'].replace('_', '-')
+        self._meta_data['uri'] = fixed
         self._meta_data['allowed_lazy_attributes'] = [Response_Adapt]
         self._meta_data['attribute_registry'] = \
             {'tm:ltm:profile:response-adapt:response-adaptstate': Response_Adapt}
@@ -736,6 +758,8 @@ class Uri_Rules_s(Collection):
     """BIG-IP® Rewrite sub-collection."""
     def __init__(self, Rewrite):
         super(Uri_Rules_s, self).__init__(Rewrite)
+        fixed = self._meta_data['uri'].replace('_', '-')
+        self._meta_data['uri'] = fixed
         self._meta_data['allowed_lazy_attributes'] = [Uri_Rules]
         self._meta_data['attribute_registry'] = \
             {'tm:ltm:profile:rewrite:uri-rules:uri-rulesstate': Uri_Rules}
@@ -786,6 +810,8 @@ class Server_Ldaps(Collection):
     """BIG-IP® Server_Ldap profile collection."""
     def __init__(self, profile):
         super(Server_Ldaps, self).__init__(profile)
+        fixed = self._meta_data['uri'].replace('_', '-')
+        self._meta_data['uri'] = fixed
         self._meta_data['allowed_lazy_attributes'] = [Server_Ldap]
         self._meta_data['attribute_registry'] = \
             {'tm:ltm:profile:server-ldap:server-ldapstate': Server_Ldap}
@@ -803,6 +829,8 @@ class Server_Ssls(Collection):
     """BIG-IP® Server_Ssl profile collection."""
     def __init__(self, profile):
         super(Server_Ssls, self).__init__(profile)
+        fixed = self._meta_data['uri'].replace('_', '-')
+        self._meta_data['uri'] = fixed
         self._meta_data['allowed_lazy_attributes'] = [Server_Ssl]
         self._meta_data['attribute_registry'] = \
             {'tm:ltm:profile:server-ssl:server-sslstate': Server_Ssl}
@@ -1003,6 +1031,8 @@ class Web_Accelerations(Collection):
     """BIG-IP® Web_Acceleration profile collection."""
     def __init__(self, profile):
         super(Web_Accelerations, self).__init__(profile)
+        fixed = self._meta_data['uri'].replace('_', '-')
+        self._meta_data['uri'] = fixed
         self._meta_data['allowed_lazy_attributes'] = [Web_Acceleration]
         self._meta_data['attribute_registry'] = \
             {'tm:ltm:profile:web-acceleration:web-accelerationstate': Web_Acceleration}
@@ -1020,6 +1050,8 @@ class Web_Securitys(Collection):
     """BIG-IP® Web_Security profile collection."""
     def __init__(self, profile):
         super(Web_Securitys, self).__init__(profile)
+        fixed = self._meta_data['uri'].replace('_', '-')
+        self._meta_data['uri'] = fixed
         self._meta_data['allowed_lazy_attributes'] = [Web_Security]
         self._meta_data['attribute_registry'] = \
             {'tm:ltm:profile:web-security:web-securitystate': Web_Security}

--- a/f5/bigip/tm/ltm/profile.py
+++ b/f5/bigip/tm/ltm/profile.py
@@ -86,7 +86,7 @@ class Analytics_s(Collection):
 
     .. note::
          Profile and sub-collections
-         requires AVR provisioned.
+         require AVR provisioned.
     """
     def __init__(self, profile):
         super(Analytics_s, self).__init__(profile)
@@ -160,7 +160,7 @@ class Certificate_Authority(Resource):
         self._meta_data['required_json_kind'] = \
             'tm:ltm:profile:certificate-authority:certificate-authoritystate'
 
-# Delete/Post usupported - need to amend this
+
 class Classifications(Collection):
     """BIG-IP® Classification profile collection."""
     def __init__(self, profile):
@@ -176,6 +176,24 @@ class Classification(Resource):
         super(Classification, self).__init__(Classifications)
         self._meta_data['required_json_kind'] = \
             'tm:ltm:profile:classification:classificationstate'
+
+    def create(self, **kwargs):
+        """Create is not supported for Classification
+
+        :raises: UnsupportedOperation
+        """
+        raise UnsupportedOperation(
+            "%s does not support the update method" % self.__class__.__name__
+        )
+
+    def delete(self, **kwargs):
+        """Delete is not supported for Classification
+
+        :raises: UnsupportedOperation
+        """
+        raise UnsupportedOperation(
+            "%s does not support the delete method" % self.__class__.__name__
+        )
 
 
 class Client_Ldaps(Collection):

--- a/f5/bigip/tm/ltm/test/test_profile.py
+++ b/f5/bigip/tm/ltm/test/test_profile.py
@@ -1,0 +1,84 @@
+# Copyright 2016 F5 Networks Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+
+import mock
+import pytest
+
+from f5.bigip.resource import MissingRequiredCreationParameter
+from f5.bigip.resource import UnsupportedOperation
+from f5.bigip.tm.ltm.profile import Classification
+from f5.bigip.tm.ltm.profile import Ocsp_Stapling_Params
+from f5.bigip.tm.ltm.profile import Web_Security
+
+
+@pytest.fixture
+def fake_klass():
+    fake_kl = mock.MagicMock()
+    return Classification(fake_kl)
+
+
+@pytest.fixture
+def fake_ocsp_staple():
+    fake_ocsp = mock.MagicMock()
+    return Ocsp_Stapling_Params(fake_ocsp)
+
+
+@pytest.fixture
+def fake_websec():
+    fake_websec = mock.MagicMock()
+    return Web_Security(fake_websec)
+
+
+class TestClassification(object):
+    def test_create_raises(self):
+        with pytest.raises(UnsupportedOperation):
+            k = fake_klass()
+            k.create(name='random')
+
+    def test_delete_raises(self):
+        with pytest.raises(UnsupportedOperation):
+            k = fake_klass()
+            k.delete()
+
+
+class TestOcspStaple(object):
+    def test_create_conflict(self):
+        with pytest.raises(MissingRequiredCreationParameter):
+            ocsp = fake_ocsp_staple()
+            ocsp.create(name='fake.ocsp', useProxyServer='enabled',
+                        trustedCa='/partition/fakeCA', dnsResolver='fake.dns')
+
+
+class TestWebSecurity(object):
+    def test_create_raises(self):
+        with pytest.raises(UnsupportedOperation):
+            ws = fake_websec()
+            ws.create(name='random')
+
+    def test_update_raises(self):
+        with pytest.raises(UnsupportedOperation):
+            ws = fake_websec()
+            ws.update()
+
+    def test_refresh_raises(self):
+        with pytest.raises(UnsupportedOperation):
+            ws = fake_websec()
+            ws.refresh()
+
+    def test_delete_raises(self):
+        with pytest.raises(UnsupportedOperation):
+            ws = fake_websec()
+            ws.delete()

--- a/f5/bigip/tm/net/dns_resolver.py
+++ b/f5/bigip/tm/net/dns_resolver.py
@@ -15,7 +15,7 @@
 # limitations under the License.
 #
 
-"""BIG-IP® Network ARP module.
+"""BIG-IP® Network DNS Resolver module.
 
 REST URI
     ``http://localhost/mgmt/tm/net/dns-resolver``

--- a/test/functional/ltm/test_profile.py
+++ b/test/functional/ltm/test_profile.py
@@ -14,12 +14,11 @@ common = 'bigip.ltm.profile.'
 
 # Helper class to limit code repetition
 class HelperTest(object):
-    def __init__(self, partition, name, item, idx):
-        self.name = name
-        self.partition = partition
+    def __init__(self, item, idx):
         self.item = item
         self.idx = idx
-
+        self.name = 'test' + self.fullstring()
+        self.partition = 'Common'
 
     def fullstring(self):
         if self.item[self.idx].lower()[-2:] == '_s':
@@ -29,49 +28,397 @@ class HelperTest(object):
         full_str = '.' +self.item[self.idx][:-endind]
         return full_str.lower()
 
-
     def setup_test(self, request, bigip):
         def teardown():
             if profile.exists(name=self.name, partition=self.partition):
                 profile.delete()
         request.addfinalizer(teardown)
         hc = common+self.item[self.idx].lower()
-        hc1 = eval(hc)
         profile = eval(hc + self.fullstring())
         profile.create(name=self.name, partition=self.partition)
-        return hc1, profile
+        return hc, profile
+
+    def test_CURDL(self, request, bigip):
+
+        # Testing create
+        hc, profile1 = self.setup_test(request, bigip)
+        assert profile1.name == self.name
+
+        # Testing update
+        profile1.description = TESTDESCRIPTION
+        profile1.update()
+        assert profile1.description == TESTDESCRIPTION
+
+        # Testing refresh
+        profile1.description = ''
+        profile1.refresh()
+        assert profile1.description == TESTDESCRIPTION
+
+        # Testing load
+        profile2 = eval(hc+self.fullstring())
+        profile2.load(partition=self.partition, name=self.name)
+        assert profile1.selfLink == profile2.selfLink
 
 # Begin Analytics tests
 ##placeholder
 # End Analytics tests
 
-# Begin Analytics tests
+# Begin Certificate Authority tests
+class TestCertifcateAutority(object):
+    def test_ca(self, request, bigip):
+        ca = HelperTest(end_lst, 0)
+        ca.test_CURDL(request, bigip)
+# End Certificate Authority tests
 
-# End Analytics tests
+# Begin Classification tests
+##placeholder
+# End Classification tests
 
+# Begin ClientLdap tests
+class TestClientLdap(object):
+    def test_clientldap(self, request, bigip):
+        ldap = HelperTest(end_lst, 2)
+        ldap.test_CURDL(request, bigip)
+# End ClientLdap tests
+
+# Begin ClientSSL tests
+class TestClientSsl(object):
+    def test_clientssl(self, request, bigip):
+        cssl = HelperTest(end_lst, 3)
+        cssl.test_CURDL(request, bigip)
+# End ClientSSL tests
+
+# Begin Dhcpv4 tests
+class TestDhcpv4(object):
+    def test_dhcpv4(self, request, bigip):
+        dhcpv4 = HelperTest(end_lst, 4)
+        dhcpv4.test_CURDL(request, bigip)
+# End Dhcpv4 tests
+
+# Begin Dhcpv6 tests
+class TestDhcpv6(object):
+    def test_dhcpv6(self, request, bigip):
+        dhcpv6 = HelperTest(end_lst, 5)
+        dhcpv6.test_CURDL(request, bigip)
+# End Dhcpv6 tests
+
+# Begin Diameter tests
+class TestDiameter(object):
+    def test_diameter(self, request, bigip):
+        diameter = HelperTest(end_lst, 6)
+        diameter.test_CURDL(request, bigip)
+# End Diameter tests
+
+# Begin Dns tests
+class TestDns(object):
+    def test_dns(self, request, bigip):
+        dns = HelperTest(end_lst, 7)
+        dns.test_CURDL(request, bigip)
+# End Dns tests
+
+# Begin Dns Logging tests -- needs publisher configured beforehand
+class TestDnsLogging(object):
+    def test_dns_logging(self, request, bigip):
+        dnslog = HelperTest(end_lst, 8)
+        dnslog.test_CURDL(request, bigip)
+# End Dns Logging test
+
+# Begin FastHttp tests
+class TestFastHttp(object):
+    def test_fasthttp(self, request, bigip):
+        fasthttp = HelperTest(end_lst, 9)
+        fasthttp.test_CURDL(request, bigip)
+# End FastHttp tests
+
+# Begin FastL4 tests
+class TestFastL4(object):
+    def test_fastl4(self, request, bigip):
+        fastl4 = HelperTest(end_lst, 10)
+        fastl4.test_CURDL(request, bigip)
+# End FastL4 tests
+
+# Begin Fix tests
+class TestFix(object):
+    def test_fix(self, request, bigip):
+        fix = HelperTest(end_lst, 11)
+        fix.test_CURDL(request, bigip)
+# End Fix tests
+
+# Begin FTP tests
+class TestFtp(object):
+    def test_ftp(self, request, bigip):
+        ftp = HelperTest(end_lst, 12)
+        ftp.test_CURDL(request, bigip)
+# End FTP tests
+
+# Begin GTP tests
+class TestGtp(object):
+    def test_gtp(self, request, bigip):
+        gtp = HelperTest(end_lst, 13)
+        gtp.test_CURDL(request, bigip)
+# End GTP tests
+
+# Begin HTML tests
+class TestHtml(object):
+    def test_html(self, request, bigip):
+        html = HelperTest(end_lst, 14)
+        html.test_CURDL(request, bigip)
+# End HTML tests
 
 # Begin HTTP tests
 class TestHttp(object):
-    def test_CURDL(self, request, bigip):
-        h = HelperTest('Common', 'test1', end_lst, 15)
-
-        # Testing create
-        hc1, http1 = h.setup_test(request, bigip)
-        assert http1.name == 'test1'
-
-        # Testing update
-        http1.description = TESTDESCRIPTION
-        http1.update()
-        assert http1.description == TESTDESCRIPTION
-
-        # Testing refresh
-        http1.description = ''
-        http1.refresh()
-        assert http1.description == TESTDESCRIPTION
-
-        # Testing load
-        http2 = hc1.http
-        http2.load(partition='Common', name='test1')
-        assert http2.selfLink == http1.selfLink
-
+    def test_http(self, request, bigip):
+        http = HelperTest(end_lst, 15)
+        http.test_CURDL(request, bigip)
 # End HTTP tests
+
+# Begin HTTP Compression tests
+class TestHttpCompress(object):
+    def test_httpcompress(self, request, bigip):
+        httpc = HelperTest(end_lst, 16)
+        httpc.test_CURDL(request, bigip)
+# End HTTP Compression tests
+
+# Begin HTTP tests
+class TestHttp2(object):
+    def test_http2(self, request, bigip):
+        http2 = HelperTest(end_lst, 17)
+        http2.test_CURDL(request, bigip)
+# End HTTP tests
+
+# Begin ICAP tests - Failing ## no attribute description
+class TestIcap(object):
+    def test_icap(self, request, bigip):
+        icap = HelperTest(end_lst, 18)
+        icap.test_CURDL(request, bigip)
+# End ICAP tests
+
+# Begin IIOP tests
+class TestIiop(object):
+    def test_iiop(self, request, bigip):
+        iiop = HelperTest(end_lst, 19)
+        iiop.test_CURDL(request, bigip)
+# End IIOP tests
+
+# Begin Ipother tests
+class TestIother(object):
+    def test_ipother(self, request, bigip):
+        ipoth = HelperTest(end_lst, 20)
+        ipoth.test_CURDL(request, bigip)
+# End Ipother tests
+
+# Begin Mblb tests
+class TestMblb(object):
+    def test_mblb(self, request, bigip):
+        mblb = HelperTest(end_lst, 21)
+        mblb.test_CURDL(request, bigip)
+# End Mblb tests
+
+# Begin Mssql tests
+class TestMssql(object):
+    def test_mssql(self, request, bigip):
+        mssql = HelperTest(end_lst, 22)
+        mssql.test_CURDL(request, bigip)
+# End Mssql tests
+
+# Begin Ntlm tests
+class TestNtlm(object):
+    def test_Ntlm(self, request, bigip):
+        ntlm = HelperTest(end_lst, 23)
+        ntlm.test_CURDL(request, bigip)
+# End Ntlm tests
+
+# Begin Ocsp Stapling Params tests ## Needs to determine dns resolver
+class TestOcspStaplingParams(object):
+    def test_ocspstapleparam(self, request, bigip):
+        ocspst = HelperTest(end_lst, 24)
+        ocspst.test_CURDL(request, bigip)
+# End Ocsp Stapling Params tests
+
+# Begin Oneconnect tests
+class TestOneConnect(object):
+    def test_oneconnect(self, request, bigip):
+        onec = HelperTest(end_lst, 25)
+        onec.test_CURDL(request, bigip)
+# End Oneconnect tests
+
+# Begin Pcp tests
+class TestPcp(object):
+    def test_pcp(self, request, bigip):
+        pcp = HelperTest(end_lst, 26)
+        pcp.test_CURDL(request, bigip)
+# End Pcp tests
+
+# Begin Pptp tests
+class TestPptp(object):
+    def test_pptp(self, request, bigip):
+        pptp = HelperTest(end_lst, 27)
+        pptp.test_CURDL(request, bigip)
+# End Pptp tests
+
+# Begin Qoe tests
+class TestQoe(object):
+    def test_qoe(self, request, bigip):
+        qoe = HelperTest(end_lst, 28)
+        qoe.test_CURDL(request, bigip)
+# End Qoe tests
+
+# Begin Radius tests
+class TestRadius(object):
+    def test_radius(self, request, bigip):
+        radius = HelperTest(end_lst, 29)
+        radius.test_CURDL(request, bigip)
+# End Radius tests
+
+# Begin Ramcache tests
+##placeholder
+# End Ramcache tests
+
+# Begin Request Adapt tests -- no attribute Description
+class TestRequestAdapt(object):
+    def test_request_adapt(self, request, bigip):
+        rq_adp = HelperTest( end_lst, 30)
+        rq_adp.test_CURDL(request, bigip)
+# End Request Adapt tests
+
+# Begin Request Log tests
+class TestRequestLog(object):
+    def test_request_log(self, request, bigip):
+        rq_log = HelperTest(end_lst, 31)
+        rq_log.test_CURDL(request, bigip)
+# End Request Log tests
+
+# Begin Response Adapt tests  -- no attribute Description
+class TestResponseAdapt(object):
+    def test_response_adapt(self, request, bigip):
+        res_adp = HelperTest(end_lst, 32)
+        res_adp.test_CURDL(request, bigip)
+# End Response Adapt tests
+
+# Begin Rewrite tests
+## placeholder
+# End Rewrite tests
+
+# Begin Rstps tests
+class TestRstps(object):
+    def test_rstps(self, request, bigip):
+        rstps = HelperTest(end_lst, 33)
+        rstps.test_CURDL(request, bigip)
+# End Rstps tests
+
+# Begin Sctps tests
+class TestSctps(object):
+    def test_sctps(self, request, bigip):
+        sctps = HelperTest(end_lst, 34)
+        sctps.test_CURDL(request, bigip)
+# End Sctps tests
+
+# Begin Server Ldap tests
+class TestServerLdap(object):
+    def test_server_ldap(self, request, bigip):
+        sldap = HelperTest(end_lst, 35)
+        sldap.test_CURDL(request, bigip)
+# End Server Ldap tests
+
+# Begin Server Ssl tests
+class TestServerSsl(object):
+    def test_server_ssl(self, request, bigip):
+        sssl = HelperTest(end_lst, 36)
+        sssl.test_CURDL(request, bigip)
+# End Server Ldap tests
+
+# Begin Sip tests
+class TestSip(object):
+    def test_sip(self, request, bigip):
+        sip = HelperTest(end_lst, 37)
+        sip.test_CURDL(request, bigip)
+# End Sip tests
+
+# Begin Smtp tests
+class TestSmtp(object):
+    def test_smtp(self, request, bigip):
+        smtp = HelperTest(end_lst, 38)
+        smtp.test_CURDL(request, bigip)
+# End Smtp tests
+
+# Begin Smtps tests -- this needs some special treatment as it barfs with name conflicts
+class TestSmtps(object):
+    def test_smtps(self, request, bigip):
+        smtps = HelperTest(end_lst, 39)
+        smtps.test_CURDL(request, bigip)
+# End Smtps tests
+
+# Begin Sock tests --needs dns resolver
+class TestSock(object):
+    def test_sock(self, request, bigip):
+        socks = HelperTest(end_lst, 40)
+        socks.test_CURDL(request, bigip)
+# End Sock tests
+
+# Begin Spdy tests
+class TestSpdy(object):
+    def test_spdy(self, request, bigip):
+        spdy = HelperTest(end_lst, 41)
+        spdy.test_CURDL(request, bigip)
+# End Spdy tests
+
+# Begin Statistics tests
+class TestStatistics(object):
+    def test_statistics(self, request, bigip):
+        stat = HelperTest(end_lst, 42)
+        stat.test_CURDL(request, bigip)
+# End Statistics tests
+
+# Begin Stream tests
+class TestStream(object):
+    def test_stream(self, request, bigip):
+        stream = HelperTest(end_lst, 43)
+        stream.test_CURDL(request, bigip)
+# End Stream tests
+
+# Begin Tcp tests
+class TestTcp(object):
+    def test_tcp(self, request, bigip):
+        testcp = HelperTest(end_lst, 44)
+        testcp.test_CURDL(request, bigip)
+# End Tcp tests
+
+# Begin Tftp tests
+class TestTftp(object):
+    def test_tftp(self, request, bigip):
+        tftp = HelperTest(end_lst, 45)
+        tftp.test_CURDL(request, bigip)
+# End Tftp tests
+
+# Begin Udp tests
+class TestUdp(object):
+    def test_udp(self, request, bigip):
+        tesudp = HelperTest(end_lst, 46)
+        tesudp.test_CURDL(request, bigip)
+# End Udp tests
+
+# Begin Wa Cache tests
+## placeholder
+# End Wa Cache tests
+
+# Begin WebAcceleration tests --no attribute description
+class TestWebAcceleration(object):
+    def test_web_acceleration(self, request, bigip):
+        wa = HelperTest(end_lst, 47)
+        wa.test_CURDL(request, bigip)
+# End Web Acceleration tests
+
+# Begin Web Security tests -- no attribute description
+class TestWebSecurity(object):
+    def test_web_security(self, request, bigip):
+        ws = HelperTest(end_lst, 48)
+        ws.test_CURDL(request, bigip)
+# End Web Security tests
+
+# Begin Xml tests
+class TestXml(object):
+    def test_xml(self, request, bigip):
+        testxml = HelperTest(end_lst, 49)
+        testxml.test_CURDL(request, bigip)
+# End Xml tests
+

--- a/test/functional/ltm/test_profile.py
+++ b/test/functional/ltm/test_profile.py
@@ -28,20 +28,20 @@ class HelperTest(object):
         full_str = '.' +self.item[self.idx][:-endind]
         return full_str.lower()
 
-    def setup_test(self, request, bigip):
+    def setup_test(self, request, bigip, **kwargs):
         def teardown():
             if profile.exists(name=self.name, partition=self.partition):
                 profile.delete()
         request.addfinalizer(teardown)
         hc = common+self.item[self.idx].lower()
         profile = eval(hc + self.fullstring())
-        profile.create(name=self.name, partition=self.partition)
+        profile.create(name=self.name, partition=self.partition, **kwargs)
         return hc, profile
 
-    def test_CURDL(self, request, bigip):
+    def test_CURDL(self, request, bigip, **kwargs):
 
         # Testing create
-        hc, profile1 = self.setup_test(request, bigip)
+        hc, profile1 = self.setup_test(request, bigip, **kwargs)
         assert profile1.name == self.name
 
         # Testing update
@@ -116,11 +116,12 @@ class TestDns(object):
         dns.test_CURDL(request, bigip)
 # End Dns tests
 
-# Begin Dns Logging tests -- needs publisher configured beforehand
+# Begin Dns Logging tests
 class TestDnsLogging(object):
     def test_dns_logging(self, request, bigip):
         dnslog = HelperTest(end_lst, 8)
-        dnslog.test_CURDL(request, bigip)
+        dnslog.test_CURDL(request, bigip,
+                          logPublisher='/Common/local-db-publisher')
 # End Dns Logging test
 
 # Begin FastHttp tests
@@ -228,7 +229,8 @@ class TestNtlm(object):
         ntlm.test_CURDL(request, bigip)
 # End Ntlm tests
 
-# Begin Ocsp Stapling Params tests ## Needs to determine dns resolver
+# Begin Ocsp Stapling Params tests ## Needs to determine dns resolver or proxy,
+# so 2 mutually exclusive and required attr
 class TestOcspStaplingParams(object):
     def test_ocspstapleparam(self, request, bigip):
         ocspst = HelperTest(end_lst, 24)
@@ -348,7 +350,7 @@ class TestSmtps(object):
         smtps.test_CURDL(request, bigip)
 # End Smtps tests
 
-# Begin Sock tests --needs dns resolver
+# Begin Sock tests --needs dns resolver and does not support description
 class TestSock(object):
     def test_sock(self, request, bigip):
         socks = HelperTest(end_lst, 40)

--- a/test/functional/ltm/test_profile.py
+++ b/test/functional/ltm/test_profile.py
@@ -1,0 +1,77 @@
+
+TESTDESCRIPTION = "TESTDESCRIPTION"
+
+end_lst = ['Certificate_Authoritys', 'Classifications', 'Client_Ldaps', 'Client_Ssls',
+       'Dhcpv4s','Dhcpv6s', 'Diameters', 'Dns_s', 'Dns_Loggings', 'Fasthttps',
+       'Fastl4s', 'Fixs', 'Ftps','Gtps', 'Htmls', 'Https', 'Http_Compressions',
+       'Http2s', 'Icaps', 'Iiops', 'Ipothers', 'Mblbs', 'Mssqls', 'Ntlms',
+       'Ocsp_Stapling_Params_s', 'One_Connects', 'Pcps', 'Pptps', 'Qoes', 'Radius_s',
+       'Request_Adapts', 'Request_Logs', 'Response_Adapts', 'Rtsps', 'Sctps','Server_Ldaps',
+       'Server_Ssls', 'Sips', 'Smtps', 'Smtps_s', 'Socks_s','Spdys', 'Statistics_s', 'Streams',
+       'Tcps', 'Tftps', 'Udps', 'Web_Accelerations', 'Web_Securitys', 'Xmls']
+common = 'bigip.ltm.profile.'
+
+
+# Helper class to limit code repetition
+class HelperTest(object):
+    def __init__(self, partition, name, item, idx):
+        self.name = name
+        self.partition = partition
+        self.item = item
+        self.idx = idx
+
+
+    def fullstring(self):
+        if self.item[self.idx].lower()[-2:] == '_s':
+            endind = 2
+        else:
+            endind = 1
+        full_str = '.' +self.item[self.idx][:-endind]
+        return full_str.lower()
+
+
+    def setup_test(self, request, bigip):
+        def teardown():
+            if profile.exists(name=self.name, partition=self.partition):
+                profile.delete()
+        request.addfinalizer(teardown)
+        hc = common+self.item[self.idx].lower()
+        hc1 = eval(hc)
+        profile = eval(hc + self.fullstring())
+        profile.create(name=self.name, partition=self.partition)
+        return hc1, profile
+
+# Begin Analytics tests
+##placeholder
+# End Analytics tests
+
+# Begin Analytics tests
+
+# End Analytics tests
+
+
+# Begin HTTP tests
+class TestHttp(object):
+    def test_CURDL(self, request, bigip):
+        h = HelperTest('Common', 'test1', end_lst, 15)
+
+        # Testing create
+        hc1, http1 = h.setup_test(request, bigip)
+        assert http1.name == 'test1'
+
+        # Testing update
+        http1.description = TESTDESCRIPTION
+        http1.update()
+        assert http1.description == TESTDESCRIPTION
+
+        # Testing refresh
+        http1.description = ''
+        http1.refresh()
+        assert http1.description == TESTDESCRIPTION
+
+        # Testing load
+        http2 = hc1.http
+        http2.load(partition='Common', name='test1')
+        assert http2.selfLink == http1.selfLink
+
+# End HTTP tests

--- a/test/functional/ltm/test_profile.py
+++ b/test/functional/ltm/test_profile.py
@@ -1,3 +1,17 @@
+# Copyright 2015-2106 F5 Networks Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
 
 TESTDESCRIPTION = "TESTDESCRIPTION"
 
@@ -60,7 +74,10 @@ class HelperTest(object):
         assert profile1.selfLink == profile2.selfLink
 
 # Begin Analytics tests
-##placeholder
+class TestAnalyticsCollection(object):
+    def test_get_collection(self, request, bigip):
+
+
 # End Analytics tests
 
 # Begin Certificate Authority tests

--- a/test/functional/tm/ltm/test_profile.py
+++ b/test/functional/tm/ltm/test_profile.py
@@ -93,7 +93,7 @@ def setup_test_subc(request, bigip):
     return prf_alert, prf_traffic, avrhc1
 
 class TestAnalytics(object):
-    def test_analytics_CURDL(self, request, bigip):
+    def test_CURDL(self, request, bigip):
         avr = HelperTest(end_lst, 50)
         avr.test_CURDL(request, bigip)
 
@@ -124,32 +124,25 @@ class TestAnalyticsSubCol(object):
         # Testing load
         alert2 = avrhc1.alerts_s.alerts.load(name='test_alert')
         assert alert1.name == alert2.name
-        traffic2 = avrhc1.traffic_captures.traffic_capture.load(name='test_traf_cap')
+        traffic2 = avrhc1.traffic_captures.traffic_capture.load(name=
+                                                                'test_traf_cap')
         assert traffic1.name == traffic2.name
 #End Analytics tests
 
 # Begin Certificate Authority tests
 class TestCertifcateAutority(object):
-    def test_ca(self, request, bigip):
+    def test_CURDL(self, request, bigip):
         ca = HelperTest(end_lst, 0)
         ca.test_CURDL(request, bigip)
 # End Certificate Authority tests
 
 # Begin Classification tests
-def setup_class_test(request, bigip):
-    def teardown():
-        if profile.exists(name='classification'):
-            pass
-    request.addfinalizer(teardown)
-    hc = bigip.ltm.profile.classifications
-    profile = hc.classification
-    profile.load(name='classification')
-    return profile, hc
-
 class TestClassification(object):
     def test_RUL(self, request, bigip):
+
         # Load test
-        klass1, hc1 = setup_class_test(request, bigip)
+        klass1 = bigip.ltm.profile.classifications.load(name=
+                                                        'classification')
 
         # Update test
         klass1.description = TESTDESCRIPTION
@@ -164,49 +157,49 @@ class TestClassification(object):
 
 # Begin ClientLdap tests
 class TestClientLdap(object):
-    def test_clientldap(self, request, bigip):
+    def test_CURDL(self, request, bigip):
         ldap = HelperTest(end_lst, 2)
         ldap.test_CURDL(request, bigip)
 # End ClientLdap tests
 
 # Begin ClientSSL tests
 class TestClientSsl(object):
-    def test_clientssl(self, request, bigip):
+    def test_CURDL(self, request, bigip):
         cssl = HelperTest(end_lst, 3)
         cssl.test_CURDL(request, bigip)
 # End ClientSSL tests
 
 # Begin Dhcpv4 tests
 class TestDhcpv4(object):
-    def test_dhcpv4(self, request, bigip):
+    def test_CURDL(self, request, bigip):
         dhcpv4 = HelperTest(end_lst, 4)
         dhcpv4.test_CURDL(request, bigip)
 # End Dhcpv4 tests
 
 # Begin Dhcpv6 tests
 class TestDhcpv6(object):
-    def test_dhcpv6(self, request, bigip):
+    def test_CURDL(self, request, bigip):
         dhcpv6 = HelperTest(end_lst, 5)
         dhcpv6.test_CURDL(request, bigip)
 # End Dhcpv6 tests
 
 # Begin Diameter tests
 class TestDiameter(object):
-    def test_diameter(self, request, bigip):
+    def test_CURDL(self, request, bigip):
         diameter = HelperTest(end_lst, 6)
         diameter.test_CURDL(request, bigip)
 # End Diameter tests
 
 # Begin Dns tests
 class TestDns(object):
-    def test_dns(self, request, bigip):
+    def test_CURDL(self, request, bigip):
         dns = HelperTest(end_lst, 7)
         dns.test_CURDL(request, bigip)
 # End Dns tests
 
 # Begin Dns Logging tests
 class TestDnsLogging(object):
-    def test_dns_logging(self, request, bigip):
+    def test_CURDL(self, request, bigip):
         dnslog = HelperTest(end_lst, 8)
         dnslog.test_CURDL(request, bigip,
                           logPublisher='/Common/local-db-publisher')
@@ -214,70 +207,70 @@ class TestDnsLogging(object):
 
 # Begin FastHttp tests
 class TestFastHttp(object):
-    def test_fasthttp(self, request, bigip):
+    def test_CURDL(self, request, bigip):
         fasthttp = HelperTest(end_lst, 9)
         fasthttp.test_CURDL(request, bigip)
 # End FastHttp tests
 
 # Begin FastL4 tests
 class TestFastL4(object):
-    def test_fastl4(self, request, bigip):
+    def test_CURDL(self, request, bigip):
         fastl4 = HelperTest(end_lst, 10)
         fastl4.test_CURDL(request, bigip)
 # End FastL4 tests
 
 # Begin Fix tests
 class TestFix(object):
-    def test_fix(self, request, bigip):
+    def test_CURDL(self, request, bigip):
         fix = HelperTest(end_lst, 11)
         fix.test_CURDL(request, bigip)
 # End Fix tests
 
 # Begin FTP tests
 class TestFtp(object):
-    def test_ftp(self, request, bigip):
+    def test_CURDL(self, request, bigip):
         ftp = HelperTest(end_lst, 12)
         ftp.test_CURDL(request, bigip)
 # End FTP tests
 
 # Begin GTP tests
 class TestGtp(object):
-    def test_gtp(self, request, bigip):
+    def test_CURDL(self, request, bigip):
         gtp = HelperTest(end_lst, 13)
         gtp.test_CURDL(request, bigip)
 # End GTP tests
 
 # Begin HTML tests
 class TestHtml(object):
-    def test_html(self, request, bigip):
+    def test_CURDL(self, request, bigip):
         html = HelperTest(end_lst, 14)
         html.test_CURDL(request, bigip)
 # End HTML tests
 
 # Begin HTTP tests
 class TestHttp(object):
-    def test_http(self, request, bigip):
+    def test_CURDL(self, request, bigip):
         http = HelperTest(end_lst, 15)
         http.test_CURDL(request, bigip)
 # End HTTP tests
 
 # Begin HTTP Compression tests
 class TestHttpCompress(object):
-    def test_httpcompress(self, request, bigip):
+    def test_CURDL(self, request, bigip):
         httpc = HelperTest(end_lst, 16)
         httpc.test_CURDL(request, bigip)
 # End HTTP Compression tests
 
 # Begin HTTP tests
 class TestHttp2(object):
-    def test_http2(self, request, bigip):
+    def test_CURDL(self, request, bigip):
         http2 = HelperTest(end_lst, 17)
         http2.test_CURDL(request, bigip)
 # End HTTP tests
 
-# Begin ICAP tests - Failing ## no attribute description
+# Begin ICAP tests
 class TestIcap(object):
-    def test_icap(self, request, bigip):
+    def test_CURDL(self, request, bigip):
         icap = HelperTest(end_lst, 18)
 
         # Test Create
@@ -295,53 +288,61 @@ class TestIcap(object):
         assert icap1.previewLength == 100
 
         # Test Load
-        icapc2 = bigip.ltm.profile.icaps.icap.load(
+        icap2 = bigip.ltm.profile.icaps.icap.load(
             name='test.icap', partition='Common')
-        assert icapc1.selfLink == icapc2.selfLink
-
+        assert icap1.selfLink == icap2.selfLink
 # End ICAP tests
 
 # Begin IIOP tests
 class TestIiop(object):
-    def test_iiop(self, request, bigip):
+    def test_CURDL(self, request, bigip):
         iiop = HelperTest(end_lst, 19)
         iiop.test_CURDL(request, bigip)
 # End IIOP tests
 
 # Begin Ipother tests
 class TestIother(object):
-    def test_ipother(self, request, bigip):
+    def ttest_CURDL(self, request, bigip):
         ipoth = HelperTest(end_lst, 20)
         ipoth.test_CURDL(request, bigip)
 # End Ipother tests
 
 # Begin Mblb tests
 class TestMblb(object):
-    def test_mblb(self, request, bigip):
+    def test_CURDL(self, request, bigip):
         mblb = HelperTest(end_lst, 21)
         mblb.test_CURDL(request, bigip)
 # End Mblb tests
 
 # Begin Mssql tests
 class TestMssql(object):
-    def test_mssql(self, request, bigip):
+    def test_CURDL(self, request, bigip):
         mssql = HelperTest(end_lst, 22)
         mssql.test_CURDL(request, bigip)
 # End Mssql tests
 
 # Begin Ntlm tests
 class TestNtlm(object):
-    def test_Ntlm(self, request, bigip):
+    def test_CURDL(self, request, bigip):
         ntlm = HelperTest(end_lst, 23)
         ntlm.test_CURDL(request, bigip)
 # End Ntlm tests
 
 # Begin Ocsp Stapling Params tests ## Needs to determine dns resolver or proxy,
 # so 2 mutually exclusive and required attr
+
+def setup_dns_resolver(self, request, bigip, **kwargs):
+    def teardown():
+        if profile.exists(name=self.name, partition=self.partition):
+            profile.delete()
+    request.addfinalizer(teardown)
+    dns_res=bigip.ltm.
+
+
 class TestOcspStaplingParams(object):
     def test_ocspstapleparam(self, request, bigip):
-        ocspst = HelperTest(end_lst, 24)
-        ocspst.test_CURDL(request, bigip)
+
+
 # End Ocsp Stapling Params tests
 
 # Begin Oneconnect tests
@@ -511,7 +512,7 @@ class TestUdp(object):
 # End Wa Cache tests
 
 
-# Begin WebAcceleration tests --no attribute description
+# Begin WebAcceleration tests
 class TestWebAcceleration(object):
     def test_web_acceleration(self, request, bigip):
         wa = HelperTest(end_lst, 47)
@@ -521,40 +522,32 @@ class TestWebAcceleration(object):
         assert wa1.name == 'test.web_acceleration'
 
         # Test Update
-        wa1.previewLength = 100
+        wa1.cacheAgingRate = 5
         wa1.update()
-        assert wa1.previewLength == 100
+        assert wa1.cacheAgingRate == 5
 
         # Test Refresh
-        wa1.previewLength = 50
+        wa1.cacheAgingRate = 10
         wa1.refresh()
-        assert wa1.previewLength == 100
+        assert wa1.cacheAgingRate == 5
 
         # Test Load
-        wa2 = bigip.ltm.profile.icaps.icap.load(
+        wa2 = bigip.ltm.profile.web_accelerations.web_acceleration.load(
             name='test.web_acceleration', partition='Common')
-        assert wa1.selfLink == wa2.selfLink
+        assert wa1.cacheAgingRate == wa2.cacheAgingRate
 # End Web Acceleration tests
 
 # Begin Web Security tests
 class TestWebSecurity(object):
-    def test_web_security(self, request, bigip):
-        ws = HelperTest(end_lst, 48)
-
-        # Test Create
-        ws1, wspc = ws.setup_test(request, bigip)
-        assert ws1.name == 'test.web_security'
-
-        # Test Load
-        ws2 = bigip.ltm.profile.icaps.icap.load(
-            name='test.web_security', partition='Common')
-        assert ws1.selfLink == ws2.selfLink
-
+    def test_load(self, request, bigip):
+        ws1 = bigip.ltm.profile.web_securitys.web_security.load\
+            (name='websecurity')
+        assert ws1.name == 'websecurity'
 # End Web Security tests
 
 # Begin Xml tests
 class TestXml(object):
-    def test_xml(self, request, bigip):
+    def test_CURDL(self, request, bigip):
         testxml = HelperTest(end_lst, 49)
         testxml.test_CURDL(request, bigip)
 # End Xml tests

--- a/test/functional/tm/ltm/test_profile.py
+++ b/test/functional/tm/ltm/test_profile.py
@@ -15,14 +15,19 @@
 
 TESTDESCRIPTION = "TESTDESCRIPTION"
 
-end_lst = ['Certificate_Authoritys', 'Classifications', 'Client_Ldaps', 'Client_Ssls',
-       'Dhcpv4s','Dhcpv6s', 'Diameters', 'Dns_s', 'Dns_Loggings', 'Fasthttps',
-       'Fastl4s', 'Fixs', 'Ftps','Gtps', 'Htmls', 'Https', 'Http_Compressions',
-       'Http2s', 'Icaps', 'Iiops', 'Ipothers', 'Mblbs', 'Mssqls', 'Ntlms',
-       'Ocsp_Stapling_Params_s', 'One_Connects', 'Pcps', 'Pptps', 'Qoes', 'Radius_s',
-       'Request_Adapts', 'Request_Logs', 'Response_Adapts', 'Rtsps', 'Sctps','Server_Ldaps',
-       'Server_Ssls', 'Sips', 'Smtps', 'Smtps_s', 'Socks_s','Spdys', 'Statistics_s', 'Streams',
-       'Tcps', 'Tftps', 'Udps', 'Web_Accelerations', 'Web_Securitys', 'Xmls', 'Analytics_s']
+end_lst = ['Certificate_Authoritys', 'Classifications', 'Client_Ldaps',
+           'Client_Ssls', 'Dhcpv4s', 'Dhcpv6s', 'Diameters', 'Dns_s',
+           'Dns_Loggings', 'Fasthttps', 'Fastl4s', 'Fixs', 'Ftps',
+           'Gtps', 'Htmls', 'Https', 'Http_Compressions',  'Http2s',
+           'Icaps', 'Iiops', 'Ipothers', 'Mblbs', 'Mssqls', 'Ntlms',
+           'Ocsp_Stapling_Params_s', 'One_Connects', 'Pcps', 'Pptps',
+           'Qoes', 'Radius_s', 'Request_Adapts', 'Request_Logs',
+           'Response_Adapts', 'Rtsps', 'Sctps', 'Server_Ldaps',
+           'Server_Ssls', 'Sips', 'Smtps', 'Smtps_s', 'Socks_s',
+           'Spdys', 'Statistics_s', 'Streams', 'Tcps', 'Tftps', 'Udps',
+           'Web_Accelerations', 'Web_Securitys', 'Xmls', 'Analytics_s',
+           'Rewrites']
+
 common = 'bigip.ltm.profile.'
 
 
@@ -39,7 +44,7 @@ class HelperTest(object):
             endind = 2
         else:
             endind = 1
-        full_str = '.' +self.item[self.idx][:-endind]
+        full_str = '.' + self.item[self.idx][:-endind]
         return full_str.lower()
 
     def setup_test(self, request, bigip, **kwargs):
@@ -96,6 +101,8 @@ class HelperTest(object):
 
 # Begin Analytics tests
 # Sub-collection setup function
+
+
 def setup_test_subc(request, bigip):
     def teardown():
         if prf_alert.exists(name='test_alert'):
@@ -113,10 +120,12 @@ def setup_test_subc(request, bigip):
     request.addfinalizer(teardown)
     return prf_alert, prf_traffic, avrhc1
 
+
 class TestAnalytics(object):
     def test_CURDL(self, request, bigip):
         avr = HelperTest(end_lst, 50)
         avr.test_CURDL(request, bigip)
+
 
 class TestAnalyticsSubCol(object):
     def test_CURDL(self, request, bigip):
@@ -145,19 +154,27 @@ class TestAnalyticsSubCol(object):
         # Testing load
         alert2 = avrhc1.alerts_s.alerts.load(name='test_alert')
         assert alert1.name == alert2.name
-        traffic2 = avrhc1.traffic_captures.traffic_capture.load(name=
-                                                                'test_traf_cap')
+        traffic2 = avrhc1.traffic_captures.traffic_capture.load(
+            name='test_traf_cap')
         assert traffic1.name == traffic2.name
-#End Analytics tests
+
+
+# End Analytics tests
 
 # Begin Certificate Authority tests
+
+
 class TestCertifcateAutority(object):
     def test_CURDL(self, request, bigip):
         ca = HelperTest(end_lst, 0)
         ca.test_CURDL(request, bigip)
+
+
 # End Certificate Authority tests
 
 # Begin Classification tests
+
+
 class TestClassification(object):
     def test_RUL(self, request, bigip):
 
@@ -174,122 +191,189 @@ class TestClassification(object):
         klass1.description = 'ICHANGEDIT'
         klass1.refresh()
         assert klass1.description == TESTDESCRIPTION
+
+
 # End Classification tests
 
 # Begin ClientLdap tests
+
+
 class TestClientLdap(object):
     def test_CURDL(self, request, bigip):
         ldap = HelperTest(end_lst, 2)
         ldap.test_CURDL(request, bigip)
+
+
 # End ClientLdap tests
 
 # Begin ClientSSL tests
+
+
 class TestClientSsl(object):
     def test_CURDL(self, request, bigip):
         cssl = HelperTest(end_lst, 3)
         cssl.test_CURDL(request, bigip)
+
+
 # End ClientSSL tests
 
 # Begin Dhcpv4 tests
+
+
 class TestDhcpv4(object):
     def test_CURDL(self, request, bigip):
         dhcpv4 = HelperTest(end_lst, 4)
         dhcpv4.test_CURDL(request, bigip)
+
+
 # End Dhcpv4 tests
 
 # Begin Dhcpv6 tests
+
+
 class TestDhcpv6(object):
     def test_CURDL(self, request, bigip):
         dhcpv6 = HelperTest(end_lst, 5)
         dhcpv6.test_CURDL(request, bigip)
+
+
 # End Dhcpv6 tests
 
 # Begin Diameter tests
+
+
 class TestDiameter(object):
     def test_CURDL(self, request, bigip):
         diameter = HelperTest(end_lst, 6)
         diameter.test_CURDL(request, bigip)
+
+
 # End Diameter tests
 
 # Begin Dns tests
+
+
 class TestDns(object):
     def test_CURDL(self, request, bigip):
         dns = HelperTest(end_lst, 7)
         dns.test_CURDL(request, bigip)
+
+
 # End Dns tests
 
 # Begin Dns Logging tests
+
+
 class TestDnsLogging(object):
     def test_CURDL(self, request, bigip):
         dnslog = HelperTest(end_lst, 8)
-        dnslog.test_CURDL(request, bigip,
-                          logPublisher='/Common/local-db-publisher')
+        dnslog.test_CURDL(
+            request, bigip, logPublisher='/Common/local-db-publisher')
+
 # End Dns Logging test
 
 # Begin FastHttp tests
+
+
 class TestFastHttp(object):
     def test_CURDL(self, request, bigip):
         fasthttp = HelperTest(end_lst, 9)
         fasthttp.test_CURDL(request, bigip)
+
+
 # End FastHttp tests
 
 # Begin FastL4 tests
+
+
 class TestFastL4(object):
     def test_CURDL(self, request, bigip):
         fastl4 = HelperTest(end_lst, 10)
         fastl4.test_CURDL(request, bigip)
+
+
 # End FastL4 tests
 
 # Begin Fix tests
+
+
 class TestFix(object):
     def test_CURDL(self, request, bigip):
         fix = HelperTest(end_lst, 11)
         fix.test_CURDL(request, bigip)
+
+
 # End Fix tests
 
 # Begin FTP tests
+
+
 class TestFtp(object):
     def test_CURDL(self, request, bigip):
         ftp = HelperTest(end_lst, 12)
         ftp.test_CURDL(request, bigip)
+
+
 # End FTP tests
 
 # Begin GTP tests
+
+
 class TestGtp(object):
     def test_CURDL(self, request, bigip):
         gtp = HelperTest(end_lst, 13)
         gtp.test_CURDL(request, bigip)
+
+
 # End GTP tests
 
 # Begin HTML tests
+
+
 class TestHtml(object):
     def test_CURDL(self, request, bigip):
         html = HelperTest(end_lst, 14)
         html.test_CURDL(request, bigip)
+
+
 # End HTML tests
 
 # Begin HTTP tests
+
+
 class TestHttp(object):
     def test_CURDL(self, request, bigip):
         http = HelperTest(end_lst, 15)
         http.test_CURDL(request, bigip)
+
+
 # End HTTP tests
 
 # Begin HTTP Compression tests
+
+
 class TestHttpCompress(object):
     def test_CURDL(self, request, bigip):
         httpc = HelperTest(end_lst, 16)
         httpc.test_CURDL(request, bigip)
+
+
 # End HTTP Compression tests
 
 # Begin HTTP tests
+
+
 class TestHttp2(object):
     def test_CURDL(self, request, bigip):
         http2 = HelperTest(end_lst, 17)
         http2.test_CURDL(request, bigip)
+
+
 # End HTTP tests
 
 # Begin ICAP tests
+
+
 class TestIcap(object):
     def test_CURDL(self, request, bigip):
         icap = HelperTest(end_lst, 18)
@@ -312,41 +396,63 @@ class TestIcap(object):
         icap2 = bigip.ltm.profile.icaps.icap.load(
             name='test.icap', partition='Common')
         assert icap1.selfLink == icap2.selfLink
+
+
 # End ICAP tests
 
 # Begin IIOP tests
+
+
 class TestIiop(object):
     def test_CURDL(self, request, bigip):
         iiop = HelperTest(end_lst, 19)
         iiop.test_CURDL(request, bigip)
+
+
 # End IIOP tests
 
 # Begin Ipother tests
+
+
 class TestIother(object):
     def ttest_CURDL(self, request, bigip):
         ipoth = HelperTest(end_lst, 20)
         ipoth.test_CURDL(request, bigip)
+
+
 # End Ipother tests
 
 # Begin Mblb tests
+
+
 class TestMblb(object):
     def test_CURDL(self, request, bigip):
         mblb = HelperTest(end_lst, 21)
         mblb.test_CURDL(request, bigip)
+
+
 # End Mblb tests
 
 # Begin Mssql tests
+
+
 class TestMssql(object):
     def test_CURDL(self, request, bigip):
         mssql = HelperTest(end_lst, 22)
         mssql.test_CURDL(request, bigip)
+
+
 # End Mssql tests
 
 # Begin Ntlm tests
+
+
 class TestNtlm(object):
     def test_CURDL(self, request, bigip):
         ntlm = HelperTest(end_lst, 23)
         ntlm.test_CURDL(request, bigip)
+
+
 # End Ntlm tests
 
 # Begin Ocsp Stapling Params tests
@@ -359,135 +465,270 @@ def setup_dns_resolver(request, bigip, name):
     dns_res = bigip.net.dns_resolvers.dns_resolver.create(name=name)
     return dns_res
 
+
 class TestOcspStaplingParams(object):
     def test_CURDL(self, request, bigip):
 
-    # Setup DNS resolver as prerequisite
+        # Setup DNS resolver as prerequisite
         dns = setup_dns_resolver(request, bigip, 'test_resolv')
 
-    # Test CURDL
+        # Test CURDL
         http2 = HelperTest(end_lst, 24)
         http2.test_CURDL(request, bigip,
                          dnsResolver=dns.name,
                          trustedCa='/Common/ca-bundle.crt',
                          useProxyServer='disabled')
 
+
 # End Ocsp Stapling Params tests
 
 # Begin Oneconnect tests
+
+
 class TestOneConnect(object):
     def test_CURDL(self, request, bigip):
         onec = HelperTest(end_lst, 25)
         onec.test_CURDL(request, bigip)
+
+
 # End Oneconnect tests
 
 # Begin Pcp tests
+
+
 class TestPcp(object):
     def test_CURDL(self, request, bigip):
         pcp = HelperTest(end_lst, 26)
         pcp.test_CURDL(request, bigip)
+
+
 # End Pcp tests
 
 # Begin Pptp tests
+
+
 class TestPptp(object):
     def test_CURDL(self, request, bigip):
         pptp = HelperTest(end_lst, 27)
         pptp.test_CURDL(request, bigip)
+
+
 # End Pptp tests
 
 # Begin Qoe tests
+
+
 class TestQoe(object):
     def test_CURDL(self, request, bigip):
         qoe = HelperTest(end_lst, 28)
         qoe.test_CURDL(request, bigip)
+
+
 # End Qoe tests
 
 # Begin Radius tests
+
+
 class TestRadius(object):
     def test_CURDL(self, request, bigip):
         radius = HelperTest(end_lst, 29)
         radius.test_CURDL(request, bigip)
+
+
 # End Radius tests
 
-# Begin Ramcache tests
-##placeholder
-# End Ramcache tests
-
 # Begin Request Adapt tests
+
+
 class TestRequestAdapt(object):
     def test_CURDL(self, request, bigip):
-        rq_adp = HelperTest( end_lst, 30)
+        rq_adp = HelperTest(end_lst, 30)
         rq_adp.test_CURDL_Adapt(request, bigip)
+
+
 # End Request Adapt tests
 
 # Begin Request Log tests
+
+
 class TestRequestLog(object):
     def test_CURDL(self, request, bigip):
         rq_log = HelperTest(end_lst, 31)
         rq_log.test_CURDL(request, bigip)
+
+
 # End Request Log tests
 
 # Begin Response Adapt tests
+
+
 class TestResponseAdapt(object):
     def test_CURDL(self, request, bigip):
         res_adp = HelperTest(end_lst, 32)
         res_adp.test_CURDL_Adapt(request, bigip)
+
+
 # End Response Adapt tests
 
 # Begin Rewrite tests
-## placeholder
+# Sub-collection setup function
+
+
+def setup_test_uri(request, bigip):
+    def teardown():
+        if uri1.exists(name='test.uri'):
+            uri1.delete()
+
+    rewrite = HelperTest(end_lst, 51)
+    url_rw, rewrite_str = rewrite.setup_test(
+        request, bigip, rewriteMode='uri-translation')
+    del rewrite_str
+    client = {'host': 'example.com', 'path': '/', 'scheme': 'http'}
+    server = {'host': 'instance.com', 'path': '/', 'scheme': 'http'}
+    uri1 = url_rw.uri_rules_s.uri_rules.create(name='test.uri',
+                                               type='request',
+                                               client=client,
+                                               server=server)
+    request.addfinalizer(teardown)
+    return uri1, url_rw
+
+
+class TestRewrite(object):
+    def test_CURDL_rewrite(self, request, bigip):
+
+        # Test Create
+        rewrite = HelperTest(end_lst, 51)
+        rewrite1, rewrite_str = \
+            rewrite.setup_test(request, bigip)
+        del rewrite_str
+        assert rewrite1.name == 'test.rewrite'
+
+        # Test update
+        rewrite1.clientCachingType = 'no-cache'
+        rewrite1.update()
+        assert rewrite1.clientCachingType == 'no-cache'
+
+        # Test refresh
+        rewrite1.splitTunneling = 'true'
+        rewrite1.refresh()
+        assert rewrite1.splitTunneling == 'false'
+
+        # Test load
+        rewrite2 = bigip.ltm.profile.rewrites.rewrite.load(name='test.rewrite',
+                                                           partition='Common')
+        assert rewrite1.selfLink == rewrite2.selfLink
+
+
+class TestUriRulesSubCol(object):
+    def test_CURDL(self, request, bigip):
+
+        # Test Create
+        uri1, uri_rw = setup_test_uri(request, bigip)
+        assert uri1.name == 'test.uri'
+
+        # Test Update
+        client = {'host': 'sample.com',
+                  'path': '/', 'scheme': 'https'}
+        uri1.client = client
+        uri1.update()
+        assert uri1.client == {'host': 'sample.com',
+                               'path': '/', 'scheme': 'https'}
+
+        # Test Refresh
+        client = {'host': 'changed.com',
+                  'path': '/', 'scheme': 'http'}
+        uri1.client = client
+        uri1.refresh()
+        assert uri1.client == {'host': 'sample.com',
+                               'path': '/', 'scheme': 'https'}
+
+        # Test Load
+        uri2 = uri_rw.uri_rules_s.uri_rules.load(name='test.uri')
+        assert uri1.selfLink == uri2.selfLink
+
+
 # End Rewrite tests
 
 # Begin Rstps tests
+
+
 class TestRstps(object):
     def test_CURDL(self, request, bigip):
         rstps = HelperTest(end_lst, 33)
         rstps.test_CURDL(request, bigip)
+
+
 # End Rstps tests
 
 # Begin Sctps tests
+
+
 class TestSctps(object):
     def test_CURDL(self, request, bigip):
         sctps = HelperTest(end_lst, 34)
         sctps.test_CURDL(request, bigip)
+
+
 # End Sctps tests
 
 # Begin Server Ldap tests
+
+
 class TestServerLdap(object):
     def test_CURDL(self, request, bigip):
         sldap = HelperTest(end_lst, 35)
         sldap.test_CURDL(request, bigip)
+
+
 # End Server Ldap tests
 
 # Begin Server Ssl tests
+
+
 class TestServerSsl(object):
     def test_CURDL(self, request, bigip):
         sssl = HelperTest(end_lst, 36)
         sssl.test_CURDL(request, bigip)
+
+
 # End Server Ldap tests
 
 # Begin Sip tests
+
+
 class TestSip(object):
     def test_CURDL(self, request, bigip):
         sip = HelperTest(end_lst, 37)
         sip.test_CURDL(request, bigip)
+
+
 # End Sip tests
 
 # Begin Smtp tests
+
+
 class TestSmtp(object):
     def test_CURDL(self, request, bigip):
         smtp = HelperTest(end_lst, 38)
         smtp.test_CURDL(request, bigip)
+
+
 # End Smtp tests
 
-# Begin Smtps tests -- this needs some special treatment as it barfs with name conflicts
+# Begin Smtps tests
+
+
 class TestSmtps(object):
     def test_CURDL(self, request, bigip):
         smtps = HelperTest(end_lst, 39)
         smtps.test_CURDL(request, bigip)
+
+
 # End Smtps tests
 
 # Begin Sock tests
+
+
 class TestSock(object):
     def test_CURDL(self, request, bigip):
 
@@ -496,56 +737,80 @@ class TestSock(object):
         socks = HelperTest(end_lst, 40)
         socks.test_CURDL(request, bigip,
                          dnsResolver=dns.name)
+
+
 # End Sock tests
 
 # Begin Spdy tests
+
+
 class TestSpdy(object):
     def test_CURDL(self, request, bigip):
         spdy = HelperTest(end_lst, 41)
         spdy.test_CURDL(request, bigip)
+
+
 # End Spdy tests
 
 # Begin Statistics tests
+
+
 class TestStatistics(object):
     def test_CURDL(self, request, bigip):
         stat = HelperTest(end_lst, 42)
         stat.test_CURDL(request, bigip)
+
+
 # End Statistics tests
 
 # Begin Stream tests
+
+
 class TestStream(object):
     def test_CURDL(self, request, bigip):
         stream = HelperTest(end_lst, 43)
         stream.test_CURDL(request, bigip)
+
+
 # End Stream tests
 
 # Begin Tcp tests
+
+
 class TestTcp(object):
     def test_CURDL(self, request, bigip):
         testcp = HelperTest(end_lst, 44)
         testcp.test_CURDL(request, bigip)
+
+
 # End Tcp tests
 
 # Begin Tftp tests
+
+
 class TestTftp(object):
     def test_CURDL(self, request, bigip):
         tftp = HelperTest(end_lst, 45)
         tftp.test_CURDL(request, bigip)
+
+
 # End Tftp tests
 
 # Begin Udp tests
+
+
 class TestUdp(object):
     def test_CURDL(self, request, bigip):
         tesudp = HelperTest(end_lst, 46)
         tesudp.test_CURDL(request, bigip)
-# End Udp tests
 
-# Begin Wa Cache tests
-## placeholder
-# End Wa Cache tests
+
+# End Udp tests
 
 
 # Begin WebAcceleration tests
+
+
 class TestWebAcceleration(object):
     def test_CURDL(self, request, bigip):
         wa = HelperTest(end_lst, 47)
@@ -568,20 +833,29 @@ class TestWebAcceleration(object):
         wa2 = bigip.ltm.profile.web_accelerations.web_acceleration.load(
             name='test.web_acceleration', partition='Common')
         assert wa1.cacheAgingRate == wa2.cacheAgingRate
+
+
 # End Web Acceleration tests
 
 # Begin Web Security tests
+
+
 class TestWebSecurity(object):
     def test_load(self, request, bigip):
-        ws1 = bigip.ltm.profile.web_securitys.web_security.load\
-            (name='websecurity')
+        ws1 = bigip.ltm.profile.\
+            web_securitys.web_security.load(name='websecurity')
         assert ws1.name == 'websecurity'
+
+
 # End Web Security tests
 
 # Begin Xml tests
+
+
 class TestXml(object):
     def test_CURDL(self, request, bigip):
         testxml = HelperTest(end_lst, 49)
         testxml.test_CURDL(request, bigip)
-# End Xml tests
 
+
+# End Xml tests

--- a/test/functional/tm/ltm/test_profile.py
+++ b/test/functional/tm/ltm/test_profile.py
@@ -157,12 +157,12 @@ class TestClassification(object):
 
         # Update test
         klass1.description = TESTDESCRIPTION
-        klass.update()
+        klass1.update()
         assert klass1.description == TESTDESCRIPTION
 
         # Refresh test
         klass1.description = 'ICHANGEDIT'
-        klass.refresh()
+        klass1.refresh()
         assert klass1.description == TESTDESCRIPTION
 
 

--- a/test/functional/tm/ltm/test_profile.py
+++ b/test/functional/tm/ltm/test_profile.py
@@ -138,9 +138,7 @@ class TestCertifcateAutority(object):
 # End Certificate Authority tests
 
 # Begin Classification tests
-
-
-def setup_class_test(self, request, bigip):
+def setup_class_test(request, bigip):
     def teardown():
         if profile.exists(name='classification'):
 
@@ -164,13 +162,6 @@ class TestClassification(object):
         klass1.description = 'ICHANGEDIT'
         klass1.refresh()
         assert klass1.description == TESTDESCRIPTION
-
-
-
-
-
-
-
 # End Classification tests
 
 # Begin ClientLdap tests

--- a/test/functional/tm/ltm/test_profile.py
+++ b/test/functional/tm/ltm/test_profile.py
@@ -73,6 +73,27 @@ class HelperTest(object):
         profile2.load(partition=self.partition, name=self.name)
         assert profile1.selfLink == profile2.selfLink
 
+    def test_CURDL_Adapt(self, request, bigip):
+
+        # Testing create
+        profile1, hc = self.setup_test(request, bigip)
+        assert profile1.name == self.name
+
+        # Testing update
+        profile1.timeout = 10
+        profile1.update()
+        assert profile1.timeout == 10
+
+        # Testing refresh
+        profile1.timeout = 0
+        profile1.refresh()
+        assert profile1.timeout == 10
+
+        # Testing load
+        profile2 = eval(hc+self.fullstring())
+        profile2.load(partition=self.partition, name=self.name)
+        assert profile1.selfLink == profile2.selfLink
+
 # Begin Analytics tests
 # Sub-collection setup function
 def setup_test_subc(request, bigip):
@@ -141,8 +162,8 @@ class TestClassification(object):
     def test_RUL(self, request, bigip):
 
         # Load test
-        klass1 = bigip.ltm.profile.classifications.load(name=
-                                                        'classification')
+        klass1 = bigip.ltm.profile.classifications.classification.\
+            load(name='classification')
 
         # Update test
         klass1.description = TESTDESCRIPTION
@@ -328,54 +349,62 @@ class TestNtlm(object):
         ntlm.test_CURDL(request, bigip)
 # End Ntlm tests
 
-# Begin Ocsp Stapling Params tests ## Needs to determine dns resolver or proxy,
-# so 2 mutually exclusive and required attr
+# Begin Ocsp Stapling Params tests
 
-def setup_dns_resolver(self, request, bigip, **kwargs):
+def setup_dns_resolver(request, bigip, name):
     def teardown():
-        if profile.exists(name=self.name, partition=self.partition):
-            profile.delete()
+        if dns_res.exists(name=name):
+            dns_res.delete()
     request.addfinalizer(teardown)
-    dns_res=bigip.ltm.
-
+    dns_res = bigip.net.dns_resolvers.dns_resolver.create(name=name)
+    return dns_res
 
 class TestOcspStaplingParams(object):
-    def test_ocspstapleparam(self, request, bigip):
+    def test_CURDL(self, request, bigip):
 
+    # Setup DNS resolver as prerequisite
+        dns = setup_dns_resolver(request, bigip, 'test_resolv')
+
+    # Test CURDL
+        http2 = HelperTest(end_lst, 24)
+        http2.test_CURDL(request, bigip,
+                         dnsResolver=dns.name,
+                         trustedCa='/Common/ca-bundle.crt',
+                         useProxyServer='disabled')
 
 # End Ocsp Stapling Params tests
 
 # Begin Oneconnect tests
 class TestOneConnect(object):
-    def test_oneconnect(self, request, bigip):
+    def test_CURDL(self, request, bigip):
         onec = HelperTest(end_lst, 25)
         onec.test_CURDL(request, bigip)
 # End Oneconnect tests
 
 # Begin Pcp tests
 class TestPcp(object):
-    def test_pcp(self, request, bigip):
+    def test_CURDL(self, request, bigip):
         pcp = HelperTest(end_lst, 26)
         pcp.test_CURDL(request, bigip)
 # End Pcp tests
 
 # Begin Pptp tests
 class TestPptp(object):
-    def test_pptp(self, request, bigip):
+    def test_CURDL(self, request, bigip):
         pptp = HelperTest(end_lst, 27)
         pptp.test_CURDL(request, bigip)
 # End Pptp tests
 
 # Begin Qoe tests
 class TestQoe(object):
-    def test_qoe(self, request, bigip):
+    def test_CURDL(self, request, bigip):
         qoe = HelperTest(end_lst, 28)
         qoe.test_CURDL(request, bigip)
 # End Qoe tests
 
 # Begin Radius tests
 class TestRadius(object):
-    def test_radius(self, request, bigip):
+    def test_CURDL(self, request, bigip):
         radius = HelperTest(end_lst, 29)
         radius.test_CURDL(request, bigip)
 # End Radius tests
@@ -384,25 +413,25 @@ class TestRadius(object):
 ##placeholder
 # End Ramcache tests
 
-# Begin Request Adapt tests -- no attribute Description
+# Begin Request Adapt tests
 class TestRequestAdapt(object):
-    def test_request_adapt(self, request, bigip):
+    def test_CURDL(self, request, bigip):
         rq_adp = HelperTest( end_lst, 30)
-        rq_adp.test_CURDL(request, bigip)
+        rq_adp.test_CURDL_Adapt(request, bigip)
 # End Request Adapt tests
 
 # Begin Request Log tests
 class TestRequestLog(object):
-    def test_request_log(self, request, bigip):
+    def test_CURDL(self, request, bigip):
         rq_log = HelperTest(end_lst, 31)
         rq_log.test_CURDL(request, bigip)
 # End Request Log tests
 
-# Begin Response Adapt tests  -- no attribute Description
+# Begin Response Adapt tests
 class TestResponseAdapt(object):
-    def test_response_adapt(self, request, bigip):
+    def test_CURDL(self, request, bigip):
         res_adp = HelperTest(end_lst, 32)
-        res_adp.test_CURDL(request, bigip)
+        res_adp.test_CURDL_Adapt(request, bigip)
 # End Response Adapt tests
 
 # Begin Rewrite tests
@@ -411,98 +440,102 @@ class TestResponseAdapt(object):
 
 # Begin Rstps tests
 class TestRstps(object):
-    def test_rstps(self, request, bigip):
+    def test_CURDL(self, request, bigip):
         rstps = HelperTest(end_lst, 33)
         rstps.test_CURDL(request, bigip)
 # End Rstps tests
 
 # Begin Sctps tests
 class TestSctps(object):
-    def test_sctps(self, request, bigip):
+    def test_CURDL(self, request, bigip):
         sctps = HelperTest(end_lst, 34)
         sctps.test_CURDL(request, bigip)
 # End Sctps tests
 
 # Begin Server Ldap tests
 class TestServerLdap(object):
-    def test_server_ldap(self, request, bigip):
+    def test_CURDL(self, request, bigip):
         sldap = HelperTest(end_lst, 35)
         sldap.test_CURDL(request, bigip)
 # End Server Ldap tests
 
 # Begin Server Ssl tests
 class TestServerSsl(object):
-    def test_server_ssl(self, request, bigip):
+    def test_CURDL(self, request, bigip):
         sssl = HelperTest(end_lst, 36)
         sssl.test_CURDL(request, bigip)
 # End Server Ldap tests
 
 # Begin Sip tests
 class TestSip(object):
-    def test_sip(self, request, bigip):
+    def test_CURDL(self, request, bigip):
         sip = HelperTest(end_lst, 37)
         sip.test_CURDL(request, bigip)
 # End Sip tests
 
 # Begin Smtp tests
 class TestSmtp(object):
-    def test_smtp(self, request, bigip):
+    def test_CURDL(self, request, bigip):
         smtp = HelperTest(end_lst, 38)
         smtp.test_CURDL(request, bigip)
 # End Smtp tests
 
 # Begin Smtps tests -- this needs some special treatment as it barfs with name conflicts
 class TestSmtps(object):
-    def test_smtps(self, request, bigip):
+    def test_CURDL(self, request, bigip):
         smtps = HelperTest(end_lst, 39)
         smtps.test_CURDL(request, bigip)
 # End Smtps tests
 
-# Begin Sock tests --needs dns resolver and does not support description
+# Begin Sock tests
 class TestSock(object):
-    def test_sock(self, request, bigip):
+    def test_CURDL(self, request, bigip):
+
+        dns = setup_dns_resolver(request, bigip,
+                                 'test_resolv')
         socks = HelperTest(end_lst, 40)
-        socks.test_CURDL(request, bigip)
+        socks.test_CURDL(request, bigip,
+                         dnsResolver=dns.name)
 # End Sock tests
 
 # Begin Spdy tests
 class TestSpdy(object):
-    def test_spdy(self, request, bigip):
+    def test_CURDL(self, request, bigip):
         spdy = HelperTest(end_lst, 41)
         spdy.test_CURDL(request, bigip)
 # End Spdy tests
 
 # Begin Statistics tests
 class TestStatistics(object):
-    def test_statistics(self, request, bigip):
+    def test_CURDL(self, request, bigip):
         stat = HelperTest(end_lst, 42)
         stat.test_CURDL(request, bigip)
 # End Statistics tests
 
 # Begin Stream tests
 class TestStream(object):
-    def test_stream(self, request, bigip):
+    def test_CURDL(self, request, bigip):
         stream = HelperTest(end_lst, 43)
         stream.test_CURDL(request, bigip)
 # End Stream tests
 
 # Begin Tcp tests
 class TestTcp(object):
-    def test_tcp(self, request, bigip):
+    def test_CURDL(self, request, bigip):
         testcp = HelperTest(end_lst, 44)
         testcp.test_CURDL(request, bigip)
 # End Tcp tests
 
 # Begin Tftp tests
 class TestTftp(object):
-    def test_tftp(self, request, bigip):
+    def test_CURDL(self, request, bigip):
         tftp = HelperTest(end_lst, 45)
         tftp.test_CURDL(request, bigip)
 # End Tftp tests
 
 # Begin Udp tests
 class TestUdp(object):
-    def test_udp(self, request, bigip):
+    def test_CURDL(self, request, bigip):
         tesudp = HelperTest(end_lst, 46)
         tesudp.test_CURDL(request, bigip)
 # End Udp tests
@@ -514,7 +547,7 @@ class TestUdp(object):
 
 # Begin WebAcceleration tests
 class TestWebAcceleration(object):
-    def test_web_acceleration(self, request, bigip):
+    def test_CURDL(self, request, bigip):
         wa = HelperTest(end_lst, 47)
 
         # Test Create

--- a/test/functional/tm/ltm/test_profile.py
+++ b/test/functional/tm/ltm/test_profile.py
@@ -122,11 +122,9 @@ class TestAnalyticsSubCol(object):
         assert traffic1.requestCapturedParts == 'headers'
 
         # Testing load
-        alert2 = avrhc1.alerts_s.alerts
-        alert2.load(name='test_alert')
+        alert2 = avrhc1.alerts_s.alerts.load(name='test_alert')
         assert alert1.name == alert2.name
-        traffic2 = avrhc1.traffic_captures.traffic_capture
-        traffic2.load(name='test_traf_cap')
+        traffic2 = avrhc1.traffic_captures.traffic_capture.load(name='test_traf_cap')
         assert traffic1.name == traffic2.name
 #End Analytics tests
 
@@ -141,7 +139,7 @@ class TestCertifcateAutority(object):
 def setup_class_test(request, bigip):
     def teardown():
         if profile.exists(name='classification'):
-
+            pass
     request.addfinalizer(teardown)
     hc = bigip.ltm.profile.classifications
     profile = hc.classification
@@ -281,7 +279,26 @@ class TestHttp2(object):
 class TestIcap(object):
     def test_icap(self, request, bigip):
         icap = HelperTest(end_lst, 18)
-        icap.test_CURDL(request, bigip)
+
+        # Test Create
+        icap1, icapc = icap.setup_test(request, bigip)
+        assert icap1.name == 'test.icap'
+
+        # Test Update
+        icap1.previewLength = 100
+        icap1.update()
+        assert icap1.previewLength == 100
+
+        # Test Refresh
+        icap1.previewLength = 50
+        icap1.refresh()
+        assert icap1.previewLength == 100
+
+        # Test Load
+        icapc2 = bigip.ltm.profile.icaps.icap.load(
+            name='test.icap', partition='Common')
+        assert icapc1.selfLink == icapc2.selfLink
+
 # End ICAP tests
 
 # Begin IIOP tests
@@ -493,18 +510,46 @@ class TestUdp(object):
 ## placeholder
 # End Wa Cache tests
 
+
 # Begin WebAcceleration tests --no attribute description
 class TestWebAcceleration(object):
     def test_web_acceleration(self, request, bigip):
         wa = HelperTest(end_lst, 47)
-        wa.test_CURDL(request, bigip)
+
+        # Test Create
+        wa1, wapc = wa.setup_test(request, bigip)
+        assert wa1.name == 'test.web_acceleration'
+
+        # Test Update
+        wa1.previewLength = 100
+        wa1.update()
+        assert wa1.previewLength == 100
+
+        # Test Refresh
+        wa1.previewLength = 50
+        wa1.refresh()
+        assert wa1.previewLength == 100
+
+        # Test Load
+        wa2 = bigip.ltm.profile.icaps.icap.load(
+            name='test.web_acceleration', partition='Common')
+        assert wa1.selfLink == wa2.selfLink
 # End Web Acceleration tests
 
-# Begin Web Security tests -- no attribute description
+# Begin Web Security tests
 class TestWebSecurity(object):
     def test_web_security(self, request, bigip):
         ws = HelperTest(end_lst, 48)
-        ws.test_CURDL(request, bigip)
+
+        # Test Create
+        ws1, wspc = ws.setup_test(request, bigip)
+        assert ws1.name == 'test.web_security'
+
+        # Test Load
+        ws2 = bigip.ltm.profile.icaps.icap.load(
+            name='test.web_security', partition='Common')
+        assert ws1.selfLink == ws2.selfLink
+
 # End Web Security tests
 
 # Begin Xml tests


### PR DESCRIPTION
Fixes #349, #341

This update introduces profile submodule to LTM, allowing to create LTM classes.

Problem: SDK did not have the APIs to create LTM profiles, this change has addressed that

Analysis: Introduced new profile.py sub-module which incorporated majority of LTM profiles.

CAVEAT: Ramcache, and wa-cache profiles have placeholder classes and are not implemented due to some issues I was having with matching tmsh syntax to REST. This needs further investigation with Product Development

Tests:
Unit Tests
Flake8
Functional Tests
