### PR TITLE
Issues:

### DIFF
--- a/f5/bigip/tm/sys/ntp.py
+++ b/f5/bigip/tm/sys/ntp.py
@@ -30,9 +30,10 @@ REST Kind
 from f5.bigip.mixins import UnnamedResourceMixin
 from f5.bigip.resource import Collection
 from f5.bigip.resource import Resource
+from f5.bigip.resource import ResourceBase
 
 
-class Ntp(UnnamedResourceMixin, Resource):
+class Ntp(UnnamedResourceMixin, ResourceBase):
     """BIG-IP® system NTP unnamed resource
 
         .. note::
@@ -47,6 +48,7 @@ class Ntp(UnnamedResourceMixin, Resource):
         self._meta_data['attribute_registry'] = {
             'tm:sys:ntp:restrict:restrictcollectionstate': Restricts
         }
+        self._meta_data['allowed_lazy_attributes'] = [Restricts]
 
 
 class Restricts(Collection):

--- a/test/functional/tm/sys/test_ntp.py
+++ b/test/functional/tm/sys/test_ntp.py
@@ -14,29 +14,28 @@
 #
 
 
-def setup_ntp_test(request, bigip):
+def setup_ntp_test(request, mgmt_root):
     def teardown():
-        n.servers = servers
+        n.servers = []
         n.update()
     request.addfinalizer(teardown)
-    n = bigip.sys.ntp.load()
-    servers = n.servers
-    return n, servers
+    n = mgmt_root.tm.sys.ntp.load()
+    return n
 
 
-class iTestGlobal_Setting(object):
-    def itest_RUL(self, request, bigip):
+class TestGlobal_Setting(object):
+    def test_RUL(self, request, mgmt_root):
         # Load
         ip = '192.168.1.1'
-        ntp1, orig_servers = setup_ntp_test(request, bigip)
-        ntp2 = bigip.sys.ntp.load()
-        assert len(ntp1.servers) == len(ntp2.servers)
+        ntp1 = setup_ntp_test(request, mgmt_root)
+        ntp2 = mgmt_root.tm.sys.ntp.load()
 
         # Update
         ntp1.servers = [ip]
         ntp1.update()
+
         assert ip in ntp1.servers
-        assert ip not in ntp2.servers
+        assert not hasattr(ntp2, 'servers')
 
         # Refresh
         ntp2.refresh()


### PR DESCRIPTION
Fixes #492

Problem:
Inheriting from the Resource class overrides the inheritence for the
load method in UnnamedResourceMixin

The result is that when using the ntp endpoint and loading the information,
an exception is raised.

Analysis:
The change corrects the order of inheritence

Tests:
na
