### PR TITLE
Fixes #435, #437

### DIFF
--- a/f5/bigip/tm/sys/config.py
+++ b/f5/bigip/tm/sys/config.py
@@ -35,9 +35,9 @@ class Config(UnnamedResourceMixin, ResourceBase,
     def __init__(self, sys):
         super(Config, self).__init__(sys)
         self._meta_data['allowed_lazy_attributes'] = []
-        self._meta_data['attribute_registry'] = {}
+        self._meta_data['required_json_kind'] = \
+            'tm:sys:config:configstate'
         self._meta_data['allowed_commands'].append('save')
-        self._meta_data['allowed_commands'].append('load')
 
     def update(self, **kwargs):
         '''Update is not supported for Config

--- a/f5/bigip/tm/sys/crypto.py
+++ b/f5/bigip/tm/sys/crypto.py
@@ -25,7 +25,7 @@ GUI Path
 REST Kind
     ``tm:sys:config:*``
 """
-
+from f5.bigip.mixins import CommandExecutionMixin
 from f5.bigip.resource import Collection
 from f5.bigip.resource import OrganizingCollection
 from f5.bigip.resource import Resource
@@ -40,49 +40,67 @@ class Crypto(OrganizingCollection):
         ]
 
 
-class Keys(Collection):
+class Keys(Collection, CommandExecutionMixin):
+    """BIG-IP® Crypto key collection
+
+
+        note::
+        This collection supports install command.
+        Given the fact that we will be expecting hyphen
+        parameters, the function will need to utilize
+        variable keyword argument syntax. In other words
+        define a dictionary with the arbitrary keys and
+        then pass it as in the form **foo into the method
+        call. e.g.
+
+        param_set ={'from-local-file': FOOPATH, 'name': 'FOOKEY'}
+        bigip.tm.sys.crypto.keys.exec_cmd('install', **param_set)
+
+
+    """
     def __init__(self, crypto):
         super(Keys, self).__init__(crypto)
-        self._meta_data['allowed_lazy_attributes'] = [
-            Key
-        ]
+        self._meta_data['allowed_lazy_attributes'] = [Key]
+        self._meta_data['allowed_commands'].append('install')
         self._meta_data['attribute_registry'] =\
             {'tm:sys:crypto:key:keystate': Key}
 
-    def install_key(self, certfilename, keyfilename):
-        payload =\
-            {"from-local-file": "/var/config/rest/downloads/%s" % keyfilename,
-             "command": "install",
-             "name": certfilename[:-4]}
-        self._meta_data['icr_session'].post(self._meta_data['uri'],
-                                            json=payload)
-
 
 class Key(Resource):
+    """BIG-IP® Crypto key resource"""
     def __init__(self, keys):
         super(Key, self).__init__(keys)
         self._meta_data['required_json_kind'] = 'tm:sys:crypto:key:keystate'
 
 
-class Certs(Collection):
+class Certs(Collection, CommandExecutionMixin):
+    """BIG-IP® Crypto cert collection
+
+
+        note::
+        This collection supports install command.
+        Given the fact that we will be expecting hyphen
+        parameters, the function will need to utilize
+        variable keyword argument syntax. In other words
+        define a dictionary with the arbitrary keys and
+        then pass it as in the form **foo into the method
+        call. e.g.
+
+        param_set ={'from-local-file': FOOPATH, 'name': 'FOOCERT'}
+        bigip.tm.sys.crypto.certs.exec_cmd('install', **param_set)
+
+
+    """
     def __init__(self, crypto):
         super(Certs, self).__init__(crypto)
-        self._meta_data['allowed_lazy_attributes'] = [
-            Cert
-        ]
+        self._meta_data['allowed_lazy_attributes'] = [Cert]
+        self._meta_data['allowed_commands'].append('install')
         self._meta_data['attribute_registry'] =\
             {'tm:sys:crypto:cert:certstate': Cert}
 
-    def install_cert(self, certfilename):
-        payload =\
-            {"from-local-file": "/var/config/rest/downloads/%s" % certfilename,
-             "command": "install",
-             "name": certfilename[:-4]}
-        self._meta_data['icr_session'].post(self._meta_data['uri'],
-                                            json=payload)
-
 
 class Cert(Resource):
+    """BIG-IP® Crypto cert resource"""
     def __init__(self, certs):
         super(Cert, self).__init__(certs)
         self._meta_data['required_json_kind'] = 'tm:sys:crypto:cert:certstate'

--- a/test/functional/ssl_profile_creation/test_ssl_profile_creation.py
+++ b/test/functional/ssl_profile_creation/test_ssl_profile_creation.py
@@ -84,9 +84,13 @@ def test_ssl_profile_creation(cleaner, symbols, tmpdir):
     ssl_client_profile = mr.tm.ltm.profile.client_ssls.client_ssl
     uploader.upload_file(str(certpath))
     uploader.upload_file(str(keypath))
-    cert_registrar.install_cert(CERTFILENAME)
+    CERTPATH = '/var/config/rest/downloads/' + CERTFILENAME
+    KEYPATH = '/var/config/rest/downloads/' + FAKEKEYFILENAME
+    cert_set = {'from-local-file': CERTPATH, 'name': 'faketestcert'}
+    key_set = {'from-local-file': KEYPATH, 'name': 'faketestkey'}
+    cert_registrar.exec_cmd('install', **cert_set)
     pp([cert.raw for cert in cert_registrar.get_collection()])
-    key_registrar.install_key(CERTFILENAME, FAKEKEYFILENAME)
+    key_registrar.exec_cmd('install', **key_set)
     pp([key.raw for key in key_registrar.get_collection()])
     chain = [{'name': 'newestcert',
               'cert': '/Common/NEWTESTCLIENTPROFILENAME.crt',

--- a/test/functional/tm/sys/test_config.py
+++ b/test/functional/tm/sys/test_config.py
@@ -17,4 +17,4 @@
 class TestConfig(object):
     def test_save(self, bigip):
         c = bigip.sys.config
-        c.save()
+        c.exec_cmd('save')


### PR DESCRIPTION
Problem: Some of the code contained hardcoded payloads, and custom methods, given the new command mixin this has been removed causing some tests to fail.
Cert and Key collections did not allow defining certificate names

Analysis: Custom methods from crypto/cert and crypto/key have been removed to be more in line with how the SDK deals with commands.
Config endpoint had load parameter removed due to some unexpected errors. All relevant tests have been corrected to reflect that change

CAVEAT: Cert and key resources need to have certain methods removed/appended to be in line with REST documentation. sys/config endpoint needs to have load command support added at some point. This is to be done in next update

Tests:
Flake8
Functional Tests
