### PR TITLE
Bugfix.tg 11 5 4

### DIFF
--- a/test/functional/cm/test_traffic_group.py
+++ b/test/functional/cm/test_traffic_group.py
@@ -13,6 +13,8 @@
 # limitations under the License.
 #
 
+from distutils.version import LooseVersion
+import pytest
 from requests import HTTPError
 
 TEST_DESCR = "TEST DESCRIPTION"
@@ -32,11 +34,24 @@ def setup_traffic_group_test(request, bigip, name, partition, **kwargs):
 
 
 class TestTrafficGroups(object):
-    def test_device_list(self, bigip):
+    @pytest.mark.skipif(
+        LooseVersion(
+            pytest.config.getoption('--release')
+        ) < LooseVersion('11.6.0'),
+        reason='Skip test if on a version below 11.6.0. The '
+        'mac attribute does not exist in 11.5.4.')
+    def test_device_list_11_6_and_greater(self, bigip):
         groups = bigip.cm.traffic_groups.get_collection()
         assert len(groups)
         assert groups[0].generation > 0
         assert hasattr(groups[0], 'mac')
+
+    def test_device_list_alternative(self, bigip):
+        '''An alternative to test above that works regardless of version.'''
+        groups = bigip.cm.traffic_groups.get_collection()
+        assert len(groups)
+        assert groups[0].generation > 0
+        assert hasattr(groups[0], 'isFloating')
 
 
 class TestDevice(object):


### PR DESCRIPTION
@zancas 
#### What's this change do?

Fixes a test issue that is only apparent when testing traffic_group for a specific attribute ('mac') in 11.5.4.
#### Any background context?

The test/functional/cm/test_traffic_group.py::TestTrafficGroups::test_device test was failing against 11.5.4 because the above attribute does not exist for a traffic_group.
#### Where should the reviewer start?

Only test fixups here.
