### PR TITLE
Fixes #349, #341

### DIFF
--- a/f5/bigip/tm/ltm/profile.py
+++ b/f5/bigip/tm/ltm/profile.py
@@ -1,6 +1,6 @@
 # coding=utf-8
 #
-# Copyright 2016 F5 Networks Inc.
+#  Copyright 2014-2016 F5 Networks Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -14,39 +14,91 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-"""BIG-IP® system config module
+"""BIG-IP® LTM profile submodule.
 
 REST URI
-    ``http://localhost/mgmt/tm/ltm/profile``
+    ``http://localhost/mgmt/tm/ltm/profile/``
 
 GUI Path
-    ``System``
+    ``Local Traffic --> Profiles``
 
 REST Kind
-    ``tm:sys:*``
+    ``tm:ltm:profile*``
 """
-import logging
+
 
 from f5.bigip.resource import Collection
 from f5.bigip.resource import OrganizingCollection
 from f5.bigip.resource import Resource
+from f5.bigip.resource import UnsupportedOperation
 
 
 class Profile(OrganizingCollection):
     def __init__(self, ltm):
         super(Profile, self).__init__(ltm)
         self._meta_data['allowed_lazy_attributes'] = [
-            Client_Ssls
-        ]
+            Analytics_s,
+            Certificate_Authoritys,
+            Classifications,
+            Client_Ldaps,
+            Client_Ssls,
+            Dhcpv4s,
+            Dhcpv6s,
+            Diameters,
+            Dns_s,
+            Dns_Loggings,
+            Fasthttps,
+            Fastl4s,
+            Fixs,
+            Ftps,
+            Gtps,
+            Htmls,
+            Https,
+            Http_Compressions,
+            Http2s,
+            Icaps,
+            Iiops,
+            Ipothers,
+            Mblbs,
+            Mssqls,
+            Ntlms,
+            Ocsp_Stapling_Params_s,
+            One_Connects,
+            Pcps,
+            Pptps,
+            Qoes,
+            Radius_s,
+            Ramcaches,
+            Request_Adapts,
+            Request_Logs,
+            Response_Adapts,
+            Rewrites,
+            Rtsps,
+            Sctps,
+            Server_Ldaps,
+            Server_Ssls,
+            Sips,
+            Smtps,
+            Smtps_s,
+            Socks_s,
+            Spdys,
+            Statistics_s,
+            Streams,
+            Tcps,
+            Tftps,
+            Udps,
+            Wa_Caches,
+            Web_Accelerations,
+            Web_Securitys,
+            Xmls]
 
 
 class Client_Ssls(Collection):
+    """BIG-IP® Client SSL profile collection."""
     def __init__(self, profile):
         super(Client_Ssls, self).__init__(profile)
-        self._meta_data['allowed_lazy_attributes'] = [
-            Client_Ssl
-        ]
-        self._meta_data['attribute_registry'] =\
+        self._meta_data['allowed_lazy_attributes'] = [Client_Ssl]
+        self._meta_data['attribute_registry'] = \
             {'tm:ltm:profile:client-ssl:client-sslstate': Client_Ssl}
 
 
@@ -56,9 +108,1052 @@ class Client_Ssl(Resource):
         self._meta_data['required_json_kind'] =\
             'tm:ltm:profile:client-ssl:client-sslstate'
 
