### PR TITLE
Clustering trust_domain is broken due to api changes in tm.sys.application

### DIFF
--- a/f5/multi_device/trust_domain.py
+++ b/f5/multi_device/trust_domain.py
@@ -212,7 +212,7 @@ class TrustDomain(object):
                                  iapp will be deleted
         '''
 
-        iapp = deploying_device.tm.sys.applications
+        iapp = deploying_device.tm.sys.application
         iapp_serv = iapp.services.service.load(
             name=iapp_name, partition=self.partition
         )
@@ -231,10 +231,10 @@ class TrustDomain(object):
                                  iapp will be created
         '''
 
-        tmpl = deploying_device.tm.sys.applications.templates.template
-        serv = deploying_device.tm.sys.applications.services.service
+        tmpl = deploying_device.tm.sys.application.templates.template
+        serv = deploying_device.tm.sys.application.services.service
         tmpl.create(name=iapp_name, partition=self.partition, actions=actions)
-        pollster(deploying_device.tm.sys.applications.templates.template.load)(
+        pollster(deploying_device.tm.sys.application.templates.template.load)(
             name=iapp_name, partition=self.partition
         )
         serv.create(


### PR DESCRIPTION
@zancas 

Issues:
Fixes #521

Problem:
The clustering module trust_domain.py is broken because the api changed
for tm.sys.applications to tm.sys.application. I will fix the issue and
submit the fix, and we'll have to spin another release to remedy this.

Analysis:
Modified the references to applications in trust_domain.py and reran the
clustering tests.

Tests:
Clustering tests passed locally.
