### PR TITLE
Fixing functional test issues in test/functional/tm/ltm/test_policy.py

### DIFF
--- a/f5/bigip/resource.py
+++ b/f5/bigip/resource.py
@@ -568,6 +568,30 @@ class ResourceBase(PathElement, ToDictMixin):
         new_instance._activate_URI(new_instance.selfLink)
         return new_instance
 
+    def _reduce_boolean_pair(self, config_dict, key1, key2):
+        '''Ensure only one key with a boolean value is present in dict.
+
+        :param config_dict: dict -- dictionary of config or kwargs
+        :param key1: string -- first key name
+        :param key2: string -- second key name
+        :raises: BooleansToReduceHaveSameValue
+        '''
+
+        if key1 in config_dict and key2 in config_dict \
+                and config_dict[key1] == config_dict[key2]:
+            msg = 'Boolean pair, %s and %s, have same value: %s. If both ' \
+                'are given to this method, they cannot be the same, as this ' \
+                'method cannot decide which one should be True.' \
+                % (key1, key2, config_dict[key1])
+            raise BooleansToReduceHaveSameValue(msg)
+        elif key1 in config_dict and not config_dict[key1]:
+            config_dict[key2] = True
+            config_dict.pop(key1)
+        elif key2 in config_dict and not config_dict[key2]:
+            config_dict[key1] = True
+            config_dict.pop(key2)
+        return config_dict
+
 
 class OrganizingCollection(ResourceBase):
     """Base class for objects that collect resources under them.
@@ -761,30 +785,6 @@ class Resource(ResourceBase):
                                 'creation_uri_qargs': qargs,
                                 'creation_uri_frag': frag,
                                 'allowed_lazy_attributes': attrs})
-
-    def _reduce_boolean_pair(self, config_dict, key1, key2):
-        '''Ensure only one key with a boolean value is present in dict.
-
-        :param config_dict: dict -- dictionary of config or kwargs
-        :param key1: string -- first key name
-        :param key2: string -- second key name
-        :raises: BooleansToReduceHaveSameValue
-        '''
-
-        if key1 in config_dict and key2 in config_dict \
-                and config_dict[key1] == config_dict[key2]:
-            msg = 'Boolean pair, %s and %s, have same value: %s. If both ' \
-                'are given to this method, they cannot be the same, as this ' \
-                'method cannot decide which one should be True.' \
-                % (key1, key2, config_dict[key1])
-            raise BooleansToReduceHaveSameValue(msg)
-        elif key1 in config_dict and not config_dict[key1]:
-            config_dict[key2] = True
-            config_dict.pop(key1)
-        elif key2 in config_dict and not config_dict[key2]:
-            config_dict[key1] = True
-            config_dict.pop(key2)
-        return config_dict
 
     def _create(self, **kwargs):
         """wrapped by `create` override that in subclasses to customize"""

--- a/f5/bigip/tm/sys/failover.py
+++ b/f5/bigip/tm/sys/failover.py
@@ -27,13 +27,10 @@ REST Kind
 """
 
 from f5.bigip.mixins import CommandExecutionMixin
-from f5.bigip.mixins import ReduceBooleanPairToTrueMixin
 from f5.bigip.resource import UnnamedResource
 
 
-class Failover(
-        UnnamedResource, CommandExecutionMixin, ReduceBooleanPairToTrueMixin
-):
+class Failover(UnnamedResource, CommandExecutionMixin):
     '''BIG-IP® Failover stats and state change.
 
     The failover object only supports load, update, and refresh because it is
@@ -93,7 +90,7 @@ class Failover(
         :: raises InvalidParameterValue
         """
 
-        self._reduce_boolean_pair(kwargs, 'online', 'offline')
+        kwargs = self._reduce_boolean_pair(kwargs, 'online', 'offline')
         if 'offline' in kwargs:
             self._meta_data['exclusive_attributes'].append(
                 ('offline', 'standby'))

--- a/f5/bigip/tm/sys/failover.py
+++ b/f5/bigip/tm/sys/failover.py
@@ -27,15 +27,13 @@ REST Kind
 """
 
 from f5.bigip.mixins import CommandExecutionMixin
+from f5.bigip.mixins import ReduceBooleanPairToTrueMixin
 from f5.bigip.resource import UnnamedResource
-from f5.sdk_exception import F5SDKError
 
 
-class InvalidParameterValue(F5SDKError):
-    pass
-
-
-class Failover(UnnamedResource, CommandExecutionMixin):
+class Failover(
+        UnnamedResource, CommandExecutionMixin, ReduceBooleanPairToTrueMixin
+):
     '''BIG-IP® Failover stats and state change.
 
     The failover object only supports load, update, and refresh because it is
