### PR TITLE
Multiversion Support

### DIFF
--- a/f5/bigip/__init__.py
+++ b/f5/bigip/__init__.py
@@ -18,6 +18,9 @@
 
 
 from icontrol.session import iControlRESTSession
+from urlparse import parse_qs
+from urlparse import urlparse
+
 
 from f5.bigip.cm import Cm
 from f5.bigip.resource import PathElement
@@ -54,8 +57,10 @@ class ManagementRoot(PathElement):
             'bigip': self,
             'icontrol_version': icontrol_version,
             'username': username,
-            'password': password
+            'password': password,
+            'tmos_version': None,
         }
+        self._get_tmos_version()
 
     @property
     def hostname(self):
@@ -64,6 +69,18 @@ class ManagementRoot(PathElement):
     @property
     def icontrol_version(self):
         return self._meta_data['icontrol_version']
+
+    @property
+    def tmos_version(self):
+        return self._meta_data['tmos_version']
+
+    def _get_tmos_version(self):
+        connect = self._meta_data['bigip']._meta_data['icr_session']
+        base_uri = self._meta_data['uri'] + 'tm/sys/'
+        response = connect.get(base_uri)
+        ver = response.json()
+        version = str(parse_qs(urlparse(ver['selfLink']).query)['ver'][0])
+        self._meta_data['tmos_version'] = version
 
 
 class BigIP(ManagementRoot):

--- a/f5/bigip/mixins.py
+++ b/f5/bigip/mixins.py
@@ -31,6 +31,14 @@ class UnsupportedMethod(F5SDKError):
     pass
 
 
+class UnsupportedTmosVersion(F5SDKError):
+    """Raise the error if a class of an API is instantiated,
+
+    on a TMOS version where API was not yet implemented/supported.
+    """
+    pass
+
+
 class LazyAttributesRequired(F5SDKError):
     """Raised when a object accesses a lazy attribute that is not listed"""
     pass
@@ -101,9 +109,19 @@ class LazyAttributeMixin(object):
             if name == lazy_attribute.__name__.lower():
                 attribute = lazy_attribute(container)
                 bases = [base.__name__ for base in lazy_attribute.__bases__]
+                # Doing version check per each resource
+                container._check_supported_versions(attribute)
                 if 'Resource' not in bases:
                     setattr(container, name, attribute)
                 return attribute
+
+    def _check_supported_versions(container, attribute):
+        tmos_v = container._meta_data['bigip'].tmos_version
+        if tmos_v not in attribute._meta_data['supported_versions']:
+            error = "There was an attempt to access API which " \
+                    "has not been implemented or supported " \
+                    "in the device's TMOS version: {}".format(tmos_v)
+            raise UnsupportedTmosVersion(error)
 
 
 class ExclusiveAttributesMixin(object):

--- a/f5/bigip/resource.py
+++ b/f5/bigip/resource.py
@@ -153,6 +153,7 @@ class PathElement(LazyAttributeMixin):
     those elements and does not support any of the CURDLE methods that
     the other objects do.
     """
+
     def __init__(self, container):
         self._meta_data = {
             'container': container,
@@ -161,6 +162,9 @@ class PathElement(LazyAttributeMixin):
             'icontrol_version': container._meta_data['icontrol_version']
         }
         self._set_meta_data_uri()
+        # Supported versions for each class will be defined here.
+        # List can be modified downstream in each sub-class
+        self._meta_data['supported_versions'] = set(['11.6.0', '12.0.0'])
 
     def _set_meta_data_uri(self):
         base_uri = self.__class__.__name__.lower()

--- a/f5/bigip/tm/cm/trust.py
+++ b/f5/bigip/tm/cm/trust.py
@@ -31,6 +31,9 @@ class Add_To_Trust(UnnamedResourceMixin, ExclusiveAttributesMixin,
 
     def __init__(self, cm):
         super(Add_To_Trust, self).__init__(cm)
+        base_uri = type(self).__name__.replace('_', '-').lower()
+        self._meta_data['uri'] =\
+            self._meta_data['container']._meta_data['uri'] + base_uri + '/'
         self._meta_data['exclusive_attributes'].append(
             ('caDevice', 'nonCaDevice'))
         self._meta_data['required_creation_parameters'].update(
@@ -38,6 +41,7 @@ class Add_To_Trust(UnnamedResourceMixin, ExclusiveAttributesMixin,
         self._meta_data['required_json_kind'] = \
             'tm:cm:add-to-trust:runstate'
         self._meta_data['allowed_commands'].append('run')
+        self._meta_data['supported_versions'].discard('11.6.0')
 
 
 class Remove_From_Trust(UnnamedResourceMixin, CommandExecutionMixin, Resource):
@@ -54,8 +58,12 @@ class Remove_From_Trust(UnnamedResourceMixin, CommandExecutionMixin, Resource):
 
     def __init__(self, cm):
         super(Remove_From_Trust, self).__init__(cm)
+        base_uri = type(self).__name__.replace('_', '-').lower()
+        self._meta_data['uri'] =\
+            self._meta_data['container']._meta_data['uri'] + base_uri + '/'
         self._meta_data['required_creation_parameters'].update(
             ('deviceName',))
         self._meta_data['required_json_kind'] = \
             'tm:cm:remove-from-trust:runstate'
         self._meta_data['allowed_commands'].append('run')
+        self._meta_data['supported_versions'].discard('11.6.0')

--- a/f5/bigip/tm/ltm/profile.py
+++ b/f5/bigip/tm/ltm/profile.py
@@ -511,6 +511,7 @@ class Iiops(Collection):
         self._meta_data['allowed_lazy_attributes'] = [Iiop]
         self._meta_data['attribute_registry'] = \
             {'tm:ltm:profile:iiop:iiopstate': Iiop}
+        self._meta_data['supported_versions'].discard('11.6.0')
 
 
 class Iiop(Resource):
@@ -1034,6 +1035,7 @@ class Tftps(Collection):
         self._meta_data['allowed_lazy_attributes'] = [Tftp]
         self._meta_data['attribute_registry'] = \
             {'tm:ltm:profile:tftp:tftpstate': Tftp}
+        self._meta_data['supported_versions'].discard('11.6.0')
 
 
 class Tftp(Resource):


### PR DESCRIPTION
Fixes #379, #452, #461, #462

Problem: SDK needs to be able to run on multiple versions of TMOS. Some API endpoints were not implemented in the base 11.6.0, but exist in 12.x. This SDK needs the ability to verify the TMOS version when instantiating the API classes.

Analysis: This update forces the tmos version update upon ManagementRoot instantiation. Moreover it adds a new private method into LazyAttributeMixin class: _check_supported_versions which is responsible for veryfing if an instantiated class for the API is supported in the target's device tmos.

Files affected:

f5\bigip__init__.py
f5\bigip\mixins.py
f5\bigip\resource.py
f5\bigip\tm\cm\trust.py
f5\bigip\tm\ltm\profile.py

CAVEAT:  This change will affect all of the unit tests that utilize fake instance of BIGIP or ManagementRoot clases. So those tests need rewriting to accommodate the change.
