### PR TITLE
Add interfaces for client-side string upload

### DIFF
--- a/f5/bigip/cm/autodeploy/software_images.py
+++ b/f5/bigip/cm/autodeploy/software_images.py
@@ -38,7 +38,7 @@ class Software_Image_Uploads(PathElement, FileUploadMixin):
         if os.path.splitext(filename)[-1] != '.iso':
             raise ImageFilesMustHaveDotISOExtension(filename)
         self.file_bound_uri = self._meta_data['uri'] + filename
-        self._upload(filepathname, **kwargs)
+        self._upload_file(filepathname, **kwargs)
 #
 #
 # class Software_Image_Downloads(PathElement):

--- a/f5/bigip/shared/file_transfer.py
+++ b/f5/bigip/shared/file_transfer.py
@@ -17,6 +17,7 @@
 #
 
 import os
+from StringIO import StringIO
 
 from f5.bigip.mixins import FileUploadMixin
 from f5.bigip.resource import PathElement
@@ -47,4 +48,12 @@ class Uploads(PathElement, FileUploadMixin):
         if os.path.splitext(filename)[-1] == '.iso':
             raise FileMustNotHaveDotISOExtension(filename)
         self.file_bound_uri = self._meta_data['uri'] + filename
-        self._upload(filepathname, **kwargs)
+        self._upload_file(filepathname, **kwargs)
+
+    def upload_stringio(self, stringio, target, **kwargs):
+        self.file_bound_uri = self._meta_data['uri'] + target
+        self._upload(stringio, **kwargs)
+
+    def upload_bytes(self, bytestring, target, **kwargs):
+        self.file_bound_uri = self._meta_data['uri'] + target
+        self._upload(StringIO(bytestring), **kwargs)

--- a/f5/bigip/shared/test/test_file_uploads.py
+++ b/f5/bigip/shared/test/test_file_uploads.py
@@ -14,8 +14,8 @@
 #
 
 import mock
-
 import pytest
+from StringIO import StringIO
 
 from f5.bigip import ManagementRoot
 from f5.bigip.shared.file_transfer import\
@@ -59,3 +59,55 @@ def test_ISO_extension(tmpdir):
     with pytest.raises(FileMustNotHaveDotISOExtension) as EIO:
         ftu.upload_file(filepath.__str__(), chunk_size=21)
     assert EIO.value.message == 'wrongname.iso'
+
+
+def test_stringio_upload_80a(tmpdir):
+    sio = StringIO(80*'a')
+    mr = ManagementRoot('FAKENETLOC', 'FAKENAME', 'FAKEPASSWORD')
+    mr._meta_data['icr_session'] = mock.MagicMock()
+    ftu = mr.shared.file_transfer.uploads
+    ftu.upload_stringio(sio, 'testtarget', chunk_size=20)
+    session_mock = mr._meta_data['icr_session']
+    for i in range(4):
+        d = session_mock.post.call_args_list[i][1]['data']
+        assert d == 'aaaaaaaaaaaaaaaaaaaa'
+
+
+def test_stringio_upload_70a(tmpdir):
+    sio = StringIO(70*'a')
+    mr = ManagementRoot('FAKENETLOC', 'FAKENAME', 'FAKEPASSWORD')
+    mr._meta_data['icr_session'] = mock.MagicMock()
+    ftu = mr.shared.file_transfer.uploads
+    ftu.upload_stringio(sio, 'testtarget', chunk_size=20)
+    session_mock = mr._meta_data['icr_session']
+    for i in range(3):
+        d = session_mock.post.call_args_list[i][1]['data']
+        assert d == 'aaaaaaaaaaaaaaaaaaaa'
+    lchunk = session_mock.post.call_args_list[3][1]['data']
+    assert 10*'a' == lchunk
+
+
+def test_bytes_upload_80a(tmpdir):
+    bytestring80a = 80*'a'
+    mr = ManagementRoot('FAKENETLOC', 'FAKENAME', 'FAKEPASSWORD')
+    mr._meta_data['icr_session'] = mock.MagicMock()
+    ftu = mr.shared.file_transfer.uploads
+    ftu.upload_bytes(bytestring80a, 'testtarget', chunk_size=20)
+    session_mock = mr._meta_data['icr_session']
+    for i in range(4):
+        d = session_mock.post.call_args_list[i][1]['data']
+        assert d == 'aaaaaaaaaaaaaaaaaaaa'
+
+
+def test_bytes_upload_70a(tmpdir):
+    bytestring70a = 70*'a'
+    mr = ManagementRoot('FAKENETLOC', 'FAKENAME', 'FAKEPASSWORD')
+    mr._meta_data['icr_session'] = mock.MagicMock()
+    ftu = mr.shared.file_transfer.uploads
+    ftu.upload_bytes(bytestring70a, 'testtarget', chunk_size=20)
+    session_mock = mr._meta_data['icr_session']
+    for i in range(3):
+        d = session_mock.post.call_args_list[i][1]['data']
+        assert d == 'aaaaaaaaaaaaaaaaaaaa'
+    lchunk = session_mock.post.call_args_list[3][1]['data']
+    assert 10*'a' == lchunk


### PR DESCRIPTION
Issues:
Fixes #454

Problem: We need to upload secrets without writing them to a file
on the client side.

Tests: unittests in test_file_uploads.py
