### PR TITLE
    Fixes the sshd api

### DIFF
--- a/f5/bigip/tm/sys/sshd.py
+++ b/f5/bigip/tm/sys/sshd.py
@@ -28,10 +28,10 @@ REST Kind
 """
 
 from f5.bigip.mixins import UnnamedResourceMixin
-from f5.bigip.resource import Resource
+from f5.bigip.resource import ResourceBase
 
 
-class Sshd(UnnamedResourceMixin, Resource):
+class Sshd(UnnamedResourceMixin, ResourceBase):
     """BIG-IP® system SSHD unnamed resource
 
         .. note::

--- a/requirements.test.txt
+++ b/requirements.test.txt
@@ -6,3 +6,4 @@ hacking==0.10.2
 mock==1.3.0
 pytest==2.9.1
 pytest-cov>=2.2.1
+git+https://github.com/F5Networks/pytest-symbols.git

--- a/test/functional/cluster/test_cluster.py
+++ b/test/functional/cluster/test_cluster.py
@@ -76,6 +76,8 @@ def ThreeBigIPTeardownSyncFailover(request, BigIPSetup):
     request.addfinalizer(teardown_cluster)
 
 
+@pytest.mark.skipif(pytest.config.getoption('--symbols') is None,
+                    reason='Symbols must be configured')
 def test_new_failover_cluster_two_member(BigIPSetup):
     a, b, c = BigIPSetup
     bigip_list = [a, b]
@@ -89,6 +91,8 @@ def test_new_failover_cluster_two_member(BigIPSetup):
     cm.teardown()
 
 
+@pytest.mark.skipif(pytest.config.getoption('--symbols') is None,
+                    reason='Symbols must be configured')
 def test_new_failover_cluster_three_member(BigIPSetup):
     a, b, c = BigIPSetup
     bigip_list = [a, b, c]
@@ -102,6 +106,8 @@ def test_new_failover_cluster_three_member(BigIPSetup):
     cm.teardown()
 
 
+@pytest.mark.skipif(pytest.config.getoption('--symbols') is None,
+                    reason='Symbols must be configured')
 def test_existing_failover_cluster(BigIPSetup):
     a, b, c = BigIPSetup
     bigip_list = [a, b]
@@ -118,6 +124,8 @@ def test_existing_failover_cluster(BigIPSetup):
     cm.teardown()
 
 
+@pytest.mark.skipif(pytest.config.getoption('--symbols') is None,
+                    reason='Symbols must be configured')
 def test_scale_up_sync_failover(BigIPSetup, ThreeBigIPTeardownSyncFailover):
     a, b, c = BigIPSetup
     bigip_list = [a, b]
@@ -130,6 +138,8 @@ def test_scale_up_sync_failover(BigIPSetup, ThreeBigIPTeardownSyncFailover):
     cm.scale_up_by_one(c)
 
 
+@pytest.mark.skipif(pytest.config.getoption('--symbols') is None,
+                    reason='Symbols must be configured')
 def test_scale_up_down_up_down_sync_failover(
         BigIPSetup, TwoBigIPTeardownSyncFailover):
     a, b, c = BigIPSetup

--- a/test/functional/ssl_profile_creation/test_ssl_profile_creation.py
+++ b/test/functional/ssl_profile_creation/test_ssl_profile_creation.py
@@ -65,6 +65,8 @@ def cleaner(request, symbols):
     request.addfinalizer(cleaner)
 
 
+@pytest.mark.skipif(pytest.config.getoption('--symbols') is None,
+                    reason='Symbols must be configured')
 def test_ssl_profile_creation(cleaner, symbols, tmpdir):
     testdatadir = tmpdir.mkdir('testdir')
     FAKEKEYFILENAME = 'fakekey.key'

--- a/test/functional/tm/ltm/test_profile.py
+++ b/test/functional/tm/ltm/test_profile.py
@@ -561,9 +561,10 @@ class TestOcspStaplingParams(object):
         assert ocsp1.cacheErrorTimeout == 3000
 
         # Testing load