-    def create(self, certname, keyname):
-        payload = {"name": certname[:-4],
-                   "cert": certname,
-                   "key": keyname}
-        logging.debug(payload)
-        return self._create(**payload)
+
+class Analytics_s(Collection):
+    """BIG-IP® Analytics profile collection.
+
+    .. note::
+         Profile and sub-collections
+         require AVR provisioned.
+    """
+    def __init__(self, profile):
+        super(Analytics_s, self).__init__(profile)
+        self._meta_data['allowed_lazy_attributes'] = [Analytics]
+        self._meta_data['attribute_registry'] =\
+            {'tm:ltm:profile:analytics:analyticsstate': Analytics}
+
+
+class Analytics(Resource):
+    """BIG-IP® Analytics profile resource."""
+    def __init__(self, Analytics_s):
+        super(Analytics, self).__init__(Analytics_s)
+        self._meta_data['allowed_lazy_attributes'] = [Alerts_s,
+                                                      Traffic_Captures]
+        self._meta_data['required_json_kind'] = \
+            'tm:ltm:profile:analytics:analyticsstate'
+        self._meta_data['attribute_registry'] = \
+            {'tm:ltm:profile:analytics:alerts:alertscollectionstate': Alerts_s,
+             'tm:ltm:profile:analytics:traffic-capture:\
+             traffic-capturecollectionstate':
+                 Traffic_Captures}
+
+
+class Alerts_s(Collection):
+    """BIG-IP® Alerts sub-collection."""
+    def __init__(self, Analytics):
+        super(Alerts_s, self).__init__(Analytics)
+        self._meta_data['allowed_lazy_attributes'] = [Alerts]
+        self._meta_data['attribute_registry'] = \
+            {'tm:ltm:profile:analytics:alerts:alertsstate': Alerts}
+
+
+class Traffic_Captures(Collection):
+    """BIG-IP® Traffic Capture sub-collection."""
+    def __init__(self, Analytics):
+        super(Traffic_Captures, self).__init__(Analytics)
+        self._meta_data['allowed_lazy_attributes'] = [Traffic_Capture]
+        self._meta_data['attribute_registry'] = \
+            {'tm:ltm:profile:analytics:traffic-capture:\
+            traffic-capturestate': Traffic_Capture}
+
+
+class Alerts(Resource):
+    """BIG-IP® Alerts resource."""
+    def __init__(self, Alerts_s):
+        super(Alerts, self).__init__(Alerts_s)
+        self._meta_data['required_json_kind'] = \
+            'tm:ltm:profile:analytics:alerts:alertsstate'
+
+
+class Traffic_Capture(Resource):
+    """BIG-IP® Traffic Capture resource."""
+    def __init__(self, Traffic_Captures):
+        super(Traffic_Capture, self).__init__(Traffic_Captures)
+        self._meta_data['required_json_kind'] = \
+            'tm:ltm:profile:analytics:traffic-capture:traffic-capturestate'
+
+
+class Certificate_Authoritys(Collection):
+    """BIG-IP® Certificate Authority profile collection."""
+    def __init__(self, profile):
+        super(Certificate_Authoritys, self).__init__(profile)
+        self._meta_data['allowed_lazy_attributes'] = [Certificate_Authority]
+        self._meta_data['attribute_registry'] = \
+            {'tm:ltm:profile:certificate-authority:\
+            certificate-authoritystate': Certificate_Authority}
+
+
+class Certificate_Authority(Resource):
+    """BIG-IP® Certificate Authority resource."""
+    def __init__(self, Certificate_Authoritys):
+        super(Certificate_Authority, self).__init__(Certificate_Authoritys)
+        self._meta_data['required_json_kind'] = \
+            'tm:ltm:profile:certificate-authority:certificate-authoritystate'
+
+
+class Classifications(Collection):
+    """BIG-IP® Classification profile collection."""
+    def __init__(self, profile):
+        super(Classifications, self).__init__(profile)
+        self._meta_data['allowed_lazy_attributes'] = [Classification]
+        self._meta_data['attribute_registry'] = \
+            {'tm:ltm:profile:classification:\
+            classificationstate': Classification}
+
+
+class Classification(Resource):
+    """BIG-IP® Classification resource."""
+    def __init__(self, Classifications):
+        super(Classification, self).__init__(Classifications)
+        self._meta_data['required_json_kind'] = \
+            'tm:ltm:profile:classification:classificationstate'
+
+    def create(self, **kwargs):
+        """Create is not supported for Classification
+
+        :raises: UnsupportedOperation
+        """
+        raise UnsupportedOperation(
+            "%s does not support the update method" % self.__class__.__name__
+        )
+
+    def delete(self, **kwargs):
+        """Delete is not supported for Classification
+
+        :raises: UnsupportedOperation
+        """
+        raise UnsupportedOperation(
+            "%s does not support the delete method" % self.__class__.__name__
+        )
+
+
+class Client_Ldaps(Collection):
+    """BIG-IP® Client Ldap profile collection."""
+    def __init__(self, profile):
+        super(Client_Ldaps, self).__init__(profile)
+        self._meta_data['allowed_lazy_attributes'] = [Client_Ldap]
+        self._meta_data['attribute_registry'] = \
+            {'tm:ltm:profile:client-ldap:client-ldapstate': Client_Ldap}
+
+
+class Client_Ldap(Resource):
+    """BIG-IP® Client Ldap resource."""
+    def __init__(self, Client_Ldaps):
+        super(Client_Ldap, self).__init__(Client_Ldaps)
+        self._meta_data['required_json_kind'] = \
+            'tm:ltm:profile:client-ldap:client-ldapstate'
+
+
+class Dhcpv4s(Collection):
+    """BIG-IP® Dhcpv4 profile collection."""
+    def __init__(self, profile):
+        super(Dhcpv4s, self).__init__(profile)
+        self._meta_data['allowed_lazy_attributes'] = [Dhcpv4]
+        self._meta_data['attribute_registry'] = \
+            {'tm:ltm:profile:dhcpv4:dhcpv4state': Dhcpv4}
+
+
+class Dhcpv4(Resource):
+    """BIG-IP® Dhcpv4 resource."""
+    def __init__(self, Dhcpv4s):
+        super(Dhcpv4, self).__init__(Dhcpv4s)
+        self._meta_data['required_json_kind'] = \
+            'tm:ltm:profile:dhcpv4:dhcpv4state'
+
+
+class Dhcpv6s(Collection):
+    """BIG-IP® Dhcpv6 profile collection."""
+    def __init__(self, profile):
+        super(Dhcpv6s, self).__init__(profile)
+        self._meta_data['allowed_lazy_attributes'] = [Dhcpv6]
+        self._meta_data['attribute_registry'] = \
+            {'tm:ltm:profile:dhcpv6:dhcpv6state': Dhcpv6}
+
+
+class Dhcpv6(Resource):
+    """BIG-IP® Dhcpv6 resource."""
+    def __init__(self, Dhcpv6s):
+        super(Dhcpv6, self).__init__(Dhcpv6s)
+        self._meta_data['required_json_kind'] = \
+            'tm:ltm:profile:dhcpv6:dhcpv6state'
+
+
+class Diameters(Collection):
+    """BIG-IP® Diameter profile collection."""
+    def __init__(self, profile):
+        super(Diameters, self).__init__(profile)
+        self._meta_data['allowed_lazy_attributes'] = [Diameter]
+        self._meta_data['attribute_registry'] = \
+            {'tm:ltm:profile:diameter:diameterstate': Diameter}
+
+
+class Diameter(Resource):
+    """BIG-IP® Diameter resource."""
+    def __init__(self, Diameters):
+        super(Diameter, self).__init__(Diameters)
+        self._meta_data['required_json_kind'] = \
+            'tm:ltm:profile:diameter:diameterstate'
+
+
+class Dns_s(Collection):
+    """BIG-IP® DNS profile collection."""
+    def __init__(self, profile):
+        super(Dns_s, self).__init__(profile)
+        self._meta_data['allowed_lazy_attributes'] = [Dns]
+        self._meta_data['attribute_registry'] = \
+            {'tm:ltm:profile:dns:dnsstate': Dns}
+
+
+class Dns(Resource):
+    """BIG-IP® DNS resource."""
+    def __init__(self, Dns_s):
+        super(Dns, self).__init__(Dns_s)
+        self._meta_data['required_json_kind'] = \
+            'tm:ltm:profile:dns:dnsstate'
+
+
+class Dns_Loggings(Collection):
+    """BIG-IP® DNS Logging profile collection."""
+    def __init__(self, profile):
+        super(Dns_Loggings, self).__init__(profile)
+        self._meta_data['allowed_lazy_attributes'] = [Dns_Logging]
+        self._meta_data['attribute_registry'] = \
+            {'tm:ltm:profile:dns-logging:dns-loggingstate': Dns_Logging}
+
+
+class Dns_Logging(Resource):
+    """BIG-IP® DNS Logging resource."""
+    def __init__(self, Dns_Loggings):
+        super(Dns_Logging, self).__init__(Dns_Loggings)
+        self._meta_data['required_json_kind'] = \
+            'tm:ltm:profile:dns-logging:dns-loggingstate'
+        self._meta_data['required_creation_parameters'].update(
+            ('logPublisher',))
+
+
+class Fasthttps(Collection):
+    """BIG-IP® Fasthttp profile collection."""
+    def __init__(self, profile):
+        super(Fasthttps, self).__init__(profile)
+        self._meta_data['allowed_lazy_attributes'] = [Fasthttp]
+        self._meta_data['attribute_registry'] = \
+            {'tm:ltm:profile:fasthttp:fasthttpstate': Fasthttp}
+
+
+class Fasthttp(Resource):
+    """BIG-IP® Fasthttp resource."""
+    def __init__(self, Fasthttps):
+        super(Fasthttp, self).__init__(Fasthttps)
+        self._meta_data['required_json_kind'] = \
+            'tm:ltm:profile:fasthttp:fasthttpstate'
+
+
+class Fastl4s(Collection):
+    """BIG-IP® Fastl4 profile collection."""
+    def __init__(self, profile):
+        super(Fastl4s, self).__init__(profile)
+        self._meta_data['allowed_lazy_attributes'] = [Fastl4]
+        self._meta_data['attribute_registry'] = \
+            {'tm:ltm:profile:fastl4:fastl4state': Fastl4}
+
+
+class Fastl4(Resource):
+    """BIG-IP® Fastl4 resource."""
+    def __init__(self, Fastl4s):
+        super(Fastl4, self).__init__(Fastl4s)
+        self._meta_data['required_json_kind'] = \
+            'tm:ltm:profile:fastl4:fastl4state'
+
+
+class Fixs(Collection):
+    """BIG-IP® Fix profile collection."""
+    def __init__(self, profile):
+        super(Fixs, self).__init__(profile)
+        self._meta_data['allowed_lazy_attributes'] = [Fix]
+        self._meta_data['attribute_registry'] = \
+            {'tm:ltm:profile:fix:fixstate': Fix}
+
+
+class Fix(Resource):
+    """BIG-IP® Fix resource."""
+    def __init__(self, Fixs):
+        super(Fix, self).__init__(Fixs)
+        self._meta_data['required_json_kind'] = \
+            'tm:ltm:profile:fix:fixstate'
+
+
+class Ftps(Collection):
+    """BIG-IP® Ftp profile collection."""
+    def __init__(self, profile):
+        super(Ftps, self).__init__(profile)
+        self._meta_data['allowed_lazy_attributes'] = [Ftp]
+        self._meta_data['attribute_registry'] = \
+            {'tm:ltm:profile:ftp:ftpstate': Ftp}
+
+
+class Ftp(Resource):
+    """BIG-IP® Ftp resource."""
+    def __init__(self, Ftps):
+        super(Ftp, self).__init__(Ftps)
+        self._meta_data['required_json_kind'] = \
+            'tm:ltm:profile:ftp:ftpstate'
+
+
+class Gtps(Collection):
+    """BIG-IP® Gtp profile collection."""
+    def __init__(self, profile):
+        super(Gtps, self).__init__(profile)
+        self._meta_data['allowed_lazy_attributes'] = [Gtp]
+        self._meta_data['attribute_registry'] = \
+            {'tm:ltm:profile:gtp:gtpstate': Gtp}
+
+
+class Gtp(Resource):
+    """BIG-IP® Gtp resource."""
+    def __init__(self, Gtps):
+        super(Gtp, self).__init__(Gtps)
+        self._meta_data['required_json_kind'] = \
+            'tm:ltm:profile:gtp:gtpstate'
+
+
+class Htmls(Collection):
+    """BIG-IP® Html profile collection."""
+    def __init__(self, profile):
+        super(Htmls, self).__init__(profile)
+        self._meta_data['allowed_lazy_attributes'] = [Html]
+        self._meta_data['attribute_registry'] = \
+            {'tm:ltm:profile:html:htmlstate': Html}
+
+
+class Html(Resource):
+    """BIG-IP® Html resource."""
+    def __init__(self, Htmls):
+        super(Html, self).__init__(Htmls)
+        self._meta_data['required_json_kind'] = \
+            'tm:ltm:profile:html:htmlstate'
+
+
+class Https(Collection):
+    """BIG-IP® Http profile collection."""
+    def __init__(self, profile):
+        super(Https, self).__init__(profile)
+        self._meta_data['allowed_lazy_attributes'] = [Http]
+        self._meta_data['attribute_registry'] = \
+            {'tm:ltm:profile:http:httpstate': Http}
+
+
+class Http(Resource):
+    """BIG-IP® Http resource."""
+    def __init__(self, Https):
+        super(Http, self).__init__(Https)
+        self._meta_data['required_json_kind'] = \
+            'tm:ltm:profile:http:httpstate'
+
+
+class Http_Compressions(Collection):
+    """BIG-IP® Http_Compression profile collection."""
+    def __init__(self, profile):
+        super(Http_Compressions, self).__init__(profile)
+        self._meta_data['allowed_lazy_attributes'] = [Http_Compression]
+        temp = \
+            {'tm:ltm:profile:http-compression:http-compressionstate':
+                Http_Compression}
+        self._meta_data['attribute_registry'] = temp
+
+
+class Http_Compression(Resource):
+    """BIG-IP® Http_Compression resource."""
+    def __init__(self, Http_Compressions):
+        super(Http_Compression, self).__init__(Http_Compressions)
+        temp = \
+            'tm:ltm:profile:http-compression:http-compressionstate'
+        self._meta_data['required_json_kind'] = temp
+
+
+class Http2s(Collection):
+    """BIG-IP® Http2 profile collection."""
+    def __init__(self, profile):
+        super(Http2s, self).__init__(profile)
+        self._meta_data['allowed_lazy_attributes'] = [Http2]
+        self._meta_data['attribute_registry'] = \
+            {'tm:ltm:profile:http2:http2state': Http2}
+
+
+class Http2(Resource):
+    """BIG-IP® Http2 resource."""
+    def __init__(self, Http2s):
+        super(Http2, self).__init__(Http2s)
+        self._meta_data['required_json_kind'] = \
+            'tm:ltm:profile:http2:http2state'
+
+
+class Icaps(Collection):
+    """BIG-IP® Icap profile collection."""
+    def __init__(self, profile):
+        super(Icaps, self).__init__(profile)
+        self._meta_data['allowed_lazy_attributes'] = [Icap]
+        self._meta_data['attribute_registry'] = \
+            {'tm:ltm:profile:icap:icapstate': Icap}
+
+
+class Icap(Resource):
+    """BIG-IP® Icap resource."""
+    def __init__(self, Icaps):
+        super(Icap, self).__init__(Icaps)
+        self._meta_data['required_json_kind'] = \
+            'tm:ltm:profile:icap:icapstate'
+
+
+class Iiops(Collection):
+    """BIG-IP® Iiop profile collection."""
+    def __init__(self, profile):
+        super(Iiops, self).__init__(profile)
+        self._meta_data['allowed_lazy_attributes'] = [Iiop]
+        self._meta_data['attribute_registry'] = \
+            {'tm:ltm:profile:iiop:iiopstate': Iiop}
+
+
+class Iiop(Resource):
+    """BIG-IP® Iiop resource."""
+    def __init__(self, Iiops):
+        super(Iiop, self).__init__(Iiops)
+        self._meta_data['required_json_kind'] = \
+            'tm:ltm:profile:iiop:iiopstate'
+
+
+class Ipothers(Collection):
+    """BIG-IP® Ipother profile collection."""
+    def __init__(self, profile):
+        super(Ipothers, self).__init__(profile)
+        self._meta_data['allowed_lazy_attributes'] = [Ipother]
+        self._meta_data['attribute_registry'] = \
+            {'tm:ltm:profile:ipother:ipotherstate': Ipother}
+
+
+class Ipother(Resource):
+    """BIG-IP® Ipother resource."""
+    def __init__(self, Ipothers):
+        super(Ipother, self).__init__(Ipothers)
+        self._meta_data['required_json_kind'] = \
+            'tm:ltm:profile:ipother:ipotherstate'
+
+
+class Mblbs(Collection):
+    """BIG-IP® Mblb profile collection."""
+    def __init__(self, profile):
+        super(Mblbs, self).__init__(profile)
+        self._meta_data['allowed_lazy_attributes'] = [Mblb]
+        self._meta_data['attribute_registry'] = \
+            {'tm:ltm:profile:mblb:mblbstate': Mblb}
+
+
+class Mblb(Resource):
+    """BIG-IP® Mblb resource."""
+    def __init__(self, Mblbs):
+        super(Mblb, self).__init__(Mblbs)
+        self._meta_data['required_json_kind'] = \
+            'tm:ltm:profile:mblb:mblbstate'
+
+
+class Mssqls(Collection):
+    """BIG-IP® Mssql profile collection."""
+    def __init__(self, profile):
+        super(Mssqls, self).__init__(profile)
+        self._meta_data['allowed_lazy_attributes'] = [Mssql]
+        self._meta_data['attribute_registry'] = \
+            {'tm:ltm:profile:mssql:mssqlstate': Mssql}
+
+
+class Mssql(Resource):
+    """BIG-IP® Mssql resource."""
+    def __init__(self, Mssqls):
+        super(Mssql, self).__init__(Mssqls)
+        self._meta_data['required_json_kind'] = \
+            'tm:ltm:profile:mssql:mssqlstate'
+
+
+class Ntlms(Collection):
+    """BIG-IP® Ntlm profile collection."""
+    def __init__(self, profile):
+        super(Ntlms, self).__init__(profile)
+        self._meta_data['allowed_lazy_attributes'] = [Ntlm]
+        self._meta_data['attribute_registry'] = \
+            {'tm:ltm:profile:ntlm:ntlmstate': Ntlm}
+
+
+class Ntlm(Resource):
+    """BIG-IP® Ntlm resource."""
+    def __init__(self, Ntlms):
+        super(Ntlm, self).__init__(Ntlms)
+        self._meta_data['required_json_kind'] = \
+            'tm:ltm:profile:ntlm:ntlmstate'
+
+
+class Ocsp_Stapling_Params_s(Collection):
+    """BIG-IP® Ocsp_Stapling_Params profile collection."""
+    def __init__(self, profile):
+        super(Ocsp_Stapling_Params_s, self).__init__(profile)
+        self._meta_data['allowed_lazy_attributes'] = [Ocsp_Stapling_Params]
+        temp = \
+            {'tm:ltm:profile:ocsp-stapling-params:ocsp-stapling-paramsstate':
+                Ocsp_Stapling_Params}
+        self._meta_data['attribute_registry'] = temp
+
+
+class Ocsp_Stapling_Params(Resource):
+    """BIG-IP® Ocsp_Stapling_Params resource."""
+
+    def __init__(self, Ocsp_Stapling_Params_s):
+        super(Ocsp_Stapling_Params, self).__init__(Ocsp_Stapling_Params_s)
+        self._meta_data['exclusive_attributes'].append(
+            ('proxyServerPool', 'dnsResolver'))
+        self._meta_data['required_json_kind'] = \
+            'tm:ltm:profile:ocsp-stapling-params:ocsp-stapling-paramsstate'
+
+    def create(self, **kwargs):
+        """Create the resource on the BIG-IP®.
+
+        Uses HTTP POST to the `collection` URI to create a resource associated
+        with a new unique URI on the device.
+
+        As proxyServerPool parameter will be required
+        only if useProxyServer is set to 'enabled'
+        we have to use conditional to capture this logic during create.
+
+        """
+        if kwargs['useProxyServer'] == 'enabled':
+            tup_par = ('proxyServerPool', 'trustedCa', 'useProxyServer')
+        else:
+            tup_par = ('dnsResolver', 'trustedCa', 'useProxyServer')
+
+        self._meta_data['required_creation_parameters'].update(tup_par)
+        self._create(**kwargs)
+
+        return self
+
+
+class One_Connects(Collection):
+    """BIG-IP® One_Connect profile collection."""
+    def __init__(self, profile):
+        super(One_Connects, self).__init__(profile)
+        self._meta_data['allowed_lazy_attributes'] = [One_Connect]
+        self._meta_data['attribute_registry'] = \
+            {'tm:ltm:profile:one-connect:one-connectstate': One_Connect}
+
+
+class One_Connect(Resource):
+    """BIG-IP® One_Connect resource."""
+    def __init__(self, One_Connects):
+        super(One_Connect, self).__init__(One_Connects)
+        self._meta_data['required_json_kind'] = \
+            'tm:ltm:profile:one-connect:one-connectstate'
+
+
+class Pcps(Collection):
+    """BIG-IP® Pcp profile collection."""
+    def __init__(self, profile):
+        super(Pcps, self).__init__(profile)
+        self._meta_data['allowed_lazy_attributes'] = [Pcp]
+        self._meta_data['attribute_registry'] = \
+            {'tm:ltm:profile:pcp:pcpstate': Pcp}
+
+
+class Pcp(Resource):
+    """BIG-IP® Pcp resource."""
+    def __init__(self, Pcps):
+        super(Pcp, self).__init__(Pcps)
+        self._meta_data['required_json_kind'] = \
+            'tm:ltm:profile:pcp:pcpstate'
+
+
+class Pptps(Collection):
+    """BIG-IP® Pptp profile collection."""
+    def __init__(self, profile):
+        super(Pptps, self).__init__(profile)
+        self._meta_data['allowed_lazy_attributes'] = [Pptp]
+        self._meta_data['attribute_registry'] = \
+            {'tm:ltm:profile:pptp:pptpstate': Pptp}
+
+
+class Pptp(Resource):
+    """BIG-IP® Pptp resource."""
+    def __init__(self, Pptps):
+        super(Pptp, self).__init__(Pptps)
+        self._meta_data['required_json_kind'] = \
+            'tm:ltm:profile:pptp:pptpstate'
+
+
+class Qoes(Collection):
+    """BIG-IP® Qoe profile collection."""
+    def __init__(self, profile):
+        super(Qoes, self).__init__(profile)
+        self._meta_data['allowed_lazy_attributes'] = [Qoe]
+        self._meta_data['attribute_registry'] = \
+            {'tm:ltm:profile:qoe:qoestate': Qoe}
+
+
+class Qoe(Resource):
+    """BIG-IP® Qoe resource."""
+    def __init__(self, Qoes):
+        super(Qoe, self).__init__(Qoes)
+        self._meta_data['required_json_kind'] = \
+            'tm:ltm:profile:qoe:qoestate'
+
+
+class Radius_s(Collection):
+    """BIG-IP® Radius profile collection."""
+    def __init__(self, profile):
+        super(Radius_s, self).__init__(profile)
+        self._meta_data['allowed_lazy_attributes'] = [Radius]
+        self._meta_data['attribute_registry'] = \
+            {'tm:ltm:profile:radius:radiusstate': Radius}
+
+
+class Radius(Resource):
+    """BIG-IP® Radius resource."""
+    def __init__(self, Radius_s):
+        super(Radius, self).__init__(Radius_s)
+        self._meta_data['required_json_kind'] = \
+            'tm:ltm:profile:radius:radiusstate'
+
+
+class Ramcaches(Collection):
+    """BIG-IP® Ramcache profile collection."""
+    pass
+
+
+class Ramcache(Resource):
+    """BIG-IP® Ramcache resource."""
+    pass
+
+
+class Request_Adapts(Collection):
+    """BIG-IP® Request_Adapt profile collection."""
+    def __init__(self, profile):
+        super(Request_Adapts, self).__init__(profile)
+        self._meta_data['allowed_lazy_attributes'] = [Request_Adapt]
+        self._meta_data['attribute_registry'] = \
+            {'tm:ltm:profile:request-adapt:request-adaptstate': Request_Adapt}
+
+
+class Request_Adapt(Resource):
+    """BIG-IP® Request_Adapt resource."""
+    def __init__(self, Request_Adapts):
+        super(Request_Adapt, self).__init__(Request_Adapts)
+        self._meta_data['required_json_kind'] = \
+            'tm:ltm:profile:request-adapt:request-adaptstate'
+
+
+class Request_Logs(Collection):
+    """BIG-IP® Request_Log profile collection."""
+    def __init__(self, profile):
+        super(Request_Logs, self).__init__(profile)
+        self._meta_data['allowed_lazy_attributes'] = [Request_Log]
+        self._meta_data['attribute_registry'] = \
+            {'tm:ltm:profile:request-log:request-logstate': Request_Log}
+
+
+class Request_Log(Resource):
+    """BIG-IP® Request_Log resource."""
+    def __init__(self, Request_Logs):
+        super(Request_Log, self).__init__(Request_Logs)
+        self._meta_data['required_json_kind'] = \
+            'tm:ltm:profile:request-log:request-logstate'
+
+
+class Response_Adapts(Collection):
+    """BIG-IP® Response_Adapt profile collection."""
+    def __init__(self, profile):
+        super(Response_Adapts, self).__init__(profile)
+        self._meta_data['allowed_lazy_attributes'] = [Response_Adapt]
+        self._meta_data['attribute_registry'] = \
+            {'tm:ltm:profile:response-adapt:\
+            response-adaptstate': Response_Adapt}
+
+
+class Response_Adapt(Resource):
+    """BIG-IP® Response_Adapt resource."""
+    def __init__(self, Response_Adapts):
+        super(Response_Adapt, self).__init__(Response_Adapts)
+        self._meta_data['required_json_kind'] = \
+            'tm:ltm:profile:response-adapt:response-adaptstate'
+
+
+class Rewrites(Collection):
+    """BIG-IP® Rewrite profile collection."""
+    def __init__(self, profile):
+        super(Rewrites, self).__init__(profile)
+        self._meta_data['allowed_lazy_attributes'] = [Rewrite]
+        self._meta_data['attribute_registry'] = \
+            {'tm:ltm:profile:rewrite:rewritestate': Rewrite}
+
+
+class Rewrite(Resource):
+    """BIG-IP® Rewrite resource."""
+    def __init__(self, Rewrites):
+        super(Rewrite, self).__init__(Rewrites)
+        self._meta_data['allowed_lazy_attributes'] = []
+        self._meta_data['required_json_kind'] = \
+            'tm:ltm:profile:rewrite:rewritestate'
+        self._meta_data['attribute_registry'] = \
+            {'tm:ltm:profile:rewrite:uri-rules:uri-rulescollectionstate':
+             Uri_Rules_s}
+
+
+class Uri_Rules_s(Collection):
+    """BIG-IP® Rewrite sub-collection."""
+    def __init__(self, Rewrite):
+        super(Uri_Rules_s, self).__init__(Rewrite)
+        self._meta_data['allowed_lazy_attributes'] = [Uri_Rules]
+        self._meta_data['attribute_registry'] = \
+            {'tm:ltm:profile:rewrite:uri-rules:uri-rulesstate': Uri_Rules}
+
+
+class Uri_Rules(Resource):
+    """BIG-IP® URI Rules resource"""
+    def __init__(self, Uri_Rules_s):
+        super(Uri_Rules, self).__init__(Uri_Rules_s)
+        self._meta_data['required_json_kind'] = \
+            'tm:ltm:profile:rewrite:uri-rules:uri-rulesstate'
+
+
+class Rtsps(Collection):
+    """BIG-IP® Rtsp profile collection."""
+    def __init__(self, profile):
+        super(Rtsps, self).__init__(profile)
+        self._meta_data['allowed_lazy_attributes'] = [Rtsp]
+        self._meta_data['attribute_registry'] = \
+            {'tm:ltm:profile:rtsp:rtspstate': Rtsp}
+
+
+class Rtsp(Resource):
+    """BIG-IP® Rtsp resource."""
+    def __init__(self, Rtsps):
+        super(Rtsp, self).__init__(Rtsps)
+        self._meta_data['required_json_kind'] = \
+            'tm:ltm:profile:rtsp:rtspstate'
+
+
+class Sctps(Collection):
+    """BIG-IP® Sctp profile collection."""
+    def __init__(self, profile):
+        super(Sctps, self).__init__(profile)
+        self._meta_data['allowed_lazy_attributes'] = [Sctp]
+        self._meta_data['attribute_registry'] = \
+            {'tm:ltm:profile:sctp:sctpstate': Sctp}
+
+
+class Sctp(Resource):
+    """BIG-IP® Sctp resource."""
+    def __init__(self, Sctps):
+        super(Sctp, self).__init__(Sctps)
+        self._meta_data['required_json_kind'] = \
+            'tm:ltm:profile:sctp:sctpstate'
+
+
+class Server_Ldaps(Collection):
+    """BIG-IP® Server_Ldap profile collection."""
+    def __init__(self, profile):
+        super(Server_Ldaps, self).__init__(profile)
+        self._meta_data['allowed_lazy_attributes'] = [Server_Ldap]
+        self._meta_data['attribute_registry'] = \
+            {'tm:ltm:profile:server-ldap:server-ldapstate': Server_Ldap}
+
+
+class Server_Ldap(Resource):
+    """BIG-IP® Server_Ldap resource."""
+    def __init__(self, Server_Ldaps):
+        super(Server_Ldap, self).__init__(Server_Ldaps)
+        self._meta_data['required_json_kind'] = \
+            'tm:ltm:profile:server-ldap:server-ldapstate'
+
+
+class Server_Ssls(Collection):
+    """BIG-IP® Server_Ssl profile collection."""
+    def __init__(self, profile):
+        super(Server_Ssls, self).__init__(profile)
+        self._meta_data['allowed_lazy_attributes'] = [Server_Ssl]
+        self._meta_data['attribute_registry'] = \
+            {'tm:ltm:profile:server-ssl:server-sslstate': Server_Ssl}
+
+
+class Server_Ssl(Resource):
+    """BIG-IP® Server_Ssl resource."""
+    def __init__(self, Server_Ssls):
+        super(Server_Ssl, self).__init__(Server_Ssls)
+        self._meta_data['required_json_kind'] = \
+            'tm:ltm:profile:server-ssl:server-sslstate'
+
+
+class Sips(Collection):
+    """BIG-IP® Sip profile collection."""
+    def __init__(self, profile):
+        super(Sips, self).__init__(profile)
+        self._meta_data['allowed_lazy_attributes'] = [Sip]
+        self._meta_data['attribute_registry'] = \
+            {'tm:ltm:profile:sip:sipstate': Sip}
+
+
+class Sip(Resource):
+    """BIG-IP® Sip resource."""
+    def __init__(self, Sips):
+        super(Sip, self).__init__(Sips)
+        self._meta_data['required_json_kind'] = \
+            'tm:ltm:profile:sip:sipstate'
+
+
+class Smtps(Collection):
+    """BIG-IP® Smtp profile collection.
+
+    .. note::
+         Profile requires ASM provisioned.
+    """
+    def __init__(self, profile):
+        super(Smtps, self).__init__(profile)
+        self._meta_data['allowed_lazy_attributes'] = [Smtp]
+        self._meta_data['attribute_registry'] = \
+            {'tm:ltm:profile:smtp:smtpstate': Smtp}
+
+
+class Smtp(Resource):
+    """BIG-IP® Smtp resource."""
+    def __init__(self, Smtps):
+        super(Smtp, self).__init__(Smtps)
+        self._meta_data['required_json_kind'] = \
+            'tm:ltm:profile:smtp:smtpstate'
+
+
+class Smtps_s(Collection):
+    """BIG-IP® Smtps profile collection."""
+    def __init__(self, profile):
+        super(Smtps_s, self).__init__(profile)
+        self._meta_data['allowed_lazy_attributes'] = [SmtpS]
+        self._meta_data['attribute_registry'] = \
+            {'tm:ltm:profile:smtps:smtpsstate': SmtpS}
+
+
+class SmtpS(Resource):
+    """BIG-IP® Smtps resource."""
+    def __init__(self, Smtps_s):
+        super(SmtpS, self).__init__(Smtps_s)
+        self._meta_data['required_json_kind'] = \
+            'tm:ltm:profile:smtps:smtpsstate'
+
+
+class Socks_s(Collection):
+    """BIG-IP® Socks profile collection."""
+    def __init__(self, profile):
+        super(Socks_s, self).__init__(profile)
+        self._meta_data['allowed_lazy_attributes'] = [Socks]
+        self._meta_data['attribute_registry'] = \
+            {'tm:ltm:profile:socks:socksstate': Socks}
+
+
+class Socks(Resource):
+    """BIG-IP® Socks resource."""
+    def __init__(self, Socks_s):
+        super(Socks, self).__init__(Socks_s)
+        self._meta_data['required_json_kind'] = \
+            'tm:ltm:profile:socks:socksstate'
+        self._meta_data['required_creation_parameters'].update(
+            ('dnsResolver',))
+
+
+class Spdys(Collection):
+    """BIG-IP® Spdy profile collection."""
+    def __init__(self, profile):
+        super(Spdys, self).__init__(profile)
+        self._meta_data['allowed_lazy_attributes'] = [Spdy]
+        self._meta_data['attribute_registry'] = \
+            {'tm:ltm:profile:spdy:spdystate': Spdy}
+
+
+class Spdy(Resource):
+    """BIG-IP® Spdy resource."""
+    def __init__(self, Spdys):
+        super(Spdy, self).__init__(Spdys)
+        self._meta_data['required_json_kind'] = \
+            'tm:ltm:profile:spdy:spdystate'
+
+
+class Statistics_s(Collection):
+    """BIG-IP® Statistics profile collection."""
+    def __init__(self, profile):
+        super(Statistics_s, self).__init__(profile)
+        self._meta_data['allowed_lazy_attributes'] = [Statistics]
+        self._meta_data['attribute_registry'] = \
+            {'tm:ltm:profile:statistics:statisticsstate': Statistics}
+
+
+class Statistics(Resource):
+    """BIG-IP® Statistics resource."""
+    def __init__(self, Statistics_s):
+        super(Statistics, self).__init__(Statistics_s)
+        self._meta_data['required_json_kind'] = \
+            'tm:ltm:profile:statistics:statisticsstate'
+
+
+class Streams(Collection):
+    """BIG-IP® Stream profile collection."""
+    def __init__(self, profile):
+        super(Streams, self).__init__(profile)
+        self._meta_data['allowed_lazy_attributes'] = [Stream]
+        self._meta_data['attribute_registry'] = \
+            {'tm:ltm:profile:stream:streamstate': Stream}
+
+
+class Stream(Resource):
+    """BIG-IP® Stream resource."""
+    def __init__(self, Streams):
+        super(Stream, self).__init__(Streams)
+        self._meta_data['required_json_kind'] = \
+            'tm:ltm:profile:stream:streamstate'
+
+
+class Tcps(Collection):
+    """BIG-IP® Tcp profile collection."""
+    def __init__(self, profile):
+        super(Tcps, self).__init__(profile)
+        self._meta_data['allowed_lazy_attributes'] = [Tcp]
+        self._meta_data['attribute_registry'] = \
+            {'tm:ltm:profile:tcp:tcpstate': Tcp}
+
+
+class Tcp(Resource):
+    """BIG-IP® Tcp resource."""
+    def __init__(self, Tcps):
+        super(Tcp, self).__init__(Tcps)
+        self._meta_data['required_json_kind'] = \
+            'tm:ltm:profile:tcp:tcpstate'
+
+
+class Tftps(Collection):
+    """BIG-IP® Tftp profile collection."""
+    def __init__(self, profile):
+        super(Tftps, self).__init__(profile)
+        self._meta_data['allowed_lazy_attributes'] = [Tftp]
+        self._meta_data['attribute_registry'] = \
+            {'tm:ltm:profile:tftp:tftpstate': Tftp}
+
+
+class Tftp(Resource):
+    """BIG-IP® Tftp resource."""
+    def __init__(self, Tftps):
+        super(Tftp, self).__init__(Tftps)
+        self._meta_data['required_json_kind'] = \
+            'tm:ltm:profile:tftp:tftpstate'
+
+
+class Udps(Collection):
+    """BIG-IP® Udp profile collection."""
+    def __init__(self, profile):
+        super(Udps, self).__init__(profile)
+        self._meta_data['allowed_lazy_attributes'] = [Udp]
+        self._meta_data['attribute_registry'] = \
+            {'tm:ltm:profile:udp:udpstate': Udp}
+
+
+class Udp(Resource):
+    """BIG-IP® Udp resource."""
+    def __init__(self, Udps):
+        super(Udp, self).__init__(Udps)
+        self._meta_data['required_json_kind'] = \
+            'tm:ltm:profile:udp:udpstate'
+
+
+class Wa_Caches(Collection):
+    """BIG-IP® Wa_Cache profile collection."""
+    pass
+
+
+class Wa_Cache(Resource):
+    """BIG-IP® Wa_Cache resource."""
+    pass
+
+
+class Web_Accelerations(Collection):
+    """BIG-IP® Web_Acceleration profile collection."""
+    def __init__(self, profile):
+        super(Web_Accelerations, self).__init__(profile)
+        self._meta_data['allowed_lazy_attributes'] = [Web_Acceleration]
+        self._meta_data['attribute_registry'] = \
+            {'tm:ltm:profile:web-acceleration:\
+            web-accelerationstate': Web_Acceleration}
+
+
+class Web_Acceleration(Resource):
+    """BIG-IP® Web_Acceleration resource."""
+    def __init__(self, Web_Accelerations):
+        super(Web_Acceleration, self).__init__(Web_Accelerations)
+        self._meta_data['required_json_kind'] = \
+            'tm:ltm:profile:web-acceleration:web-accelerationstate'
+
+
+class Web_Securitys(Collection):
+    """BIG-IP® Web_Security profile collection."""
+    def __init__(self, profile):
+        super(Web_Securitys, self).__init__(profile)
+        self._meta_data['allowed_lazy_attributes'] = [Web_Security]
+        self._meta_data['attribute_registry'] = \
+            {'tm:ltm:profile:web-security:web-securitystate': Web_Security}
+
+
+class Web_Security(Resource):
+    """BIG-IP® Web_Security resource."""
+    def __init__(self, Web_Securitys):
+        super(Web_Security, self).__init__(Web_Securitys)
+        self._meta_data['required_json_kind'] = \
+            'tm:ltm:profile:web-security:web-securitystate'
+
+    def create(self, **kwargs):
+        """Create is not supported for Web Security
+
+        :raises: UnsupportedOperation
+        """
+        raise UnsupportedOperation(
+            "%s does not support the create method" % self.__class__.__name__
+        )
+
+    def update(self, **kwargs):
+        """Update is not supported for Web Security
+
+        :raises: UnsupportedOperation
+        """
+        raise UnsupportedOperation(
+            "%s does not support the update method" % self.__class__.__name__
+        )
+
+    def refresh(self, **kwargs):
+        """Refresh is not supported for Web Security
+
+        :raises: UnsupportedOperation
+        """
+        raise UnsupportedOperation(
+            "%s does not support the refresh method" % self.__class__.__name__
+        )
+
+    def delete(self, **kwargs):
+        """Delete is not supported for Web Security
+
+        :raises: UnsupportedOperation
+        """
+        raise UnsupportedOperation(
+            "%s does not support the delete method" % self.__class__.__name__
+        )
+
+
+class Xmls(Collection):
+    """BIG-IP® Xml profile collection."""
+    def __init__(self, profile):
+        super(Xmls, self).__init__(profile)
+        self._meta_data['allowed_lazy_attributes'] = [Xml]
+        self._meta_data['attribute_registry'] = \
+            {'tm:ltm:profile:xml:xmlstate': Xml}
+
+
+class Xml(Resource):
+    """BIG-IP® Xml resource."""
+    def __init__(self, Xmls):
+        super(Xml, self).__init__(Xmls)
+        self._meta_data['required_json_kind'] = \
+            'tm:ltm:profile:xml:xmlstate'

