### PR TITLE
Issues:

### DIFF
--- a/f5/bigip/tm/sys/ntp.py
+++ b/f5/bigip/tm/sys/ntp.py
@@ -32,7 +32,7 @@ from f5.bigip.resource import Collection
 from f5.bigip.resource import Resource
 
 
-class Ntp(UnnamedResourceMixin, Resource):
+class Ntp(Resource, UnnamedResourceMixin):
     """BIG-IP® system NTP unnamed resource
 
         .. note::


### PR DESCRIPTION
@zancas @wojtek0806 
#### What issues does this address?

Fixes #492
#### What's this change do?

The change corrects the order of inheritance
#### Where should the reviewer start?
#### Any background context?

Inheriting from the Resource class overrides the inheritance for the
load method in UnnamedResourceMixin

The result is that when using the ntp endpoint and loading the information,
an exception is raised.
