### PR TITLE
Fix tunnels_s --> tunnels bug

### DIFF
--- a/f5/bigip/tm/net/__init__.py
+++ b/f5/bigip/tm/net/__init__.py
@@ -35,7 +35,7 @@ from f5.bigip.tm.net.interface import Interfaces
 from f5.bigip.tm.net.route import Routes
 from f5.bigip.tm.net.route_domain import Route_Domains
 from f5.bigip.tm.net.selfip import Selfips
-from f5.bigip.tm.net.tunnels import Tunnels_s
+from f5.bigip.tm.net.tunnels import TunnelS
 from f5.bigip.tm.net.vlan import Vlans
 
 
@@ -50,6 +50,6 @@ class Net(OrganizingCollection):
             Routes,
             Route_Domains,
             Selfips,
-            Tunnels_s,
+            TunnelS,
             Vlans
         ]

--- a/f5/bigip/tm/net/tunnels.py
+++ b/f5/bigip/tm/net/tunnels.py
@@ -28,13 +28,14 @@ REST Kind
 """
 
 from f5.bigip.resource import Collection
+from f5.bigip.resource import OrganizingCollection
 from f5.bigip.resource import Resource
 
 
-class Tunnels_s(Collection):
+class TunnelS(OrganizingCollection):
     """BIG-IP® network tunnels collection"""
     def __init__(self, net):
-        super(Tunnels_s, self).__init__(net)
+        super(TunnelS, self).__init__(net)
         self._meta_data['allowed_lazy_attributes'] = [
             Gres,
             Tunnels,
@@ -44,8 +45,8 @@ class Tunnels_s(Collection):
 
 class Tunnels(Collection):
     """BIG-IP® network tunnels resource (collection for GRE, Tunnel, VXLANs"""
-    def __init__(self, tunnels_s):
-        super(Tunnels, self).__init__(tunnels_s)
+    def __init__(self, tunnelS):
+        super(Tunnels, self).__init__(tunnelS)
         self._meta_data['allowed_lazy_attributes'] = [Gres, Tunnel, Vxlans]
         self._meta_data['attribute_registry'] =\
             {'tm:net:tunnels:tunnel:tunnelstate': Tunnel}

--- a/test/functional/tm/net/test_tunnels.py
+++ b/test/functional/tm/net/test_tunnels.py
@@ -32,7 +32,7 @@ def setup_tunnel_test(request, bigip, name, partition, ip, profile):
         delete_resource(tunnel)
     request.addfinalizer(teardown)
 
-    tunnel = bigip.net.tunnels_s.tunnels.tunnel.create(
+    tunnel = bigip.net.tunnels.tunnels.tunnel.create(
         name=name, partition=partition, localAddress=ip, profile=profile)
     return tunnel
 
@@ -42,7 +42,7 @@ def setup_gre_test(request, bigip, name, partition):
         delete_resource(gre)
     request.addfinalizer(teardown)
 
-    gre = bigip.net.tunnels_s.gres.gre.create(
+    gre = bigip.net.tunnels.gres.gre.create(
         name=name, partition=partition)
     return gre
 
@@ -52,14 +52,14 @@ def setup_vxlan_test(request, bigip, name, partition):
         delete_resource(vxlan)
     request.addfinalizer(teardown)
 
-    vxlan = bigip.net.tunnels_s.vxlans.vxlan.create(
+    vxlan = bigip.net.tunnels.vxlans.vxlan.create(
         name=name, partition=partition)
     return vxlan
 
 
 class TestTunnels(object):
     def test_tunnel_list(self, bigip):
-        tunnels = bigip.net.tunnels_s.tunnels.get_collection()
+        tunnels = bigip.net.tunnels.tunnels.get_collection()
         assert len(tunnels)
         for tunnel in tunnels:
             assert tunnel.generation
@@ -74,7 +74,7 @@ class TestTunnel(object):
         )
 
         # Load
-        t2 = bigip.net.tunnels_s.tunnels.tunnel.load(
+        t2 = bigip.net.tunnels.tunnels.tunnel.load(
             name='tunnel-test', partition='Common')
         assert t1.name == 'tunnel-test'
         assert t1.name == t2.name
@@ -99,7 +99,7 @@ class TestGre(object):
         assert g1.name == 'gre-test'
 
         # Load
-        g2 = bigip.net.tunnels_s.gres.gre.load(
+        g2 = bigip.net.tunnels.gres.gre.load(
             name='gre-test', partition='Common')
         assert g1.name == g2.name
         assert g1.generation == g2.generation
@@ -123,7 +123,7 @@ class TestVxlan(object):
         assert vx1.name == 'vxlan-test'
 
         # Load
-        vx2 = bigip.net.tunnels_s.vxlans.vxlan.load(
+        vx2 = bigip.net.tunnels.vxlans.vxlan.load(
             name='vxlan-test', partition='Common')
         assert vx1.name == vx2.name
         assert vx1.generation == vx2.generation


### PR DESCRIPTION
@pjbreaux 
Issues:
Fixes #544

Problem:  The `mgmt/tm/net/tunnels` URI corresponds to an OrganizingCollection so make the relevant concrete subclass inherit from that and name it "TunnelS" to distinguish it from the "Tunnels" collection class that corresponds to `/mgmt/tm/net/tunnels/tunnel`

Analysis:

Tests:
