### PR TITLE
Doc config updates

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -29,7 +29,7 @@ VERSION = f5.__version__
 # -- General configuration ------------------------------------------------
 
 # If your documentation needs a minimal Sphinx version, state it here.
-# needs_sphinx = '1.0'
+needs_sphinx = '1.4'
 
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
@@ -41,6 +41,7 @@ extensions = [
     'sphinx.ext.todo',
     'sphinx.ext.ifconfig',
     'sphinx.ext.viewcode',
+    'sphinx.ext.autosectionlabel',
 ]
 
 autodoc_default_flags = ['inherited-members', 'show-inheritance']
@@ -335,5 +336,15 @@ texinfo_documents = [
 
 # Example configuration for intersphinx: refer to the Python standard library.
 intersphinx_mapping = {
-    'requests': ('http://docs.python-requests.org/en/latest/', None)
+    'requests': ('http://docs.python-requests.org/en/latest/', None),
+    'heat': (
+    'http://f5-openstack-heat.readthedocs.io/en/latest', None),
+    'heatplugins': (
+    'http://f5-openstack-heat-plugins.readthedocs.io/en/latest', None),
+    'lbaasv1': (
+    'http://f5-openstack-lbaasv1.readthedocs.io/en/latest/', None),
+    'lbaasv2': (
+    'http://f5-openstack-lbaasv2-driver.readthedocs.io/en/latest', None),
+    'agent': (
+    'http://f5-openstack-agent.readthedocs.io/en/latest', None),
 }

--- a/requirements.docs.txt
+++ b/requirements.docs.txt
@@ -1,4 +1,6 @@
 -e .
 
 # Docs requirements
-Sphinx==1.3.5
+Sphinx>=1.4.1
+six>=1.10.0
+sphinx_rtd_theme


### PR DESCRIPTION
Fixes #506 

These configuration changes: a) make it possible for me to cross-reference the f5-sdk doc set from any other doc set; and b) automatically create section labels for each section (also allowing for easy cross-refs from within this project and from other projects). I also updated the minimum requirements in requirements.docs.txt.

@zancas @pjbreaux -- FYI. I'll merge this PR as soon as the build passes.
