### PR TITLE
Adds coveralls badge to repo

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,10 @@
+[run]
+omit =
+    # omit all functional tests
+    tests/*
+    # omit anything in a test directory anywhere
+    */test/*
+    # omit the devtools
+    devtools/*
+    # omit the conftest?
+    conftest.py

--- a/README.rst
+++ b/README.rst
@@ -222,3 +222,6 @@ project.
     :target: https://f5-openstack-slack.herokuapp.com/
     :alt: Slack
 
+.. |coveralls| image:: https://coveralls.io/repos/github/F5Networks/f5-common-python/badge.svg
+    :target: https://coveralls.io/github/F5Networks/f5-common-python
+    :alt: Coveralls

--- a/requirements.test.txt
+++ b/requirements.test.txt
@@ -8,3 +8,4 @@ mock==1.3.0
 pytest==2.9.1
 pytest-cov>=2.2.1
 git+https://github.com/F5Networks/pytest-symbols.git
+python-coveralls


### PR DESCRIPTION
Issues:
Fixes #547

Problem:
The f5-sdk codebase can run coverage tests, but there is no easy reporting
of these results.

Analysis:
The Coveralls.io service has been setup for the f5-common-python test. This
change to the README is to add the badge for coveralls so that developers
can easily see what the coverage tests currently result in

Tests:
None
