### PR TITLE
Bump release to 0.1.7

### DIFF
--- a/f5/__init__.py
+++ b/f5/__init__.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-__version__ = '0.1.6'
+__version__ = '0.1.7'

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ setup(
     author_email='f5_common_python@f5.com',
     url='https://github.com/F5Networks/f5-common-python',
     keywords=['F5', 'sdk', 'api', 'icontrol', 'bigip', 'api', 'ltm'],
-    install_requires=['f5-icontrol-rest >= 1.0.6', 'future'],
+    install_requires=['f5-icontrol-rest >= 1.0.7'],
     packages=find_packages(
         exclude=["*.test", "*.test.*", "test.*", "test_*", "test", "test*"]
     ),


### PR DESCRIPTION
Issues:
Fixes #479

Problem:
Need to produce a new release for 0.1.7 of f5-common-python

Analysis:
Bumped release to 0.1.7 and required f5-icontrol-rest version to 1.0.7

Tests:
All tests pass
