### PR TITLE
Adds Stats Module

### DIFF
--- a/f5/bigip/resource.py
+++ b/f5/bigip/resource.py
@@ -192,7 +192,8 @@ class PathElement(LazyAttributeMixin):
         self._meta_data['required_command_parameters'] = set()
         # You can't have more than one of the attributes in any of these sets.
         self._meta_data['exclusive_attributes'] = []
-        # We assume that resource does not have stats, to be overridden in subclasses
+        # We assume that resource does not have stats,
+        # to be overridden in subclasses
         self._meta_data['object_has_stats'] = False
 
     def _set_meta_data_uri(self):
@@ -387,7 +388,8 @@ class PathElement(LazyAttributeMixin):
 
     def _get_nest_stats(self, rdict):
         """Helper method to deal with nestedStats
-           as json format changed in v12.x
+
+        as json format changed in v12.x
         """
         for x in rdict:
             check = urlparse.urlparse(x)
@@ -987,13 +989,14 @@ class UnnamedResource(ResourceBase):
 
 class Stats(PathElement):
     """This class allows attaching 'stats' object as an
+
         attribute to a resource.
 
         Stats are available on some objects, and require
         the target object to be loaded or created first.
+
         It also allows the caller to retrieve the converted json
         response in unprocessed state.
-
     """
     def __init__(self, container):
         super(Stats, self).__init__(container)

--- a/f5/bigip/resource.py
+++ b/f5/bigip/resource.py
@@ -385,7 +385,7 @@ class PathElement(LazyAttributeMixin):
             temp_dict[key.replace('.', '_')] = value
         return temp_dict
 
-    def _pop_nest_stats(self, rdict):
+    def _get_nest_stats(self, rdict):
         """Helper method to deal with nestedStats
            as json format changed in v12.x
         """
@@ -393,7 +393,8 @@ class PathElement(LazyAttributeMixin):
             check = urlparse.urlparse(x)
             if check.scheme:
                 nested_dict = rdict[x]['nestedStats']
-                return self._key_dot_replace(nested_dict.pop('entries'))
+                tmp_dict = nested_dict['entries']
+                return self._key_dot_replace(tmp_dict)
 
         return self._key_dot_replace(rdict)
 
@@ -411,7 +412,7 @@ class PathElement(LazyAttributeMixin):
             error = 'Missing "entries" key in returned JSON'
             raise InvalidStatsJsonReturned(error)
         sanitized = self._check_keys(rdict)
-        stat_vals = self._pop_nest_stats(sanitized.pop('entries'))
+        stat_vals = self._get_nest_stats(sanitized['entries'])
         temp_meta = self._meta_data
         self.__dict__['stat'] = DottedDict(stat_vals)
         self._meta_data = temp_meta

--- a/f5/bigip/test/test_resource.py
+++ b/f5/bigip/test/test_resource.py
@@ -22,8 +22,8 @@ from f5.bigip.resource import DottedDict
 from f5.bigip.resource import ExclusiveAttributesPresent
 from f5.bigip.resource import GenerationMismatch
 from f5.bigip.resource import InvalidForceType
-from f5.bigip.resource import InvalidStatsJsonReturned
 from f5.bigip.resource import InvalidResource
+from f5.bigip.resource import InvalidStatsJsonReturned
 from f5.bigip.resource import KindTypeMismatch
 from f5.bigip.resource import MissingRequiredCommandParameter
 from f5.bigip.resource import MissingRequiredCreationParameter
@@ -39,44 +39,62 @@ from f5.bigip.resource import URICreationCollision
 from f5.bigip.tm.ltm.virtual import Virtual
 from f5.sdk_exception import UnsupportedMethod
 
-from types import *
+from types import ClassType
+from types import TypeType
 
-NESTED_DICT = {
-        u'https://localhost/mgmt/tm/fakemod/fake/fakeone/~Common~fakeone/stats': {
-            u'nestedStats': {
-                u'kind': u'tm:fakemod:fake:fakestats',
-                u'selfLink': u'https://localhost/mgmt/tm/fakemod/fake/fakeone/~Common~fakeone/stats?ver=12.1.0',
-                u'entries': {u'syncookie.accepts': {u'value': 0}, u'ephemeral.bitsOut': {u'value': 0},
-                             u'clientside.bitsOut': {u'value': 0}}}}}
 