@@ -95,14 +93,7 @@ class Failover(UnnamedResource, CommandExecutionMixin):
         :: raises InvalidParameterValue
         """
 
-        if 'online' in kwargs and 'offline' in kwargs:
-            if kwargs['online'] is True and kwargs['offline'] is True or \
-               kwargs['online'] is False and kwargs['offline'] is False:
-                error = 'Both parameters cannot have the same value' \
-                        'Currently they are: online={} offline={}'.format(
-                            kwargs['online'], kwargs['offline'])
-                raise InvalidParameterValue(error)
-
+        self._reduce_boolean_pair(kwargs, 'online', 'offline')
         if 'offline' in kwargs:
             self._meta_data['exclusive_attributes'].append(
                 ('offline', 'standby'))

--- a/test/functional/tm/ltm/test_policy.py
+++ b/test/functional/tm/ltm/test_policy.py
@@ -20,25 +20,12 @@ pp('')
 TESTDESCRIPTION = "TESTDESCRIPTION"
 
 
-def delete_resource(resources):
-    for resource in resources.get_collection():
-        system_policy_obj_name = ['_sys_CEC_SSL_client_policy',
-                                  '_sys_CEC_SSL_server_policy',
-                                  '_sys_CEC_video_policy']
-        if resource.name not in system_policy_obj_name:
-            resource.delete()
-
-
 @pytest.fixture
-def setup(request, bigip):
-    pc1 = bigip.ltm.policys
-    delete_resource(pc1)
+def setup(request, setup_device_snapshot):
+    return setup_device_snapshot
 
 
 def setup_policy_test(request, bigip, partition, name, strategy="first-match"):
-    def teardown():
-        delete_resource(pc1)
-    request.addfinalizer(teardown)
     pc1 = bigip.ltm.policys
     policy1 = pc1.policy.create(
         name=name, partition=partition, strategy=strategy)
@@ -70,10 +57,9 @@ class TestRulesAndActions(object):
         test_pol1 = rulespc.policy.load(partition='Common',
                                         name='_sys_CEC_video_policy')
         rules_s1 = test_pol1.rules_s
-        rules1 = rules_s1.rules.load(name='youporn_web_1')
+        rules1 = rules_s1.rules.load(name='cnn_web_1')
         r1actions = rules1.actions_s.actions.load(name="1")
         assert r1actions.kind == r1actions._meta_data['required_json_kind']
-        delete_resource(rulespc)
 
 
 class TestRulesAndConditions(object):
@@ -82,8 +68,7 @@ class TestRulesAndConditions(object):
         test_pol1 = rulespc.policy.load(partition='Common',
                                         name='_sys_CEC_video_policy')
         rules_s1 = test_pol1.rules_s
-        rules1 = rules_s1.rules.load(name='youporn_web_1')
+        rules1 = rules_s1.rules.load(name='cnn_web_1')
         r1conditions = rules1.conditions_s.conditions.load(name="1")
         assert r1conditions.kind ==\
             r1conditions._meta_data['required_json_kind']
-        delete_resource(rulespc)

--- a/test/functional/tm/sys/test_failover.py
+++ b/test/functional/tm/sys/test_failover.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 #
 
-from f5.bigip.mixins import BooleansToReduceHaveSameValue
+from f5.bigip.resource import BooleansToReduceHaveSameValue
 from f5.multi_device.utils import get_device_info
 from f5.multi_device.utils import pollster
 from pprint import pprint as pp


### PR DESCRIPTION
@zancas 
Don't merge until #558 has been merged!
#### What's this change do?

Implemented a module-level pytest fixture which snapshots the device
before and after the test. The diff between those snapshots is used to
remove objects created by the tests.
#### Any background context?

During test teardown, an attempt is made to delete the policies that are
not a part of the built-ins. The built-ins have changed between versions
of TMOS. We should snapshot the get_collection call and use that
pre-test snapshot to delete all those policies created by the tests.
#### Where should the reviewer start?

conftest.py change, then the changes in the test_policy.py file