-        ocsp2 = bigip.ltm.profile.ocsp_stapling_params_s
-        ocsp2.ocsp_stapling_params.load(
+        ocsp_params = bigip.ltm.profile.ocsp_stapling_params_s
+        ocsp2 = ocsp_params.ocsp_stapling_params.load(
             partition='Common', name='test.ocsp_stapling_params')
+
         assert ocsp1.selfLink == ocsp2.selfLink
 
 

--- a/test/functional/tm/sys/test_httpd.py
+++ b/test/functional/tm/sys/test_httpd.py
@@ -28,9 +28,9 @@ def cleaner(request, bigip):
 class TestHttpd(object):
     def test_load(self, cleaner, bigip):
         httpd = bigip.sys.httpd.load()
-        assert httpd.maxClients == 20
+        assert httpd.maxClients == 10
         httpd.refresh()
-        assert httpd.maxClients == 20
+        assert httpd.maxClients == 10
 
     def test_update(self, cleaner, bigip):
         httpd = bigip.sys.httpd.load()

--- a/test/functional/tm/sys/test_sshd.py
+++ b/test/functional/tm/sys/test_sshd.py
@@ -1,0 +1,312 @@
+# Copyright 2016 F5 Networks Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+
+import copy
+from pprint import pprint as pp
+import pytest
+
+V11_SUPPORTED = ['11.6.0', '11.6.1']
+V12_SUPPORTED = ['12.0.0', '12.1.0']
+
+
+def setup_sshd_test(request, bigip):
+    def teardown():
+        d.allow = ['ALL']
+        d.banner = 'disabled'
+        d.bannerText = ''
+        d.inactivityTimeout = 0
+        d.logLevel = 'info'
+        d.login = 'enabled'
+
+        if pytest.config.getoption('--release') in V12_SUPPORTED:
+            d.port = 22
+
+        d.update()
+    request.addfinalizer(teardown)
+    d = bigip.sys.sshd.load()
+    return d
+
+
+@pytest.mark.skipif(pytest.config.getoption('--release') not in V11_SUPPORTED,
+                    reason='Needs v11 TMOS to pass')
+class TestSshd11(object):
+    def test_load(self, request, bigip):
+        bigip1 = copy.deepcopy(bigip)
+        bigip2 = copy.deepcopy(bigip)
+
+        ssh1 = setup_sshd_test(request, bigip1)
+        ssh2 = setup_sshd_test(request, bigip2)
+
+        assert ssh1.allow == ssh2.allow
+        assert ssh1.banner == ssh2.banner
+        assert ssh1.inactivityTimeout == ssh2.inactivityTimeout
+        assert ssh1.logLevel == ssh2.logLevel
+        assert ssh1.login == ssh2.login
+
+        pp(ssh1.raw)
+        pp(ssh2.raw)
+
+    def test_update_allow(self, request, bigip):
+        bigip1 = copy.deepcopy(bigip)
+        bigip2 = copy.deepcopy(bigip)
+
+        ssh1 = setup_sshd_test(request, bigip1)
+        ssh2 = setup_sshd_test(request, bigip2)
+
+        ssh1.allow = ['192.168.1.1']
+        pp(ssh2.raw)
+        ssh1.update()
+        assert ['192.168.1.1'] == ssh1.allow
+        assert ['192.168.1.1'] != ssh2.allow
+
+        # Refresh
+        ssh2.refresh()
+        assert ['192.168.1.1'] == ssh2.allow
+
+    def test_update_banner(self, request, bigip):
+        bigip1 = copy.deepcopy(bigip)
+        bigip2 = copy.deepcopy(bigip)
+
+        ssh1 = setup_sshd_test(request, bigip1)
+        ssh2 = setup_sshd_test(request, bigip2)
+
+        banners = ['enabled', 'disabled']
+
+        for banner in banners:
+            ssh1.banner = banner
+            pp(ssh2.raw)
+            ssh1.update()
+            assert banner == ssh1.banner
+            assert banner != ssh2.banner
+
+            # Refresh
+            ssh2.refresh()
+            assert banner == ssh2.banner
+
+    def test_update_bannerText(self, request, bigip):
+        bigip1 = copy.deepcopy(bigip)
+        bigip2 = copy.deepcopy(bigip)
+
+        ssh1 = setup_sshd_test(request, bigip1)
+        ssh2 = setup_sshd_test(request, bigip2)
+
+        ssh1.bannerText = 'foo banner'
+        ssh1.update()
+        assert 'foo banner' == ssh1.bannerText
+        assert not hasattr(ssh2, 'bannerText')
+
+        # Refresh
+        ssh2.refresh()
+        assert 'foo banner' == ssh2.bannerText
+
+    def test_update_inactivityTimeout(self, request, bigip):
+        bigip1 = copy.deepcopy(bigip)
+        bigip2 = copy.deepcopy(bigip)
+
+        ssh1 = setup_sshd_test(request, bigip1)
+        ssh2 = setup_sshd_test(request, bigip2)
+
+        ssh1.inactivityTimeout = 10
+        ssh1.update()
+        assert 10 == ssh1.inactivityTimeout
+        assert 10 != ssh2.inactivityTimeout
+
+        # Refresh
+        ssh2.refresh()
+        assert 10 == ssh2.inactivityTimeout
+
+    def test_update_logLevel(self, request, bigip):
+        bigip1 = copy.deepcopy(bigip)
+        bigip2 = copy.deepcopy(bigip)
+
+        ssh1 = setup_sshd_test(request, bigip1)
+        ssh2 = setup_sshd_test(request, bigip2)
+
+        levels = ['debug', 'debug1', 'debug2', 'debug3', 'error', 'fatal',
+                  'info', 'quiet', 'verbose']
+
+        for level in levels:
+            ssh1.logLevel = level
+            pp(ssh2.raw)
+            ssh1.update()
+            assert level == ssh1.logLevel
+            assert level != ssh2.logLevel
+
+            # Refresh
+            ssh2.refresh()
+            assert level == ssh2.logLevel
+
+    def test_update_login(self, request, bigip):
+        bigip1 = copy.deepcopy(bigip)
+        bigip2 = copy.deepcopy(bigip)
+
+        ssh1 = setup_sshd_test(request, bigip1)
+        ssh2 = setup_sshd_test(request, bigip2)
+
+        logins = ['disabled', 'enabled']
+
+        for login in logins:
+            ssh1.login = login
+            pp(ssh2.raw)
+            ssh1.update()
+            assert login == ssh1.login
+            assert login != ssh2.login
+
+            # Refresh
+            ssh2.refresh()
+            assert login == ssh2.login
+
+
+@pytest.mark.skipif(pytest.config.getoption('--release') not in V12_SUPPORTED,
+                    reason='Needs v12 TMOS to pass')
+class TestSshd12(object):
+    def test_load(self, request, bigip):
+        bigip1 = copy.deepcopy(bigip)
+        bigip2 = copy.deepcopy(bigip)
+
+        ssh1 = setup_sshd_test(request, bigip1)
+        ssh2 = setup_sshd_test(request, bigip2)
+
+        assert ssh1.allow == ssh2.allow
+        assert ssh1.banner == ssh2.banner
+        assert ssh1.inactivityTimeout == ssh2.inactivityTimeout
+        assert ssh1.logLevel == ssh2.logLevel
+        assert ssh1.login == ssh2.login
+        assert ssh1.port == ssh2.port
+
+        pp(ssh1.raw)
+        pp(ssh2.raw)
+
+    def test_update_allow(self, request, bigip):
+        bigip1 = copy.deepcopy(bigip)
+        bigip2 = copy.deepcopy(bigip)
+
+        ssh1 = setup_sshd_test(request, bigip1)
+        ssh2 = setup_sshd_test(request, bigip2)
+
+        ssh1.allow = ['192.168.1.1']
+        ssh1.update()
+        assert ['192.168.1.1'] == ssh1.allow
+        assert ['192.168.1.1'] != ssh2.allow
+
+        # Refresh
+        ssh2.refresh()
+        assert ['192.168.1.1'] == ssh2.allow
+
+    def test_update_banner(self, request, bigip):
+        bigip1 = copy.deepcopy(bigip)
+        bigip2 = copy.deepcopy(bigip)
+
+        ssh1 = setup_sshd_test(request, bigip1)
+        ssh2 = setup_sshd_test(request, bigip2)
+
+        banners = ['enabled', 'disabled']
+
+        for banner in banners:
+            ssh1.banner = banner
+            ssh1.update()
+            assert banner == ssh1.banner
+            assert banner != ssh2.banner
+
+            # Refresh
+            ssh2.refresh()
+            assert banner == ssh2.banner
+
+    def test_update_bannerText(self, request, bigip):
+        bigip1 = copy.deepcopy(bigip)
+        bigip2 = copy.deepcopy(bigip)
+
+        ssh1 = setup_sshd_test(request, bigip1)
+        ssh2 = setup_sshd_test(request, bigip2)
+
+        ssh1.bannerText = 'foo banner'
+        ssh1.update()
+        assert 'foo banner' == ssh1.bannerText
+        assert not hasattr(ssh2, 'bannerText')
+
+        # Refresh
+        ssh2.refresh()
+        assert 'foo banner' == ssh2.bannerText
+
+    def test_update_inactivityTimeout(self, request, bigip):
+        bigip1 = copy.deepcopy(bigip)
+        bigip2 = copy.deepcopy(bigip)
+
+        ssh1 = setup_sshd_test(request, bigip1)
+        ssh2 = setup_sshd_test(request, bigip2)
+
+        ssh1.inactivityTimeout = 10
+        ssh1.update()
+        assert 10 == ssh1.inactivityTimeout
+        assert 10 != ssh2.inactivityTimeout
+
+        # Refresh
+        ssh2.refresh()
+        assert 10 == ssh2.inactivityTimeout
+
+    def test_update_logLevel(self, request, bigip):
+        bigip1 = copy.deepcopy(bigip)
+        bigip2 = copy.deepcopy(bigip)
+
+        ssh1 = setup_sshd_test(request, bigip1)
+        ssh2 = setup_sshd_test(request, bigip2)
+
+        levels = ['debug', 'debug1', 'debug2', 'debug3', 'error', 'fatal',
+                  'info', 'quiet', 'verbose']
+
+        for level in levels:
+            ssh1.logLevel = level
+            ssh1.update()
+            assert level == ssh1.logLevel
+            assert level != ssh2.logLevel
+
+            # Refresh
+            ssh2.refresh()
+            assert level == ssh2.logLevel
+
+    def test_update_login(self, request, bigip):
+        bigip1 = copy.deepcopy(bigip)
+        bigip2 = copy.deepcopy(bigip)
+
+        ssh1 = setup_sshd_test(request, bigip1)
+        ssh2 = setup_sshd_test(request, bigip2)
+
+        logins = ['disabled', 'enabled']
+
+        for login in logins:
+            ssh1.login = login
+            ssh1.update()
+            assert login == ssh1.login
+            assert login != ssh2.login
+
+            # Refresh
+            ssh2.refresh()
+            assert login == ssh2.login
+
+    def test_update_port(self, request, bigip):
+        bigip1 = copy.deepcopy(bigip)
+        bigip2 = copy.deepcopy(bigip)
+
+        ssh1 = setup_sshd_test(request, bigip1)
+        ssh2 = setup_sshd_test(request, bigip2)
+
+        ssh1.port = 1234
+        ssh1.update()
+        assert 1234 == ssh1.port
+        assert 1234 != ssh2.port
+
+        # Refresh
+        ssh2.refresh()
+        assert 1234 == ssh2.port


### PR DESCRIPTION
Issues:
Fixes #438

Problem:
The sshd api was inheriting from Resource instead of ResourceBase and
this was causing a uri KeyError

Analysis:
This patch fixes the inheritence to use the ResourceBase class and
also adds functional tests for the sshd api to prevent this from
happening in the future.

Tests:
test/functional/tm/sys/test_sshd.py