-NOT_NESTED_DICT = {u'syncookie.accepts': {u'value': 0}, u'ephemeral.bitsOut': {u'value': 0},
-                    u'clientside.bitsOut': {u'value': 0}}
+NESTED_DICT = \
+    {u'https://localhost/mgmt/tm/fakemod/fake/fakeone/~Common~fakeone/stats': {
+        u'nestedStats': {
+            u'kind': u'tm:fakemod:fake:fakestats',
+            u'selfLink': u'https://localhost/mgmt/tm/fakemod/fake/fakeone/'
+                         u'~Common~fakeone/stats?ver=12.1.0',
+            u'entries': {u'syncookie.accepts': {
+                u'value': 0}, u'ephemeral.bitsOut': {
+                u'value': 0}, u'clientside.bitsOut': {u'value': 0}}}}}
+
+NOT_NESTED_DICT = {u'syncookie.accepts': {u'value': 0},
+                   u'ephemeral.bitsOut': {u'value': 0},
+                   u'clientside.bitsOut': {u'value': 0}}
 
 NESTED_DICT_NO_URI = {u'fakekey.some': {
-    u'nestedStats': {u'kind': u'tm:fakemod:fake:fakestats',
-                     u'selfLink': u'https://localhost/mgmt/tm/fakemod/fake/fakeone/~Common~fakeone/stats?ver=12.1.0',
-                     u'entries': {u'syncookie.accepts': {u'value': 0},
-                                  u'ephemeral.bitsOut': {u'value': 0},
-                                  u'clientside.bitsOut': {u'value': 0}}}}}
+    u'nestedStats': {
+        u'kind': u'tm:fakemod:fake:fakestats',
+        u'selfLink': u'https://localhost/mgmt/tm/fakemod/'
+                     u'fake/fakeone/~Common~fakeone/stats?ver=12.1.0',
+        u'entries': {u'syncookie.accepts': {u'value': 0},
+                     u'ephemeral.bitsOut': {u'value': 0},
+                     u'clientside.bitsOut': {u'value': 0}}}}}
 
 EXPECTED_CONVERTED_DICT = {u'syncookie_accepts': {u'value': 0},
-                                      u'ephemeral_bitsOut': {u'value': 0},
-                                      u'clientside_bitsOut': {u'value': 0}}
+                           u'ephemeral_bitsOut': {u'value': 0},
+                           u'clientside_bitsOut': {u'value': 0}}
 
 EXPECTED_CONVERTED_DICT_NO_URI = {u'fakekey_some': {u'nestedStats': {
     u'kind': u'tm:fakemod:fake:fakestats', u'selfLink':
-        u'https://localhost/mgmt/tm/fakemod/fake/fakeone/~Common~fakeone/stats?ver=12.1.0',
-    u'entries': {u'syncookie_accepts': {u'value': 0}, u'ephemeral_bitsOut': {u'value': 0},
+        u'https://localhost/mgmt/tm/fakemod/fake/fakeone/'
+        u'~Common~fakeone/stats?ver=12.1.0',
+    u'entries': {u'syncookie_accepts': {u'value': 0},
+                 u'ephemeral_bitsOut': {u'value': 0},
                  u'clientside_bitsOut': {u'value': 0}}}}}
 
 RAW_DICT = {u'generation': 9575, u'kind': u'tm:ltm:virtual:virtualstats',
-            u'selfLink': u'https://testhost/mgmt/tm/ltm/virtual/~Common~test_load/stats?ver=12.1.0',
-            u'entries': { u'https://testhost/mgmt/tm/ltm/virtual/~Common~test_load/~Common~test_load/stats':{
-                u'nestedStats': {u'kind': u'tm:ltm:virtual:virtualstats',
-                                 u'selfLink':
-                                     u'https://testhost/mgmt/tm/ltm/virtual/~Common~test_load/~Common~test_load/stats?ver=12.1.0',
-                                 u'entries': {u'syncookie.accepts': {u'value': 0}, u'ephemeral.bitsOut': {u'value': 0},
-                                              u'clientside.bitsOut': {u'value': 0}}}}}}
+            u'selfLink': u'https://testhost/mgmt/tm/ltm/virtual/'
+                         u'~Common~test_load/stats?ver=12.1.0',
+            u'entries': {
+                u'https://testhost/mgmt/tm/ltm/virtual/'
+                u'~Common~test_load/~Common~test_load/stats': {
+                    u'nestedStats': {u'kind': u'tm:ltm:virtual:virtualstats',
+                                     u'selfLink': u'https://testhost/mgmt/tm/'
+                                                  u'ltm/virtual/~Common'
+                                                  u'~test_load/~Common~'
+                                                  u'test_load/stats?'
+                                                  u'ver=12.1.0',
+                                     u'entries':
+                                         {u'syncookie.accepts': {u'value': 0},
+                                          u'ephemeral.bitsOut': {u'value': 0},
+                                          u'clientside.bitsOut': {u'value': 0}
+                                          }}}}}
 
 
 class MockResponse(object):
@@ -176,9 +194,9 @@ def test__activate_URI_with_stats():
         'hostname': 'TESTDOMAIN',
         'uri': 'https://TESTDOMAIN:443/mgmt/tm/'
     }
