### PR TITLE
Feature.active standby cluster

### DIFF
--- a/f5/multi_device/cluster/__init__.py
+++ b/f5/multi_device/cluster/__init__.py
@@ -156,6 +156,7 @@ class ClusterManager(object):
         if hasattr(self, 'cluster'):
             msg = 'The ClusterManager is already managing a cluster.'
             raise AlreadyManagingCluster(msg)
+        self._check_device_number(kwargs['devices'])
         print('Adding trusted peers to root BigIP...')
         self.trust_domain.create(
             devices=kwargs['devices'],

--- a/f5/multi_device/cluster/__init__.py
+++ b/f5/multi_device/cluster/__init__.py
@@ -1,3 +1,4 @@
+# coding=utf-8
 # Copyright 2016 F5 Networks Inc.
 
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -18,9 +19,9 @@
 
 Definitions:
     Cluster: The manager of the TrustDomain and DeviceGroup objects.
-    TrustDomain: a group of BIG-IP devices that have exchanged certificates
+    TrustDomain: a group of BIG-IP® devices that have exchanged certificates
                  and trust one another
-    DeviceGroup: a group of BIG-IP device that sync configuration data and
+    DeviceGroup: a group of BIG-IP® device that sync configuration data and
                  failover connections.
 
 Clustering is broken down into three component parts: a cluster manager, a
@@ -33,6 +34,9 @@ those devices trust one another, a device group is created and each is added
 to the group. After this step, a cluster exists.
 
 Currently the only supported type of cluster is a 'sync-failover' cluster.
+The number of devices supported officially is currently two, for an
+active-standby cluster, but the code below can accommodate a four-member
+cluster.
 
 Methods:
 
@@ -85,7 +89,7 @@ Cluster = namedtuple(
 
 
 class ClusterManager(object):
-    '''Manage a cluster of BigIPs.
+    '''Manage a cluster of BIG-IP® devices.
 
     This is accomplished with REST URI calls only, but some operations are
     only permitted via tmsh commands (such as adding cm/trust-domain peers).
@@ -120,12 +124,12 @@ class ClusterManager(object):
         raise AttributeError(name)
 
     def _check_device_number(self, devices):
-        '''Check if number of devices is < 2 or > 8.
+        '''Check if number of devices is between 2 and 4
 
         :param kwargs: dict -- keyword args in dict
         '''
 
-        if len(devices) < 2 or len(devices) > 8:
+        if len(devices) < 2 or len(devices) > 4:
             msg = 'The number of devices to cluster is not supported.'
             raise ClusterNotSupported(msg)
 
@@ -144,7 +148,7 @@ class ClusterManager(object):
         self.cluster = Cluster(**kwargs)
 
     def create(self, **kwargs):
-        '''Create a cluster of BigIP devices.
+        '''Create a cluster of BIG-IP® devices.
 
         :param kwargs: dict -- keyword arguments for cluster manager
         '''
@@ -163,7 +167,7 @@ class ClusterManager(object):
         self.cluster = Cluster(**kwargs)
 
     def teardown(self):
-        '''Teardown the cluster of BigIP devices.'''
+        '''Teardown the cluster of BIG-IP® devices.'''
 
         print('Tearing down the cluster...')
         self.device_group.teardown()

--- a/f5/multi_device/trust_domain.py
+++ b/f5/multi_device/trust_domain.py
@@ -54,7 +54,7 @@ from f5.multi_device.utils import pollster
 
 
 class TrustDomain(object):
-    '''Manages the trusted peers of a BigIP device.'''
+    '''Manages the trust domain of a BIG-IP® device.'''
 
     iapp_actions = {'definition': {'implementation': None, 'presentation': ''}}
 
@@ -234,6 +234,9 @@ class TrustDomain(object):
         tmpl = deploying_device.tm.sys.applications.templates.template
         serv = deploying_device.tm.sys.applications.services.service
         tmpl.create(name=iapp_name, partition=self.partition, actions=actions)
+        pollster(deploying_device.tm.sys.applications.templates.template.load)(
+            name=iapp_name, partition=self.partition
+        )
         serv.create(
             name=iapp_name,
             partition=self.partition,

--- a/requirements.test.txt
+++ b/requirements.test.txt
@@ -2,6 +2,7 @@
 -e .
 
 # Test Requirements
+git+https://github.com/F5Networks/pytest-symbols.git
 hacking==0.10.2
 mock==1.3.0
 pytest==2.9.1

--- a/test/functional/cluster/test_cluster.py
+++ b/test/functional/cluster/test_cluster.py
@@ -45,21 +45,12 @@ def BigIPSetup():
         symbols.bigip2['netloc'],
         symbols.bigip2['username'],
         symbols.bigip2['password'])
-    c = ManagementRoot(
-        symbols.bigip3['netloc'],
-        symbols.bigip3['username'],
-        symbols.bigip3['password'])
-    d = ManagementRoot(
-        symbols.bigip4['netloc'],
-        symbols.bigip4['username'],
-        symbols.bigip4['password']
-    )
-    return a, b, c, d
+    return a, b
 
 
 @pytest.fixture
 def TwoBigIPTeardownSyncFailover(request, BigIPSetup):
-    a, b, c, d = BigIPSetup
+    a, b = BigIPSetup
     bigip_list = [a, b]
 
     def teardown_cluster():
@@ -74,8 +65,8 @@ def TwoBigIPTeardownSyncFailover(request, BigIPSetup):
 
 @pytest.fixture
 def ThreeBigIPTeardownSyncFailover(request, BigIPSetup):
-    a, b, c, d = BigIPSetup
-    bigip_list = [a, b, c]
+    a, b = BigIPSetup
+    bigip_list = [a, b]
 
     def teardown_cluster():
         cm = ClusterManager(
@@ -94,44 +85,20 @@ def ThreeBigIPTeardownSyncFailover(request, BigIPSetup):
                     "'run_cluster_tests: True'")
 class TestCluster(object):
     def test_new_failover_cluster_two_member(self, BigIPSetup):
-        a, b, c, d = BigIPSetup
+        a, b = BigIPSetup
         bigip_list = [a, b]
-        cm = ClusterManager()
+        for x in range(5):
+            cm = ClusterManager()
 
-        cm.create(
-            devices=bigip_list,
-            device_group_name=DEVICE_GROUP_NAME,
-            device_group_partition=PARTITION,
-            device_group_type='sync-failover')
-        cm.teardown()
-
-    def test_new_failover_cluster_three_member(self, BigIPSetup):
-        a, b, c, d = BigIPSetup
-        bigip_list = [a, b, c]
-        cm = ClusterManager()
-
-        cm.create(
-            devices=bigip_list,
-            device_group_name=DEVICE_GROUP_NAME,
-            device_group_partition=PARTITION,
-            device_group_type='sync-failover')
-        cm.teardown()
-
-    def test_new_failover_cluster_four_member(self, BigIPSetup):
-        a, b, c, d = BigIPSetup
-        bigip_list = [a, b, c, d]
-        cm = ClusterManager()
-
-        cm.create(
-            devices=bigip_list,
-            device_group_name=DEVICE_GROUP_NAME,
-            device_group_partition=PARTITION,
-            device_group_type='sync-failover'
-        )
-        cm.teardown()
+            cm.create(
+                devices=bigip_list,
+                device_group_name=DEVICE_GROUP_NAME,
+                device_group_partition=PARTITION,
+                device_group_type='sync-failover')
+            cm.teardown()
 
     def test_existing_failover_cluster(self, BigIPSetup):
-        a, b, c, d = BigIPSetup
+        a, b = BigIPSetup
         bigip_list = [a, b]
         cm = ClusterManager()
         kwargs = {'devices': bigip_list,

--- a/test/functional/cluster/test_cluster.py
+++ b/test/functional/cluster/test_cluster.py
@@ -144,32 +144,3 @@ class TestCluster(object):
 
         cm = ClusterManager(**kwargs)
         cm.teardown()
-
-    # The following tests were removed when scaling was taken out of
-    # the clustering feature.
-    def itest_scale_up_sync_failover(
-            self, BigIPSetup, ThreeBigIPTeardownSyncFailover
-    ):
-        a, b, c, d = BigIPSetup
-        bigip_list = [a, b]
-        cm = ClusterManager()
-        kwargs = {'devices': bigip_list,
-                  'device_group_name': DEVICE_GROUP_NAME,
-                  'device_group_partition': PARTITION,
-                  'device_group_type': 'sync-failover'}
-        cm.create(**kwargs)
-        cm.scale_up_by_one(c)
-
-    def itest_scale_up_down_up_down_sync_failover(
-            BigIPSetup, TwoBigIPTeardownSyncFailover):
-        a, b, c, d = BigIPSetup
-        bigip_list = [a, b]
-        cm = ClusterManager()
-        kwargs = {'devices': bigip_list,
-                  'device_group_name': DEVICE_GROUP_NAME,
-                  'device_group_partition': PARTITION,
-                  'device_group_type': 'sync-failover'}
-        cm.create(**kwargs)
-        for x in range(3):
-            cm.scale_up_by_one(c)
-            cm.scale_down_by_one(c)

--- a/test/functional/cluster/test_env.yaml
+++ b/test/functional/cluster/test_env.yaml
@@ -1,12 +1,9 @@
+run_cluster_tests: True
 bigip1:
     netloc: <bigip1_ip>
     username: <un>
     password: <pw>
 bigip2:
     netloc: <bigip2_ip>
-    username: <un>
-    password: <pw>
-bigip3:
-    netloc: <bigip3_ip>
     username: <un>
     password: <pw>


### PR DESCRIPTION
@zancas 
#### What's this change do?

Improves documentation and code for supporting an active standby cluster.
#### Any background context?

After talking to jgruber, I realized that having a four-member cluster isn't terribly useful because you still have to manually manage traffic groups. Without this traffic group feature, only an active standby cluster is useful because it uses one traffic group to manage traffic.
#### Where should the reviewer start?

Start at the new unit tests and then move to the functional tests. The four-member tests have been removed, since testing against two devices is easier than having four running.