--- a/test/functional/ssl_profile_creation/test_ssl_profile_creation.py
+++ b/test/functional/ssl_profile_creation/test_ssl_profile_creation.py
@@ -88,6 +88,8 @@ def test_ssl_profile_creation(cleaner, symbols, tmpdir):
     pp([cert.raw for cert in cert_registrar.get_collection()])
     key_registrar.install_key(CERTFILENAME, FAKEKEYFILENAME)
     pp([key.raw for key in key_registrar.get_collection()])
-    ssl_client_profile.create(certname='/Common/NEWTESTCLIENTPROFILENAME.crt',
-                              keyname='/Common/NEWTESTCLIENTPROFILENAME.key')
+    chain = [{'name': 'newestcert',
+              'cert': '/Common/NEWTESTCLIENTPROFILENAME.crt',
+              'key': '/Common/NEWTESTCLIENTPROFILENAME.key'}]
+    ssl_client_profile.create(name='test_cert', certKeyChain=chain)
     pp(ssl_client_profile.raw)

--- a/test/functional/tm/ltm/test_profile.py
+++ b/test/functional/tm/ltm/test_profile.py
@@ -1,0 +1,861 @@
+# Copyright 2015-2106 F5 Networks Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+TESTDESCRIPTION = "TESTDESCRIPTION"
+
+end_lst = ['Certificate_Authoritys', 'Classifications', 'Client_Ldaps',
+           'Client_Ssls', 'Dhcpv4s', 'Dhcpv6s', 'Diameters', 'Dns_s',
+           'Dns_Loggings', 'Fasthttps', 'Fastl4s', 'Fixs', 'Ftps',
+           'Gtps', 'Htmls', 'Https', 'Http_Compressions',  'Http2s',
+           'Icaps', 'Iiops', 'Ipothers', 'Mblbs', 'Mssqls', 'Ntlms',
+           'Ocsp_Stapling_Params_s', 'One_Connects', 'Pcps', 'Pptps',
+           'Qoes', 'Radius_s', 'Request_Adapts', 'Request_Logs',
+           'Response_Adapts', 'Rtsps', 'Sctps', 'Server_Ldaps',
+           'Server_Ssls', 'Sips', 'Smtps', 'Smtps_s', 'Socks_s',
+           'Spdys', 'Statistics_s', 'Streams', 'Tcps', 'Tftps', 'Udps',
+           'Web_Accelerations', 'Web_Securitys', 'Xmls', 'Analytics_s',
+           'Rewrites']
+
+common = 'bigip.ltm.profile.'
+
+
+# Helper class to limit code repetition
+class HelperTest(object):
+    def __init__(self, item, idx):
+        self.item = item
+        self.idx = idx
+        self.name = 'test' + self.fullstring()
+        self.partition = 'Common'
+
+    def fullstring(self):
+        if self.item[self.idx].lower()[-2:] == '_s':
+            endind = 2
+        else:
+            endind = 1
+        full_str = '.' + self.item[self.idx][:-endind]
+        return full_str.lower()
+
+    def setup_test(self, request, bigip, **kwargs):
+        def teardown():
+            if profile.exists(name=self.name, partition=self.partition):
+                profile.delete()
+        request.addfinalizer(teardown)
+        hc = common+self.item[self.idx].lower()
+        profile = eval(hc + self.fullstring())
+        profile.create(name=self.name, partition=self.partition, **kwargs)
+        return profile, hc
+
+    def test_CURDL(self, request, bigip, **kwargs):
+
+        # Testing create
+        profile1, hc = self.setup_test(request, bigip, **kwargs)
+        assert profile1.name == self.name
+
+        # Testing update
+        profile1.description = TESTDESCRIPTION
+        profile1.update()
+        assert profile1.description == TESTDESCRIPTION
+
+        # Testing refresh
+        profile1.description = ''
+        profile1.refresh()
+        assert profile1.description == TESTDESCRIPTION
+
+        # Testing load
+        profile2 = eval(hc+self.fullstring())
+        profile2.load(partition=self.partition, name=self.name)
+        assert profile1.selfLink == profile2.selfLink
+
+    def test_CURDL_Adapt(self, request, bigip):
+
+        # Testing create
+        profile1, hc = self.setup_test(request, bigip)
+        assert profile1.name == self.name
+
+        # Testing update
+        profile1.timeout = 10
+        profile1.update()
+        assert profile1.timeout == 10
+
+        # Testing refresh
+        profile1.timeout = 0
+        profile1.refresh()
+        assert profile1.timeout == 10
+
+        # Testing load
+        profile2 = eval(hc+self.fullstring())
+        profile2.load(partition=self.partition, name=self.name)
+        assert profile1.selfLink == profile2.selfLink
+
+# Begin Analytics tests
+# Sub-collection setup function
+
+
+def setup_test_subc(request, bigip):
+    def teardown():
+        if prf_alert.exists(name='test_alert'):
+            prf_alert.delete()
+        if prf_traffic.exists(name='test_traf_cap'):
+            prf_traffic.delete()
+
+    avr = HelperTest(end_lst, 50)
+    avrhc1, avrstr = avr.setup_test(request, bigip)
+    del avrstr
+    prf_alert = avrhc1.alerts_s.alerts
+    prf_alert.create(name='test_alert', threshold=200)
+    prf_traffic = avrhc1.traffic_captures.traffic_capture
+    prf_traffic.create(name='test_traf_cap')
+    request.addfinalizer(teardown)
+    return prf_alert, prf_traffic, avrhc1
+
+
+class TestAnalytics(object):
+    def test_CURDL(self, request, bigip):
+        avr = HelperTest(end_lst, 50)
+        avr.test_CURDL(request, bigip)
+
+
+class TestAnalyticsSubCol(object):
+    def test_CURDL(self, request, bigip):
+
+        # Testing create and delete
+        alert1, traffic1, avrhc1 = setup_test_subc(request, bigip)
+        assert alert1.name == 'test_alert'
+        assert traffic1.name == 'test_traf_cap'
+
+        # Testing update
+        alert1.threshold = 250
+        alert1.update()
+        assert alert1.threshold == 250
+        traffic1.requestCapturedParts = 'headers'
+        traffic1.update()
+        assert traffic1.requestCapturedParts == 'headers'
+
+        # Testing refresh
+        alert1.threshold = 200
+        alert1.refresh()
+        assert alert1.threshold == 250
+        traffic1.requestCapturedParts = 'none'
+        traffic1.refresh()
+        assert traffic1.requestCapturedParts == 'headers'
+
+        # Testing load
+        alert2 = avrhc1.alerts_s.alerts.load(name='test_alert')
+        assert alert1.name == alert2.name
+        traffic2 = avrhc1.traffic_captures.traffic_capture.load(
+            name='test_traf_cap')
+        assert traffic1.name == traffic2.name
+
+
+# End Analytics tests
+
+# Begin Certificate Authority tests
+
+
+class TestCertifcateAutority(object):
+    def test_CURDL(self, request, bigip):
+        ca = HelperTest(end_lst, 0)
+        ca.test_CURDL(request, bigip)
+
+
+# End Certificate Authority tests
+
+# Begin Classification tests
+
+
+class TestClassification(object):
+    def test_RUL(self, request, bigip):
+
+        # Load test
+        klass1 = bigip.ltm.profile.classifications.classification.\
+            load(name='classification')
+
+        # Update test
+        klass1.description = TESTDESCRIPTION
+        klass1.update()
+        assert klass1.description == TESTDESCRIPTION
+
+        # Refresh test
+        klass1.description = 'ICHANGEDIT'
+        klass1.refresh()
+        assert klass1.description == TESTDESCRIPTION
+
+
+# End Classification tests
+
+# Begin ClientLdap tests
+
+
+class TestClientLdap(object):
+    def test_CURDL(self, request, bigip):
+        ldap = HelperTest(end_lst, 2)
+        ldap.test_CURDL(request, bigip)
+
+
+# End ClientLdap tests
+
+# Begin ClientSSL tests
+
+
+class TestClientSsl(object):
+    def test_CURDL(self, request, bigip):
+        cssl = HelperTest(end_lst, 3)
+        cssl.test_CURDL(request, bigip)
+
+
+# End ClientSSL tests
+
+# Begin Dhcpv4 tests
+
+
+class TestDhcpv4(object):
+    def test_CURDL(self, request, bigip):
+        dhcpv4 = HelperTest(end_lst, 4)
+        dhcpv4.test_CURDL(request, bigip)
+
+
+# End Dhcpv4 tests
+
+# Begin Dhcpv6 tests
+
+
+class TestDhcpv6(object):
+    def test_CURDL(self, request, bigip):
+        dhcpv6 = HelperTest(end_lst, 5)
+        dhcpv6.test_CURDL(request, bigip)
+
+
+# End Dhcpv6 tests
+
+# Begin Diameter tests
+
+
+class TestDiameter(object):
+    def test_CURDL(self, request, bigip):
+        diameter = HelperTest(end_lst, 6)
+        diameter.test_CURDL(request, bigip)
+
+
+# End Diameter tests
+
+# Begin Dns tests
+
+
+class TestDns(object):
+    def test_CURDL(self, request, bigip):
+        dns = HelperTest(end_lst, 7)
+        dns.test_CURDL(request, bigip)
+
+
+# End Dns tests
+
+# Begin Dns Logging tests
+
+
+class TestDnsLogging(object):
+    def test_CURDL(self, request, bigip):
+        dnslog = HelperTest(end_lst, 8)
+        dnslog.test_CURDL(
+            request, bigip, logPublisher='/Common/local-db-publisher')
+
+# End Dns Logging test
+
+# Begin FastHttp tests
+
+
+class TestFastHttp(object):
+    def test_CURDL(self, request, bigip):
+        fasthttp = HelperTest(end_lst, 9)
+        fasthttp.test_CURDL(request, bigip)
+
+
+# End FastHttp tests
+
+# Begin FastL4 tests
+
+
+class TestFastL4(object):
+    def test_CURDL(self, request, bigip):
+        fastl4 = HelperTest(end_lst, 10)
+        fastl4.test_CURDL(request, bigip)
+
+
+# End FastL4 tests
+
+# Begin Fix tests
+
+
+class TestFix(object):
+    def test_CURDL(self, request, bigip):
+        fix = HelperTest(end_lst, 11)
+        fix.test_CURDL(request, bigip)
+
+
+# End Fix tests
+
+# Begin FTP tests
+
+
+class TestFtp(object):
+    def test_CURDL(self, request, bigip):
+        ftp = HelperTest(end_lst, 12)
+        ftp.test_CURDL(request, bigip)
+
+
+# End FTP tests
+
+# Begin GTP tests
+
+
+class TestGtp(object):
+    def test_CURDL(self, request, bigip):
+        gtp = HelperTest(end_lst, 13)
+        gtp.test_CURDL(request, bigip)
+
+
+# End GTP tests
+
+# Begin HTML tests
+
+
+class TestHtml(object):
+    def test_CURDL(self, request, bigip):
+        html = HelperTest(end_lst, 14)
+        html.test_CURDL(request, bigip)
+
+
+# End HTML tests
+
+# Begin HTTP tests
+
+
+class TestHttp(object):
+    def test_CURDL(self, request, bigip):
+        http = HelperTest(end_lst, 15)
+        http.test_CURDL(request, bigip)
+
+
+# End HTTP tests
+
+# Begin HTTP Compression tests
+
+
+class TestHttpCompress(object):
+    def test_CURDL(self, request, bigip):
+        httpc = HelperTest(end_lst, 16)
+        httpc.test_CURDL(request, bigip)
+
+
+# End HTTP Compression tests
+
+# Begin HTTP tests
+
+
+class TestHttp2(object):
+    def test_CURDL(self, request, bigip):
+        http2 = HelperTest(end_lst, 17)
+        http2.test_CURDL(request, bigip)
+
+
+# End HTTP tests
+
+# Begin ICAP tests
+
+
+class TestIcap(object):
+    def test_CURDL(self, request, bigip):
+        icap = HelperTest(end_lst, 18)
+
+        # Test Create
+        icap1, icapc = icap.setup_test(request, bigip)
+        assert icap1.name == 'test.icap'
+
+        # Test Update
+        icap1.previewLength = 100
+        icap1.update()
+        assert icap1.previewLength == 100
+
+        # Test Refresh
+        icap1.previewLength = 50
+        icap1.refresh()
+        assert icap1.previewLength == 100
+
+        # Test Load
+        icap2 = bigip.ltm.profile.icaps.icap.load(
+            name='test.icap', partition='Common')
+        assert icap1.selfLink == icap2.selfLink
+
+
+# End ICAP tests
+
+# Begin IIOP tests
+
+
+class TestIiop(object):
+    def test_CURDL(self, request, bigip):
+        iiop = HelperTest(end_lst, 19)
+        iiop.test_CURDL(request, bigip)
+
+
+# End IIOP tests
+
+# Begin Ipother tests
+
+
+class TestIother(object):
+    def ttest_CURDL(self, request, bigip):
+        ipoth = HelperTest(end_lst, 20)
+        ipoth.test_CURDL(request, bigip)
+
+
+# End Ipother tests
+
+# Begin Mblb tests
+
+
+class TestMblb(object):
+    def test_CURDL(self, request, bigip):
+        mblb = HelperTest(end_lst, 21)
+        mblb.test_CURDL(request, bigip)
+
+
+# End Mblb tests
+
+# Begin Mssql tests
+
+
+class TestMssql(object):
+    def test_CURDL(self, request, bigip):
+        mssql = HelperTest(end_lst, 22)
+        mssql.test_CURDL(request, bigip)
+
+
+# End Mssql tests
+
+# Begin Ntlm tests
+
+
+class TestNtlm(object):
+    def test_CURDL(self, request, bigip):
+        ntlm = HelperTest(end_lst, 23)
+        ntlm.test_CURDL(request, bigip)
+
+
+# End Ntlm tests
+
+# Begin Ocsp Stapling Params tests
+
+def setup_dns_resolver(request, bigip, name):
+    def teardown():
+        if dns_res.exists(name=name):
+            dns_res.delete()
+    request.addfinalizer(teardown)
+    dns_res = bigip.net.dns_resolvers.dns_resolver.create(name=name)
+    return dns_res
+
+
+class TestOcspStaplingParams(object):
+    def test_CURDL(self, request, bigip):
+
+        # Setup DNS resolver as prerequisite
+        dns = setup_dns_resolver(request, bigip, 'test_resolv')
+
+        # Test CURDL
+        http2 = HelperTest(end_lst, 24)
+        http2.test_CURDL(request, bigip,
+                         dnsResolver=dns.name,
+                         trustedCa='/Common/ca-bundle.crt',
+                         useProxyServer='disabled')
+
+
+# End Ocsp Stapling Params tests
+
+# Begin Oneconnect tests
+
+
+class TestOneConnect(object):
+    def test_CURDL(self, request, bigip):
+        onec = HelperTest(end_lst, 25)
+        onec.test_CURDL(request, bigip)
+
+
+# End Oneconnect tests
+
+# Begin Pcp tests
+
+
+class TestPcp(object):
+    def test_CURDL(self, request, bigip):
+        pcp = HelperTest(end_lst, 26)
+        pcp.test_CURDL(request, bigip)
+
+
+# End Pcp tests
+
+# Begin Pptp tests
+
+
+class TestPptp(object):
+    def test_CURDL(self, request, bigip):
+        pptp = HelperTest(end_lst, 27)
+        pptp.test_CURDL(request, bigip)
+
+
+# End Pptp tests
+
+# Begin Qoe tests
+
+
+class TestQoe(object):
+    def test_CURDL(self, request, bigip):
+        qoe = HelperTest(end_lst, 28)
+        qoe.test_CURDL(request, bigip)
+
+
+# End Qoe tests
+
+# Begin Radius tests
+
+
+class TestRadius(object):
+    def test_CURDL(self, request, bigip):
+        radius = HelperTest(end_lst, 29)
+        radius.test_CURDL(request, bigip)
+
+
+# End Radius tests
+
+# Begin Request Adapt tests
+
+
+class TestRequestAdapt(object):
+    def test_CURDL(self, request, bigip):
+        rq_adp = HelperTest(end_lst, 30)
+        rq_adp.test_CURDL_Adapt(request, bigip)
+
+
+# End Request Adapt tests
+
+# Begin Request Log tests
+
+
+class TestRequestLog(object):
+    def test_CURDL(self, request, bigip):
+        rq_log = HelperTest(end_lst, 31)
+        rq_log.test_CURDL(request, bigip)
+
+
+# End Request Log tests
+
+# Begin Response Adapt tests
+
+
+class TestResponseAdapt(object):
+    def test_CURDL(self, request, bigip):
+        res_adp = HelperTest(end_lst, 32)
+        res_adp.test_CURDL_Adapt(request, bigip)
+
+
+# End Response Adapt tests
+
+# Begin Rewrite tests
+# Sub-collection setup function
+
+
+def setup_test_uri(request, bigip):
+    def teardown():
+        if uri1.exists(name='test.uri'):
+            uri1.delete()
+
+    rewrite = HelperTest(end_lst, 51)
+    url_rw, rewrite_str = rewrite.setup_test(
+        request, bigip, rewriteMode='uri-translation')
+    del rewrite_str
+    client = {'host': 'example.com', 'path': '/', 'scheme': 'http'}
+    server = {'host': 'instance.com', 'path': '/', 'scheme': 'http'}
+    uri1 = url_rw.uri_rules_s.uri_rules.create(name='test.uri',
+                                               type='request',
+                                               client=client,
+                                               server=server)
+    request.addfinalizer(teardown)
+    return uri1, url_rw
+
+
+class TestRewrite(object):
+    def test_CURDL_rewrite(self, request, bigip):
+
+        # Test Create
+        rewrite = HelperTest(end_lst, 51)
+        rewrite1, rewrite_str = \
+            rewrite.setup_test(request, bigip)
+        del rewrite_str
+        assert rewrite1.name == 'test.rewrite'
+
+        # Test update
+        rewrite1.clientCachingType = 'no-cache'
+        rewrite1.update()
+        assert rewrite1.clientCachingType == 'no-cache'
+
+        # Test refresh
+        rewrite1.splitTunneling = 'true'
+        rewrite1.refresh()
+        assert rewrite1.splitTunneling == 'false'
+
+        # Test load
+        rewrite2 = bigip.ltm.profile.rewrites.rewrite.load(name='test.rewrite',
+                                                           partition='Common')
+        assert rewrite1.selfLink == rewrite2.selfLink
+
+
+class TestUriRulesSubCol(object):
+    def test_CURDL(self, request, bigip):
+
+        # Test Create
+        uri1, uri_rw = setup_test_uri(request, bigip)
+        assert uri1.name == 'test.uri'
+
+        # Test Update
+        client = {'host': 'sample.com',
+                  'path': '/', 'scheme': 'https'}
+        uri1.client = client
+        uri1.update()
+        assert uri1.client == {'host': 'sample.com',
+                               'path': '/', 'scheme': 'https'}
+
+        # Test Refresh
+        client = {'host': 'changed.com',
+                  'path': '/', 'scheme': 'http'}
+        uri1.client = client
+        uri1.refresh()
+        assert uri1.client == {'host': 'sample.com',
+                               'path': '/', 'scheme': 'https'}
+
+        # Test Load
+        uri2 = uri_rw.uri_rules_s.uri_rules.load(name='test.uri')
+        assert uri1.selfLink == uri2.selfLink
+
+
+# End Rewrite tests
+
+# Begin Rstps tests
+
+
+class TestRstps(object):
+    def test_CURDL(self, request, bigip):
+        rstps = HelperTest(end_lst, 33)
+        rstps.test_CURDL(request, bigip)
+
+
+# End Rstps tests
+
+# Begin Sctps tests
+
+
+class TestSctps(object):
+    def test_CURDL(self, request, bigip):
+        sctps = HelperTest(end_lst, 34)
+        sctps.test_CURDL(request, bigip)
+
+
+# End Sctps tests
+
+# Begin Server Ldap tests
+
+
+class TestServerLdap(object):
+    def test_CURDL(self, request, bigip):
+        sldap = HelperTest(end_lst, 35)
+        sldap.test_CURDL(request, bigip)
+
+
+# End Server Ldap tests
+
+# Begin Server Ssl tests
+
+
+class TestServerSsl(object):
+    def test_CURDL(self, request, bigip):
+        sssl = HelperTest(end_lst, 36)
+        sssl.test_CURDL(request, bigip)
+
+
+# End Server Ldap tests
+
+# Begin Sip tests
+
+
+class TestSip(object):
+    def test_CURDL(self, request, bigip):
+        sip = HelperTest(end_lst, 37)
+        sip.test_CURDL(request, bigip)
+
+
+# End Sip tests
+
+# Begin Smtp tests
+
+
+class TestSmtp(object):
+    def test_CURDL(self, request, bigip):
+        smtp = HelperTest(end_lst, 38)
+        smtp.test_CURDL(request, bigip)
+
+
+# End Smtp tests
+
+# Begin Smtps tests
+
+
+class TestSmtps(object):
+    def test_CURDL(self, request, bigip):
+        smtps = HelperTest(end_lst, 39)
+        smtps.test_CURDL(request, bigip)
+
+
+# End Smtps tests
+
+# Begin Sock tests
+
+
+class TestSock(object):
+    def test_CURDL(self, request, bigip):
+
+        dns = setup_dns_resolver(request, bigip,
+                                 'test_resolv')
+        socks = HelperTest(end_lst, 40)
+        socks.test_CURDL(request, bigip,
+                         dnsResolver=dns.name)
+
+
+# End Sock tests
+
+# Begin Spdy tests
+
+
+class TestSpdy(object):
+    def test_CURDL(self, request, bigip):
+        spdy = HelperTest(end_lst, 41)
+        spdy.test_CURDL(request, bigip)
+
+
+# End Spdy tests
+
+# Begin Statistics tests
+
+
+class TestStatistics(object):
+    def test_CURDL(self, request, bigip):
+        stat = HelperTest(end_lst, 42)
+        stat.test_CURDL(request, bigip)
+
+
+# End Statistics tests
+
+# Begin Stream tests
+
+
+class TestStream(object):
+    def test_CURDL(self, request, bigip):
+        stream = HelperTest(end_lst, 43)
+        stream.test_CURDL(request, bigip)
+
+
+# End Stream tests
+
+# Begin Tcp tests
+
+
+class TestTcp(object):
+    def test_CURDL(self, request, bigip):
+        testcp = HelperTest(end_lst, 44)
+        testcp.test_CURDL(request, bigip)
+
+
+# End Tcp tests
+
+# Begin Tftp tests
+
+
+class TestTftp(object):
+    def test_CURDL(self, request, bigip):
+        tftp = HelperTest(end_lst, 45)
+        tftp.test_CURDL(request, bigip)
+
+
+# End Tftp tests
+
+# Begin Udp tests
+
+
+class TestUdp(object):
+    def test_CURDL(self, request, bigip):
+        tesudp = HelperTest(end_lst, 46)
+        tesudp.test_CURDL(request, bigip)
+
+
+# End Udp tests
+
+
+# Begin WebAcceleration tests
+
+
+class TestWebAcceleration(object):
+    def test_CURDL(self, request, bigip):
+        wa = HelperTest(end_lst, 47)
+
+        # Test Create
+        wa1, wapc = wa.setup_test(request, bigip)
+        assert wa1.name == 'test.web_acceleration'
+
+        # Test Update
+        wa1.cacheAgingRate = 5
+        wa1.update()
+        assert wa1.cacheAgingRate == 5
+
+        # Test Refresh
+        wa1.cacheAgingRate = 10
+        wa1.refresh()
+        assert wa1.cacheAgingRate == 5
+
+        # Test Load
+        wa2 = bigip.ltm.profile.web_accelerations.web_acceleration.load(
+            name='test.web_acceleration', partition='Common')
+        assert wa1.cacheAgingRate == wa2.cacheAgingRate
+
+
+# End Web Acceleration tests
+
+# Begin Web Security tests
+
+
+class TestWebSecurity(object):
+    def test_load(self, request, bigip):
+        ws1 = bigip.ltm.profile.\
+            web_securitys.web_security.load(name='websecurity')
+        assert ws1.name == 'websecurity'
+
+
+# End Web Security tests
+
+# Begin Xml tests
+
+
+class TestXml(object):
+    def test_CURDL(self, request, bigip):
+        testxml = HelperTest(end_lst, 49)
+        testxml.test_CURDL(request, bigip)
+
+
+# End Xml tests


### PR DESCRIPTION
This update introduces profile submodule to LTM, allowing to create LTM classes.

Problem: SDK did not have the APIs to create LTM profiles, this change has addressed that

Analysis: Introduced new profile.py sub-module which incorporated majority of LTM profiles.

CAVEAT: Ramcache, and wa-cache profiles have placeholder classes and are not implemented due to some issues I was having with matching tmsh syntax to REST. This needs further investigation with Product Development

Tests:
Unit Tests
Flake8
Functional Tests