-    assert r._meta_data['object_has_stats'] == False
+    assert not r._meta_data['object_has_stats']
     r._meta_data['object_has_stats'] = True
-    assert r._meta_data['object_has_stats'] == True
+    assert r._meta_data['object_has_stats']
     TURI = 'https://localhost:443/mgmt/tm/'\
            'ltm/virtual/~Common~testvirtual/?ver=11.6&a=b#FOO'
     assert r._meta_data['allowed_lazy_attributes'] == []
@@ -204,7 +222,7 @@ def test__activate_URI_no_stats():
     }
     TURI = 'https://localhost:443/mgmt/tm/'\
            'ltm/nat/~Common~testnat/?ver=11.5&a=b#FOO'
-    assert r._meta_data['object_has_stats'] == False
+    assert not r._meta_data['object_has_stats']
     assert r._meta_data['allowed_lazy_attributes'] == []
     r._activate_URI(TURI)
     assert r._meta_data['uri'] ==\
@@ -592,12 +610,12 @@ def FakePath():
     fake_path = mock.MagicMock()
     return PathElement(fake_path)
 
+
 @pytest.fixture
 def FakeVirtual():
     r = Virtual(mock.MagicMock())
     mockuri = "https://localhost:443/mgmt/tm/ltm/virtual/~Common~test_load"
