### PR TITLE
Add GTM Datacenter support to the SDK

### DIFF
--- a/f5/bigip/tm/gtm/__init__.py
+++ b/f5/bigip/tm/gtm/__init__.py
@@ -29,6 +29,7 @@ REST Kind
 
 
 from f5.bigip.resource import OrganizingCollection
+from f5.bigip.tm.gtm.datacenter import Datacenters
 from f5.bigip.tm.gtm.rule import Rules
 
 
@@ -37,5 +38,6 @@ class Gtm(OrganizingCollection):
     def __init__(self, tm):
         super(Gtm, self).__init__(tm)
         self._meta_data['allowed_lazy_attributes'] = [
+            Datacenters,
             Rules
         ]

--- a/f5/bigip/tm/gtm/datacenter.py
+++ b/f5/bigip/tm/gtm/datacenter.py
@@ -1,0 +1,154 @@
+# coding=utf-8
+#
+# Copyright 2014-2015 F5 Networks Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""BIG-IP® Global Traffic Manager (GTM) datacenter module.
+
+REST URI
+    ``http://localhost/mgmt/tm/gtm/datacenter``
+
+GUI Path
+    ``DNS --> GSLB : Data Centers``
+
+REST Kind
+    ``tm:gtm:datacenter:*``
+"""
+
+from f5.bigip.mixins import ExclusiveAttributesMixin
+from f5.bigip.resource import Collection
+from f5.bigip.resource import Resource
+
+
+class Datacenters(Collection):
+    """BIG-IP® GTM datacenter collection"""
+    def __init__(self, gtm):
+        super(Datacenters, self).__init__(gtm)
+        self._meta_data['allowed_lazy_attributes'] = [Datacenter]
+        self._meta_data['attribute_registry'] =\
+            {'tm:gtm:datacenter:datacenterstate': Datacenter}
+
+
+class Datacenter(Resource, ExclusiveAttributesMixin):
+    """BIG-IP® GTM datacenter resource"""
+    def __init__(self, dc_s):
+        super(Datacenter, self).__init__(dc_s)
+        self._meta_data['required_json_kind'] =\
+            'tm:gtm:datacenter:datacenterstate'
+        self._meta_data['exclusive_attributes'].append(('enabled', 'disabled'))
+
+    def _endis_able(self, config_dict):
+        if 'enabled' in config_dict and not config_dict['enabled']:
+            config_dict['disabled'] = True
+        elif 'disabled' in config_dict and not config_dict['disabled']:
+            config_dict['enabled'] = True
+        return config_dict
+
+    def _endis_attrs(self):
+        """Manipulate return value to equal negation of set value
+
+        This function (uniquely?!) manipulates response values before the
+        consumer has access to them. We think this is dangerous. It is likely
+        this function will move once we figure out how to properly annotate
+        this RISKY behavior!"
+
+        The BIG-IP REST API for this particular endpoint has two fields
+        which are mutually exclusive; disabled and enabled. When using this
+        SDK API, you may do the following
+
+            d = api.tm.gtm.datasources.datasource.load(name='foo')
+            d.update(enabled=False)
+
+        You might expect that the behavior of the following...
+
+            if d.enabled:
+                print("enabled")
+            else:
+                print("disabled")
+
+        ...would result in "enabled" being printed, but that would not be
+        the case; BIG-IP will specify that "enabled" is True and that the
+        following is also now True
+
+            d.disabled == True
+
+        This behavior of setting a different variable instead of the one
+        that you specified, may not be obvious to the casual user. Therefore,
+        this method will set appropriate sister variables to be the negation
+        of the variable you set.
+
+        Therefore
+
+            d.enabled = True
+
+        will also do the following automatically
+
+            d.disabled = False
+
+        This behavior will allow the SDK to behave according to most users
+        expectations, shown below
+
+            d.update(enabled=False)
+            if d.enabled:
+                print("enabled")
+            else:
+                print("disabled")
+
+        which will print the following
+
+            "disabled"
+
+        Likewise, checking for d.disabled would return True.
+        Returns:
+            None
+        """
+        if 'disabled' in self.__dict__:
+            self.__dict__['enabled'] = not self.__dict__['disabled']
+        if 'enabled' in self.__dict__:
+            self.__dict__['disabled'] = not self.__dict__['enabled']
+        return None
+
+    def create(self, **kwargs):
+        kwargs = self._endis_able(kwargs)
+
+        if 'enabled' in kwargs and kwargs['enabled']:
+            del kwargs['disabled']
+        if 'disabled' in kwargs and kwargs['disabled']:
+            del kwargs['enabled']
+
+        self._create(**kwargs)
+        self._endis_attrs()
+        return self
+
+    def load(self, **kwargs):
+        kwargs = self._endis_able(kwargs)
+        self._load(**kwargs)
+        self._endis_attrs()
+        return self
+
+    def refresh(self, **kwargs):
+        kwargs = self._endis_able(kwargs)
+        self._refresh(**kwargs)
+        self._endis_attrs()
+        return self
+
+    def update(self, **kwargs):
+        if 'enabled' in self.__dict__ and 'enabled' not in kwargs:
+            kwargs['enabled'] = self.__dict__.pop('enabled')
+        elif 'disabled' in self.__dict__ and 'disabled' not in kwargs:
+            kwargs['disabled'] = self.__dict__.pop('disabled')
+        kwargs = self._endis_able(kwargs)
+        self._update(**kwargs)
+        self._endis_attrs()

--- a/f5/bigip/tm/gtm/test/test_datacenter.py
+++ b/f5/bigip/tm/gtm/test/test_datacenter.py
@@ -1,0 +1,44 @@
+# Copyright 2015 F5 Networks Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import mock
+import pytest
+
+from f5.bigip import ManagementRoot
+from f5.bigip.resource import MissingRequiredCreationParameter
+from f5.bigip.tm.gtm.datacenter import Datacenter
+
+
+@pytest.fixture
+def FakeDatacenter():
+    fake_dc_s = mock.MagicMock()
+    fake_dc = Datacenter(fake_dc_s)
+    return fake_dc
+
+
+class TestCreate(object):
+    def test_create_two(self, fakeicontrolsession):
+        b = ManagementRoot('192.168.1.1', 'admin', 'admin')
+        r1 = b.tm.gtm.datacenters.datacenter
+        r2 = b.tm.gtm.datacenters.datacenter
+        assert r1 is not r2
+
+    def test_create_no_args(self, FakeDatacenter):
+        with pytest.raises(MissingRequiredCreationParameter):
+            FakeDatacenter.create()
+
+    def test_create_partition(self, FakeDatacenter):
+        with pytest.raises(MissingRequiredCreationParameter):
+            FakeDatacenter.create(partition='Common')

--- a/test/functional/tm/gtm/test_datacenter.py
+++ b/test/functional/tm/gtm/test_datacenter.py
@@ -1,0 +1,169 @@
+# Copyright 2015 F5 Networks Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import pytest
+
+from f5.bigip.resource import MissingRequiredCreationParameter
+from f5.bigip.tm.gtm.datacenter import Datacenter
+from requests.exceptions import HTTPError
+
+
+def delete_dc(mgmt_root, name, partition):
+    r = mgmt_root.tm.gtm.datacenters.datacenter
+    try:
+        r.load(name=name, partition=partition)
+    except HTTPError as err:
+        if err.response.status_code != 404:
+            raise
+        return
+    r.delete()
+
+
+def setup_create_test(request, mgmt_root, name, partition):
+    def teardown():
+        delete_dc(mgmt_root, name, partition)
+    request.addfinalizer(teardown)
+
+
+def setup_basic_test(request, mgmt_root, name, partition):
+    def teardown():
+        delete_dc(mgmt_root, name, partition)
+
+    dc1 = mgmt_root.tm.gtm.datacenters.datacenter
+    dc1.create(name=name, partition=partition)
+    request.addfinalizer(teardown)
+    return dc1
+
+
+class TestCreate(object):
+    def test_create_no_args(self, mgmt_root):
+        dc1 = mgmt_root.tm.gtm.datacenters.datacenter
+        with pytest.raises(MissingRequiredCreationParameter):
+            dc1.create()
+
+    def test_create(self, request, mgmt_root):
+        setup_create_test(request, mgmt_root, 'dc1', 'Common')
+        dc1 = mgmt_root.tm.gtm.datacenters.datacenter
+        dc1.create(name='dc1', partition='Common')
+        assert dc1.name == 'dc1'
+        assert dc1.partition == 'Common'
+        assert dc1.generation and isinstance(dc1.generation, int)
+        assert dc1.kind == 'tm:gtm:datacenter:datacenterstate'
+        assert dc1.selfLink.startswith(
+            'https://localhost/mgmt/tm/gtm/datacenter/~Common~dc1')
+
+    def test_create_optional_args(self, request, mgmt_root):
+        setup_create_test(request, mgmt_root, 'dc1', 'Common')
+        dc1 = mgmt_root.tm.gtm.datacenters.datacenter
+        dc1.create(name='dc1',
+                   partition='Common',
+                   enabled=False,
+                   contact="admin@root.local",
+                   description="A datacenter is fine too",
+                   location="Between the earth and the moon")
+        assert False == dc1.enabled
+        assert "admin@root.local" == dc1.contact
+        assert "A datacenter is fine too" == dc1.description
+        assert "Between the earth and the moon" == dc1.location
+
+    def test_create_duplicate(self, request, mgmt_root):
+        setup_create_test(request, mgmt_root, 'dc1', 'Common')
+        dc1 = mgmt_root.tm.gtm.datacenters.datacenter
+        dc1.create(name='dc1', partition='Common')
+        dc2 = mgmt_root.tm.gtm.datacenters.datacenter
+        with pytest.raises(HTTPError) as err:
+            dc2.create(name='dc1', partition='Common')
+            assert err.response.status_code == 400
+
+
+class TestRefresh(object):
+    def test_refresh(self, request, mgmt_root):
+        setup_basic_test(request, mgmt_root, 'dc1', 'Common')
+        d1 = mgmt_root.tm.gtm.datacenters.datacenter.load(
+            name='dc1', partition='Common')
+        d2 = mgmt_root.tm.gtm.datacenters.datacenter.load(
+            name='dc1', partition='Common')
+        assert True == d1.enabled
+        assert True == d2.enabled
+
+        d2.update(enabled=False)
+        assert False == d2.enabled
+        assert True == d1.enabled
+
+        d1.refresh()
+        assert False == d1.enabled
+
+
+class TestLoad(object):
+    def test_load_no_object(self, mgmt_root):
+        with pytest.raises(HTTPError) as err:
+            mgmt_root.tm.gtm.datacenters.datacenter.load(
+                name='dc1', partition='Common')
+            assert err.response.status_code == 404
+
+    def test_load(self, request, mgmt_root):
+        setup_basic_test(request, mgmt_root, 'dc1', 'Common')
+        dc1 = mgmt_root.tm.gtm.datacenters.datacenter.load(
+            name='dc1', partition='Common')
+        assert True == dc1.enabled
+        dc1.update(enabled=False)
+        dc2 = mgmt_root.tm.gtm.datacenters.datacenter.load(
+            name='dc1', partition='Common')
+        assert False == dc1.enabled
+        assert False == dc2.enabled
+
+
+class TestUpdate(object):
+    def test_update(self, request, mgmt_root):
+        dc1 = setup_basic_test(request, mgmt_root, 'dc1', 'Common')
+        assert True == dc1.enabled
+        assert False == dc1.disabled
+        dc1.update(enabled=False)
+        assert False == dc1.enabled
+        assert True == dc1.disabled
+
+    def test_update_samevalue(self, request, mgmt_root):
+        dc1 = setup_basic_test(request, mgmt_root, 'dc1', 'Common')
+        dc1.update(enabled=True)
+        assert False != dc1.enabled
+
+
+class TestDelete(object):
+    def test_delete(self, request, mgmt_root):
+        dc1 = setup_basic_test(request, mgmt_root, 'dc1', 'Common')
+        dc1.delete()
+        with pytest.raises(HTTPError) as err:
+            mgmt_root.tm.gtm.datacenters.datacenter.load(
+                name='dc1', partition='Common')
+            assert err.response.status_code == 404
+
+
+class TestDatacenterCollection(object):
+    def test_datacenter_collection(self, request, mgmt_root):
+        setup_create_test(request, mgmt_root, 'dc1', 'Common')
+        dc1 = mgmt_root.tm.gtm.datacenters.datacenter
+        dc1.create(name='dc1', partition='Common')
+        assert dc1.name == 'dc1'
+        assert dc1.partition == 'Common'
+        assert dc1.generation and isinstance(dc1.generation, int)
+        assert dc1.fullPath == '/Common/dc1'
+        assert dc1.kind == 'tm:gtm:datacenter:datacenterstate'
+        assert dc1.selfLink.startswith(
+            'https://localhost/mgmt/tm/gtm/datacenter/~Common~dc1')
+
+        rc = mgmt_root.tm.gtm.datacenters.get_collection()
+        assert isinstance(rc, list)
+        assert len(rc)
+        assert isinstance(rc[0], Datacenter)


### PR DESCRIPTION
@zancas @wojtek0806 @pjbreaux 
#### What issues does this address?

Fixes #497 
#### What's this change do?

This change provides support for the GTM Datacenter API. It uses
exclusive mixins to allow users to specify either the 'enabled' or
'disabled' attributes and handles their mutual exclusion appropriately
#### Where should the reviewer start?
- test/functional/tm/gtm/test_datacenter.py
- f5/bigip/tm/gtm/test/test_datacenter.py
#### Any background context?

The SDK does not support the GTM datacenter API
