### PR TITLE
Bugfix.requests params odata

### DIFF
--- a/docs/userguide/index.rst
+++ b/docs/userguide/index.rst
@@ -12,4 +12,5 @@ using the configuration utility (the GUI). More useful still would be if you are
    endpoints
    object_path
    ltm_pools_members_code_example
+   odata_queries
    further_reading

--- a/docs/userguide/odata_queries.rst
+++ b/docs/userguide/odata_queries.rst
@@ -1,0 +1,23 @@
+OData Queries
+==============
+
+The REST service on the BIG-IP® device implements a subset of the Open Data Protocol, which allows a user to refine a set of data based on query parameters. This is especially useful when limiting the number of results returned on a ``get_collection()`` call. The way to use these query parameters with the f5-sdk is shown below:
+
+.. topic:: Examples
+
+**Filter example:** Retrieve only http profiles in a particular partition. Note this is an inclusive filter.
+    .. code-block:: python
+
+        mgmt = ManagementRoot('<ip_address>', '<username>', '<password>')
+        http_profiles = mgmt.tm.ltm.profile.https
+        http_profiles.get_collection(requests_params={'params': '$filter=partition+eq+test_folder'})
+
+**Select example:** Retrieve only the name of the http profiles.
+    .. code-block:: python
+
+        http_profiles.get_collection(requests_params={'params': '$select=name'})
+
+**Top example:** Retrieve only a certain number of rows of results from http profiles.
+    .. code-block:: python
+
+        http_profiles.get_collection(requests_params={'params': '$top=2'})

--- a/docs/userguide/odata_queries.rst
+++ b/docs/userguide/odata_queries.rst
@@ -5,19 +5,22 @@ The REST service on the BIG-IP® device implements a subset of the Open Data Pro
 
 .. topic:: Examples
 
-**Filter example:** Retrieve only http profiles in a particular partition. Note this is an inclusive filter.
+    **Filter example:** Retrieve only http profiles in a particular partition. Note this is an inclusive filter.
+
     .. code-block:: python
 
         mgmt = ManagementRoot('<ip_address>', '<username>', '<password>')
         http_profiles = mgmt.tm.ltm.profile.https
         http_profiles.get_collection(requests_params={'params': '$filter=partition+eq+test_folder'})
 
-**Select example:** Retrieve only the name of the http profiles.
+    **Select example:** Retrieve only the name of the http profiles.
+
     .. code-block:: python
 
         http_profiles.get_collection(requests_params={'params': '$select=name'})
 
-**Top example:** Retrieve only a certain number of rows of results from http profiles.
+    **Top example:** Retrieve only a certain number of rows of results from http profiles.
+
     .. code-block:: python
 
         http_profiles.get_collection(requests_params={'params': '$top=2'})

--- a/test/functional/test_requests_params.py
+++ b/test/functional/test_requests_params.py
@@ -47,7 +47,22 @@ def test_get_dollar_filtered_collection(request, bigip, pool_factory):
     test_pools = (Pool1Config, Pool2Config)
     pool_registry, member_registry =\
         pool_factory(bigip, request, test_pools)
-    rp = {'params': {'$filter': 'partition eq za'}}
+    rp = {'params': '$filter=partition+eq+za'}
     pools_in_za = bigip.ltm.pools.get_collection(requests_params=rp)
     muri = pools_in_za[0]._meta_data['uri']
     assert muri.endswith('/mgmt/tm/ltm/pool/~za~TEST/')
+
+
+def test_get_dollar_select_collection_properties(request, bigip, mgmt_root):
+    http_profiles = mgmt_root.tm.ltm.profile.https
+    without_select = http_profiles.get_collection()
+    with_select = http_profiles.get_collection(
+        requests_params={'params': '$select=name'}
+    )
+    expected_profs = [
+        {'name': 'http'},
+        {'name': 'http-explicit'},
+        {'name': 'http-transparent'}
+    ]
+    assert without_select != with_select
+    assert expected_profs == with_select


### PR DESCRIPTION
@jputrino and @zancas 
#### What's this change do?

Fixes a test issue that is only apparent when testing requests_params against an 11.5.4 image. In addition to fixing the issue, a doc has also been added to let our users know how to make these types of what's called OData queries (select, filter, top etc...).
#### Any background context?

The requests_params test for filtering based on partition was failing when testing against 11.5.4.
#### Where should the reviewer start?

Start at the doc addition, then go to the tests.