-    attrs = {'get.return_value':
-        MockResponse(
+    attrs = {'get.return_value': MockResponse(
             {
                 u"generation": 0,
                 u"selfLink": mockuri,
@@ -631,9 +649,7 @@ def MakeFakeResourceContainer(FakePath):
 
     mockconturi = 'https://testhost/mgmt/tm/ltm/virtual/~Common~test_load/'
     bigipuri = 'https://testhost/mgmt/tm/'
-    attrs = {'get.return_value':
-                 MockResponse(RAW_DICT)}
-
+    attrs = {'get.return_value': MockResponse(RAW_DICT)}
     return_session = mock.MagicMock(**attrs)
     FakePath._meta_data = {
         'hostname': 'testhost',
@@ -654,7 +670,8 @@ class TestPathElementStatsModuleHelpers(object):
                      'fuz.bar': {'baz.foo': {'faz': {'baz.fuz': 1}}}}
         undotted_fake_dict = p._key_dot_replace(fake_dict)
         assert undotted_fake_dict == {'foo_bar': 'foo', 'baz': 'baz.foo',
-                     'fuz_bar': {'baz_foo': {'faz': {'baz_fuz': 1}}}}
+                                      'fuz_bar': {'baz_foo': {'faz': {
+                                          'baz_fuz': 1}}}}
 
     def test_pop_nest_stats_nested(self):
         p = PathElement(mock.MagicMock())
@@ -699,19 +716,18 @@ class TestStats(object):
     def test_resource_preload(self):
         virt = FakeVirtual()
         chk_lst = virt._meta_data['allowed_lazy_attributes']
-        assert virt._meta_data['object_has_stats'] == True
+        assert virt._meta_data['object_has_stats']
         assert 'stats' in [cls.__name__.lower() for cls in chk_lst
                            if type(cls) in [TypeType, ClassType]]
 
     def test_stats_init(self):
         virt = FakeVirtual()
-        attrs = {'get.return_value':
-                     MockResponse(RAW_DICT)}
-
+        attrs = {'get.return_value': MockResponse(RAW_DICT)}
         return_session = mock.MagicMock(**attrs)
         virt._meta_data['bigip']._meta_data['icr_session'] = return_session
         fake_stats = virt.stats
-        uri = 'https://TESTDOMAIN:443/mgmt/tm/ltm/virtual/~Common~test_load/stats/'
+        uri = 'https://TESTDOMAIN:443/mgmt/tm/' \
+              'ltm/virtual/~Common~test_load/stats/'
         assert fake_stats._meta_data['uri'] == uri
         assert 'stat' in fake_stats.__dict__
         assert hasattr(fake_stats.stat, 'syncookie_accepts')
@@ -723,9 +739,7 @@ class TestStats(object):
 
     def test_stats_raw(self):
         virt = FakeVirtual()
-        attrs = {'get.return_value':
-                     MockResponse(RAW_DICT)}
-
+        attrs = {'get.return_value': MockResponse(RAW_DICT)}
         return_session = mock.MagicMock(**attrs)
         virt._meta_data['bigip']._meta_data['icr_session'] = return_session
         fake_stats = virt.stats
@@ -735,15 +749,18 @@ class TestStats(object):
 class TestDottedDict(object):
         def test_init_dict(self):
             undotted_fake_dict = {'foo_bar': 'foo', 'baz': 'baz.foo',
-                           'fuz_bar': {'baz_foo': {'faz': {'baz_fuz': 1}}}}
+                                  'fuz_bar': {'baz_foo': {
+                                      'faz': {'baz_fuz': 1}}}}
             testdotted = DottedDict(undotted_fake_dict)
             assert testdotted.keys() == undotted_fake_dict.keys()
             assert not hasattr(testdotted, 'baz_foo')
             assert isinstance(testdotted['fuz_bar'], dict)
 
         def test_init_nondict_elements(self):
-            undotted_fake_mixed_dict = {'foo_bar': ('one', 'two'), 'baz': ['baz', 'foo'],
-                                        'fuz_bar': {'baz_foo': {'faz': ['baz_fuz', (1, 2, 3)]}}}
+            undotted_fake_mixed_dict = {'foo_bar': ('one', 'two'),
+                                        'baz': ['baz', 'foo'],
+                                        'fuz_bar': {'baz_foo': {
+                                            'faz': ['baz_fuz', (1, 2, 3)]}}}
             testdotted = DottedDict(undotted_fake_mixed_dict)
             assert testdotted.keys() == undotted_fake_mixed_dict.keys()
             assert not hasattr(testdotted, 'baz_foo')
@@ -752,17 +769,20 @@ class TestDottedDict(object):
 
         def test_getattr(self):
             undotted_fake_dict = {'foo_bar': 'foo', 'baz': 'baz.foo',
-                                  'fuz_bar': {'baz_foo': {'faz': {'baz_fuz': 1}}}}
+                                  'fuz_bar': {'baz_foo': {
+                                      'faz': {'baz_fuz': 1}}}}
             testdotted = DottedDict(undotted_fake_dict)
             assert isinstance(testdotted.fuz_bar, DottedDict)
-            assert hasattr(testdotted.fuz_bar.baz_foo , 'faz')
+            assert hasattr(testdotted.fuz_bar.baz_foo, 'faz')
             assert isinstance(testdotted.fuz_bar.baz_foo.faz, DottedDict)
             assert hasattr(testdotted.fuz_bar.baz_foo.faz, 'baz_fuz')
             assert testdotted.fuz_bar.baz_foo.faz.baz_fuz == 1
 
         def test_getattr_nondict_elements(self):
-            undotted_fake_mixed_dict = {'foo_bar': ('one', 'two'), 'baz': ['baz', 'foo'],
-                                  'fuz_bar': {'baz_foo': {'faz': ['baz_fuz', (1, 2, 3)]}}}
+            undotted_fake_mixed_dict = {'foo_bar': ('one', 'two'),
+                                        'baz': ['baz', 'foo'],
+                                        'fuz_bar': {'baz_foo': {'faz': [
+                                            'baz_fuz', (1, 2, 3)]}}}
             testdotted = DottedDict(undotted_fake_mixed_dict)
             assert isinstance(testdotted.fuz_bar, DottedDict)
             assert hasattr(testdotted.fuz_bar.baz_foo, 'faz')

--- a/f5/bigip/test/test_resource.py
+++ b/f5/bigip/test/test_resource.py
@@ -18,9 +18,11 @@ import requests
 
 from f5.bigip.resource import Collection
 from f5.bigip.resource import DeviceProvidesIncompatibleKey
+from f5.bigip.resource import DottedDict
 from f5.bigip.resource import ExclusiveAttributesPresent
 from f5.bigip.resource import GenerationMismatch
 from f5.bigip.resource import InvalidForceType
+from f5.bigip.resource import InvalidStatsJsonReturned
 from f5.bigip.resource import InvalidResource
 from f5.bigip.resource import KindTypeMismatch
 from f5.bigip.resource import MissingRequiredCommandParameter
@@ -36,6 +38,45 @@ from f5.bigip.resource import UnregisteredKind
 from f5.bigip.resource import URICreationCollision
 from f5.bigip.tm.ltm.virtual import Virtual
 from f5.sdk_exception import UnsupportedMethod
+
+from types import *
+
+NESTED_DICT = {
+        u'https://localhost/mgmt/tm/fakemod/fake/fakeone/~Common~fakeone/stats': {
+            u'nestedStats': {
+                u'kind': u'tm:fakemod:fake:fakestats',
+                u'selfLink': u'https://localhost/mgmt/tm/fakemod/fake/fakeone/~Common~fakeone/stats?ver=12.1.0',
+                u'entries': {u'syncookie.accepts': {u'value': 0}, u'ephemeral.bitsOut': {u'value': 0},
+                             u'clientside.bitsOut': {u'value': 0}}}}}
+
+NOT_NESTED_DICT = {u'syncookie.accepts': {u'value': 0}, u'ephemeral.bitsOut': {u'value': 0},
+                    u'clientside.bitsOut': {u'value': 0}}
+
+NESTED_DICT_NO_URI = {u'fakekey.some': {
+    u'nestedStats': {u'kind': u'tm:fakemod:fake:fakestats',
+                     u'selfLink': u'https://localhost/mgmt/tm/fakemod/fake/fakeone/~Common~fakeone/stats?ver=12.1.0',
+                     u'entries': {u'syncookie.accepts': {u'value': 0},
+                                  u'ephemeral.bitsOut': {u'value': 0},
+                                  u'clientside.bitsOut': {u'value': 0}}}}}
+
+EXPECTED_CONVERTED_DICT = {u'syncookie_accepts': {u'value': 0},
+                                      u'ephemeral_bitsOut': {u'value': 0},
+                                      u'clientside_bitsOut': {u'value': 0}}
+
+EXPECTED_CONVERTED_DICT_NO_URI = {u'fakekey_some': {u'nestedStats': {
+    u'kind': u'tm:fakemod:fake:fakestats', u'selfLink':
+        u'https://localhost/mgmt/tm/fakemod/fake/fakeone/~Common~fakeone/stats?ver=12.1.0',
+    u'entries': {u'syncookie_accepts': {u'value': 0}, u'ephemeral_bitsOut': {u'value': 0},
+                 u'clientside_bitsOut': {u'value': 0}}}}}
+
+RAW_DICT = {u'generation': 9575, u'kind': u'tm:ltm:virtual:virtualstats',
+            u'selfLink': u'https://testhost/mgmt/tm/ltm/virtual/~Common~test_load/stats?ver=12.1.0',
+            u'entries': { u'https://testhost/mgmt/tm/ltm/virtual/~Common~test_load/~Common~test_load/stats':{
+                u'nestedStats': {u'kind': u'tm:ltm:virtual:virtualstats',
+                                 u'selfLink':
+                                     u'https://testhost/mgmt/tm/ltm/virtual/~Common~test_load/~Common~test_load/stats?ver=12.1.0',
+                                 u'entries': {u'syncookie.accepts': {u'value': 0}, u'ephemeral.bitsOut': {u'value': 0},
+                                              u'clientside.bitsOut': {u'value': 0}}}}}}
 
 
 class MockResponse(object):
@@ -127,7 +168,33 @@ class TestResourcecreate(object):
         assert x.selfLink == u".../~Common~test_create"
 
 
-def test__activate_URI():
+def test__activate_URI_with_stats():
+    r = Resource(mock.MagicMock())
+    r._meta_data['allowed_lazy_attributes'] = []
+    r._meta_data['attribute_registry'] = {u"tm:": u"SPAM"}
+    r._meta_data['bigip']._meta_data = {
+        'hostname': 'TESTDOMAIN',
+        'uri': 'https://TESTDOMAIN:443/mgmt/tm/'
+    }
+    assert r._meta_data['object_has_stats'] == False
+    r._meta_data['object_has_stats'] = True
+    assert r._meta_data['object_has_stats'] == True
+    TURI = 'https://localhost:443/mgmt/tm/'\
+           'ltm/virtual/~Common~testvirtual/?ver=11.6&a=b#FOO'
+    assert r._meta_data['allowed_lazy_attributes'] == []
+    r._activate_URI(TURI)
+    assert r._meta_data['uri'] ==\
+        'https://TESTDOMAIN:443/mgmt/tm/ltm/virtual/~Common~testvirtual/'
+    assert r._meta_data['creation_uri_qargs'] ==\
+        {'a': ['b'], 'ver': ['11.6']}
+    assert r._meta_data['creation_uri_frag'] == 'FOO'
+    chk_lst = r._meta_data['allowed_lazy_attributes']
+    assert u"SPAM" in chk_lst
+    assert 'stats' in [cls.__name__.lower() for cls in chk_lst
+                       if type(cls) in [TypeType, ClassType]]
+
+
+def test__activate_URI_no_stats():
     r = Resource(mock.MagicMock())
     r._meta_data['allowed_lazy_attributes'] = []
     r._meta_data['attribute_registry'] = {u"tm:": u"SPAM"}
@@ -137,6 +204,7 @@ def test__activate_URI():
     }
     TURI = 'https://localhost:443/mgmt/tm/'\
            'ltm/nat/~Common~testnat/?ver=11.5&a=b#FOO'
+    assert r._meta_data['object_has_stats'] == False
     assert r._meta_data['allowed_lazy_attributes'] == []
     r._activate_URI(TURI)
     assert r._meta_data['uri'] ==\
@@ -517,6 +585,190 @@ class TestPathElement(object):
         with pytest.raises(ExclusiveAttributesPresent) as EAEIO:
             p._check_exclusive_parameters(**fakearg)
         assert 'FOOEX, BAREX' in EAEIO.value.message
+
+
+@pytest.fixture
+def FakePath():
+    fake_path = mock.MagicMock()
+    return PathElement(fake_path)
+
+@pytest.fixture
+def FakeVirtual():
+    r = Virtual(mock.MagicMock())
+    mockuri = "https://localhost:443/mgmt/tm/ltm/virtual/~Common~test_load"
+    attrs = {'get.return_value':
+        MockResponse(
+            {
+                u"generation": 0,
+                u"selfLink": mockuri,
+                u"kind": u"tm:ltm:virtual:virtualstate"
+            }
+        )}
+    mock_session = mock.MagicMock(**attrs)
+    r._meta_data['bigip']._meta_data = \
+        {'icr_session': mock_session,
+         'hostname': 'TESTDOMAINNAME',
+         'uri': 'https://TESTDOMAIN:443/mgmt/tm/'
+         }
+    r._meta_data['bigip'].tmos_version = '12.1.0'
+    r.generation = 0
+    x = r.load(partition='Common', name='test_load')
+    return x
+
+
+@pytest.fixture
+def MakeFakeResourceContainer(FakePath):
+    class FakeMetaData(object):
+        def __init__(self, **kwargs):
+            self._meta_data = {}
+            meta_data_defaults = {
+                'uri': kwargs['uri'],
+                'icontrol_version': '',
+                'icr_session': kwargs['icr_session'],
+                'bigip': self
+            }
+            self._meta_data.update(meta_data_defaults)
+
+    mockconturi = 'https://testhost/mgmt/tm/ltm/virtual/~Common~test_load/'
+    bigipuri = 'https://testhost/mgmt/tm/'
+    attrs = {'get.return_value':
+                 MockResponse(RAW_DICT)}
+
+    return_session = mock.MagicMock(**attrs)
+    FakePath._meta_data = {
+        'hostname': 'testhost',
+        'icr_session': '',
+        'uri': '',
+        'icontrol_version': '',
+        'bigip': FakeMetaData(icr_session=return_session, uri=bigipuri),
+        'container': FakeMetaData(uri=mockconturi, icr_session='')
+    }
+
+    return FakePath
+
+
+class TestPathElementStatsModuleHelpers(object):
+    def test_key_dot_replace(self):
+        p = PathElement(mock.MagicMock())
+        fake_dict = {'foo.bar': 'foo', 'baz': 'baz.foo',
+                     'fuz.bar': {'baz.foo': {'faz': {'baz.fuz': 1}}}}
+        undotted_fake_dict = p._key_dot_replace(fake_dict)
+        assert undotted_fake_dict == {'foo_bar': 'foo', 'baz': 'baz.foo',
+                     'fuz_bar': {'baz_foo': {'faz': {'baz_fuz': 1}}}}
+
+    def test_pop_nest_stats_nested(self):
+        p = PathElement(mock.MagicMock())
+        nest = p._get_nest_stats(NESTED_DICT)
+        assert nest == EXPECTED_CONVERTED_DICT
+
+    def test_pop_nest_stats_not_nested(self):
+        p = PathElement(mock.MagicMock())
+        not_nest = p._get_nest_stats(NOT_NESTED_DICT)
+        assert not_nest == EXPECTED_CONVERTED_DICT
+
+    def test_pop_nest_stats_nested_no_uri(self):
+        p = PathElement(mock.MagicMock())
+        nested_nouri = p._get_nest_stats(NESTED_DICT_NO_URI)
+        assert nested_nouri == EXPECTED_CONVERTED_DICT_NO_URI
+
+    def test_get_stats_raw(self, FakePath):
+        v = MakeFakeResourceContainer(FakePath)
+        raw_dict = v._get_stats_raw()
+        ret_uri = 'https://testhost/mgmt/tm/ltm/virtual/~Common~test_load/'
+        assert v._meta_data['container']._meta_data['uri'] == ret_uri
+        assert raw_dict == RAW_DICT
+
+    def test_update_stats_invalid_json(self):
+        fake_dict = {'foo.bar': 'foo', 'baz': 'baz.foo',
+                     'fuz.bar': {'baz.foo': {'faz': {'baz.fuz': 1}}}}
+        p = PathElement(mock.MagicMock())
+        with pytest.raises(InvalidStatsJsonReturned)as err:
+            p._update_stats(fake_dict)
+        assert err.value.message == 'Missing "entries" key in returned JSON'
+
+    def test_update_stats(self):
+        p = PathElement(mock.MagicMock())
+        p._update_stats(RAW_DICT)
+        assert 'stat' in p.__dict__
+        assert hasattr(p.__dict__['stat'], 'syncookie_accepts')
+        assert hasattr(p.__dict__['stat'], 'ephemeral_bitsOut')
+        assert hasattr(p.__dict__['stat'], 'clientside_bitsOut')
+
+
+class TestStats(object):
+    def test_resource_preload(self):
+        virt = FakeVirtual()
+        chk_lst = virt._meta_data['allowed_lazy_attributes']
+        assert virt._meta_data['object_has_stats'] == True
+        assert 'stats' in [cls.__name__.lower() for cls in chk_lst
+                           if type(cls) in [TypeType, ClassType]]
+
+    def test_stats_init(self):
+        virt = FakeVirtual()
+        attrs = {'get.return_value':
+                     MockResponse(RAW_DICT)}
+
+        return_session = mock.MagicMock(**attrs)
+        virt._meta_data['bigip']._meta_data['icr_session'] = return_session
+        fake_stats = virt.stats
+        uri = 'https://TESTDOMAIN:443/mgmt/tm/ltm/virtual/~Common~test_load/stats/'
+        assert fake_stats._meta_data['uri'] == uri
+        assert 'stat' in fake_stats.__dict__
+        assert hasattr(fake_stats.stat, 'syncookie_accepts')
+        assert hasattr(fake_stats.stat, 'ephemeral_bitsOut')
+        assert hasattr(fake_stats.stat, 'clientside_bitsOut')
+        assert fake_stats.stat.syncookie_accepts.value == 0
+        assert fake_stats.stat.ephemeral_bitsOut.value == 0
+        assert fake_stats.stat.clientside_bitsOut.value == 0
+
+    def test_stats_raw(self):
+        virt = FakeVirtual()
+        attrs = {'get.return_value':
+                     MockResponse(RAW_DICT)}
+
+        return_session = mock.MagicMock(**attrs)
+        virt._meta_data['bigip']._meta_data['icr_session'] = return_session
+        fake_stats = virt.stats
+        assert fake_stats.stats_raw == RAW_DICT
+
+
+class TestDottedDict(object):
+        def test_init_dict(self):
+            undotted_fake_dict = {'foo_bar': 'foo', 'baz': 'baz.foo',
+                           'fuz_bar': {'baz_foo': {'faz': {'baz_fuz': 1}}}}
+            testdotted = DottedDict(undotted_fake_dict)
+            assert testdotted.keys() == undotted_fake_dict.keys()
+            assert not hasattr(testdotted, 'baz_foo')
+            assert isinstance(testdotted['fuz_bar'], dict)
+
+        def test_init_nondict_elements(self):
+            undotted_fake_mixed_dict = {'foo_bar': ('one', 'two'), 'baz': ['baz', 'foo'],
+                                        'fuz_bar': {'baz_foo': {'faz': ['baz_fuz', (1, 2, 3)]}}}
+            testdotted = DottedDict(undotted_fake_mixed_dict)
+            assert testdotted.keys() == undotted_fake_mixed_dict.keys()
+            assert not hasattr(testdotted, 'baz_foo')
+            assert isinstance(testdotted['foo_bar'], tuple)
+            assert isinstance(testdotted['baz'], list)
+
+        def test_getattr(self):
+            undotted_fake_dict = {'foo_bar': 'foo', 'baz': 'baz.foo',
+                                  'fuz_bar': {'baz_foo': {'faz': {'baz_fuz': 1}}}}
+            testdotted = DottedDict(undotted_fake_dict)
+            assert isinstance(testdotted.fuz_bar, DottedDict)
+            assert hasattr(testdotted.fuz_bar.baz_foo , 'faz')
+            assert isinstance(testdotted.fuz_bar.baz_foo.faz, DottedDict)
+            assert hasattr(testdotted.fuz_bar.baz_foo.faz, 'baz_fuz')
+            assert testdotted.fuz_bar.baz_foo.faz.baz_fuz == 1
+
+        def test_getattr_nondict_elements(self):
+            undotted_fake_mixed_dict = {'foo_bar': ('one', 'two'), 'baz': ['baz', 'foo'],
+                                  'fuz_bar': {'baz_foo': {'faz': ['baz_fuz', (1, 2, 3)]}}}
+            testdotted = DottedDict(undotted_fake_mixed_dict)
+            assert isinstance(testdotted.fuz_bar, DottedDict)
+            assert hasattr(testdotted.fuz_bar.baz_foo, 'faz')
+            assert isinstance(testdotted.fuz_bar.baz_foo.faz, list)
+            assert not hasattr(testdotted.fuz_bar.baz_foo.faz, 'baz_fuz')
+            assert testdotted.fuz_bar.baz_foo.faz == ['baz_fuz', (1, 2, 3)]
 
 
 class TestUnnamedResource(object):

--- a/f5/bigip/tm/ltm/pool.py
+++ b/f5/bigip/tm/ltm/pool.py
@@ -55,7 +55,6 @@ class Pool(Resource):
         self._meta_data['attribute_registry'] = {
             'tm:ltm:pool:memberscollectionstate': Members_s
         }
-        self._meta_data['object_has_stats'] = True
 
 
 class Members_s(Collection):

--- a/f5/bigip/tm/ltm/pool.py
+++ b/f5/bigip/tm/ltm/pool.py
@@ -55,6 +55,7 @@ class Pool(Resource):
         self._meta_data['attribute_registry'] = {
             'tm:ltm:pool:memberscollectionstate': Members_s
         }
+        self._meta_data['object_has_stats'] = True
 
 
 class Members_s(Collection):

--- a/f5/bigip/tm/ltm/virtual.py
+++ b/f5/bigip/tm/ltm/virtual.py
@@ -31,6 +31,7 @@ from f5.bigip.resource import Collection
 from f5.bigip.resource import Resource
 
 
+
 class Virtuals(Collection):
     """BIG-IP® LTM virtual collection"""
     def __init__(self, ltm):
@@ -48,6 +49,8 @@ class Virtual(Resource):
         self._meta_data['required_json_kind'] = 'tm:ltm:virtual:virtualstate'
         self._meta_data['attribute_registry'] =\
             {'tm:ltm:virtual:profiles:profilescollectionstate': Profiles_s}
+        self._meta_data['object_has_stats'] = True
+
 
 
 class Profiles(Resource):

--- a/f5/bigip/tm/ltm/virtual.py
+++ b/f5/bigip/tm/ltm/virtual.py
@@ -31,7 +31,6 @@ from f5.bigip.resource import Collection
 from f5.bigip.resource import Resource
 
 
-
 class Virtuals(Collection):
     """BIG-IP® LTM virtual collection"""
     def __init__(self, ltm):
@@ -50,7 +49,6 @@ class Virtual(Resource):
         self._meta_data['attribute_registry'] =\
             {'tm:ltm:virtual:profiles:profilescollectionstate': Profiles_s}
         self._meta_data['object_has_stats'] = True
-
 
 
 class Profiles(Resource):

--- a/test/functional/tm/ltm/test_virtual.py
+++ b/test/functional/tm/ltm/test_virtual.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 #
 
+from f5.bigip.resource import DottedDict
 from pprint import pprint as pp
 
 TESTDESCRIPTION = "TESTDESCRIPTION"
@@ -45,6 +46,16 @@ class TestVirtual(object):
         assert virtual1.description == TESTDESCRIPTION
         virtual2 = vc1.virtual.load(partition='Common', name='vstest1')
         assert virtual2.selfLink == virtual1.selfLink
+
+    def test_virtual_stats(self, request, bigip):
+        virtual1, vc1 = setup_virtual_test(request, bigip, 'Common', 'vstest1')
+        v1_stats = virtual1.stats
+        assert v1_stats.kind == 'tm:ltm:virtual:virtualstats'
+        assert hasattr(v1_stats, 'stat')
+        assert isinstance(v1_stats.stat.cmpEnableMode, DottedDict)
+        assert v1_stats.stat.cmpEnableMode.description == 'all-cpus'
+        assert hasattr(v1_stats.stat.clientside_pktsOut, 'value')
+        assert isinstance(v1_stats.stat.clientside_pktsOut.value, int)
 
 
 def test_profiles_CE(bigip, opt_release):

--- a/test/functional/tm/ltm/test_virtual.py
+++ b/test/functional/tm/ltm/test_virtual.py
@@ -50,7 +50,6 @@ class TestVirtual(object):
     def test_virtual_stats(self, request, bigip):
         virtual1, vc1 = setup_virtual_test(request, bigip, 'Common', 'vstest1')
         v1_stats = virtual1.stats
-        assert v1_stats.kind == 'tm:ltm:virtual:virtualstats'
         assert hasattr(v1_stats, 'stat')
         assert isinstance(v1_stats.stat.cmpEnableMode, DottedDict)
         assert v1_stats.stat.cmpEnableMode.description == 'all-cpus'


### PR DESCRIPTION
@zancas @pjbreaux  @caphrim007 

What's this change do?

This PR will add the STATS capability to selected resources. In this first iteration only Virtual Server resources will be supported, more resources will be added gradually. 

Any background context?
BIGIP allows users to retrieve stats on many resource objects in the bigip, this is rough equivalent to tmsh show.... command.

At the moment only Virtual Servers are enabled to support stats, rest of the resources will be added in gradually.
Stats module for collections needs different approach hence this was not implemented in this release, but is planned for the future

Where should the reviewer start?
f5-common-python\test\functional\tm\ltm\test_virtual.py
f5-common-python\f5\bigip\resource.py
f5-common-python\f5\bigip\test\test_resource.py
f5-common-python\f5\bigip\tm\ltm\virtual.py
