### PR TITLE
Bugfix.failover tests 11 5 4

### DIFF
--- a/f5/bigip/tm/ltm/profile.py
+++ b/f5/bigip/tm/ltm/profile.py
@@ -235,6 +235,7 @@ class Client_Ldaps(Collection):
         self._meta_data['allowed_lazy_attributes'] = [Client_Ldap]
         self._meta_data['attribute_registry'] = \
             {'tm:ltm:profile:client-ldap:client-ldapstate': Client_Ldap}
+        self._meta_data['minimum_version'] = '11.6.0'
 
 
 class Client_Ldap(Resource):
@@ -252,6 +253,7 @@ class Dhcpv4s(Collection):
         self._meta_data['allowed_lazy_attributes'] = [Dhcpv4]
         self._meta_data['attribute_registry'] = \
             {'tm:ltm:profile:dhcpv4:dhcpv4state': Dhcpv4}
+        self._meta_data['minimum_version'] = '11.6.0'
 
 
 class Dhcpv4(Resource):
@@ -269,6 +271,7 @@ class Dhcpv6s(Collection):
         self._meta_data['allowed_lazy_attributes'] = [Dhcpv6]
         self._meta_data['attribute_registry'] = \
             {'tm:ltm:profile:dhcpv6:dhcpv6state': Dhcpv6}
+        self._meta_data['minimum_version'] = '11.6.0'
 
 
 class Dhcpv6(Resource):
@@ -407,6 +410,7 @@ class Gtps(Collection):
         self._meta_data['allowed_lazy_attributes'] = [Gtp]
         self._meta_data['attribute_registry'] = \
             {'tm:ltm:profile:gtp:gtpstate': Gtp}
+        self._meta_data['minimum_version'] = '11.6.0'
 
 
 class Gtp(Resource):
@@ -478,6 +482,7 @@ class Http2s(Collection):
         self._meta_data['allowed_lazy_attributes'] = [Http2]
         self._meta_data['attribute_registry'] = \
             {'tm:ltm:profile:http2:http2state': Http2}
+        self._meta_data['minimum_version'] = '11.6.0'
 
 
 class Http2(Resource):
@@ -600,6 +605,7 @@ class Ocsp_Stapling_Params_s(Collection):
             {'tm:ltm:profile:ocsp-stapling-params:ocsp-stapling-paramsstate':
                 Ocsp_Stapling_Params}
         self._meta_data['attribute_registry'] = temp
+        self._meta_data['minimum_version'] = '11.6.0'
 
 
 class Ocsp_Stapling_Params(Resource):
@@ -878,6 +884,7 @@ class Server_Ldaps(Collection):
         self._meta_data['allowed_lazy_attributes'] = [Server_Ldap]
         self._meta_data['attribute_registry'] = \
             {'tm:ltm:profile:server-ldap:server-ldapstate': Server_Ldap}
+        self._meta_data['minimum_version'] = '11.6.0'
 
 
 class Server_Ldap(Resource):
@@ -933,6 +940,7 @@ class Smtps(Collection):
         self._meta_data['allowed_lazy_attributes'] = [Smtp]
         self._meta_data['attribute_registry'] = \
             {'tm:ltm:profile:smtp:smtpstate': Smtp}
+        self._meta_data['minimum_version'] = '11.6.0'
 
 
 class Smtp(Resource):

--- a/test/functional/tm/ltm/test_profile.py
+++ b/test/functional/tm/ltm/test_profile.py
@@ -13,6 +13,9 @@
 # limitations under the License.
 #
 
+
+from distutils.version import LooseVersion
+from f5.bigip.mixins import UnsupportedTmosVersion
 from pprint import pprint as pp
 pp(__file__)
 import pytest
@@ -210,10 +213,25 @@ class TestClassification(object):
 
 
 class TestClientLdap(object):
-    def test_CURDL(self, request, bigip):
+    @pytest.mark.skipif(
+        LooseVersion(pytest.config.getoption('--release'))
+        < LooseVersion('11.6.0'),
+        reason='This collection exists on 11.6.0 or greater.'
+    )
+    def test_CURDL_11_6_and_greater(self, request, bigip):
         ldap = HelperTest(end_lst, 2)
         ldap.test_CURDL(request, bigip)
 
+    @pytest.mark.skipif(
+        LooseVersion(pytest.config.getoption('--release'))
+        >= LooseVersion('11.6.0'),
+        reason='This collection does not exist on 11.5.4 or less.'
+    )
+    def test_CURDL_11_5_4_and_less(self, request, bigip):
+        ldap = HelperTest(end_lst, 2)
+        with pytest.raises(UnsupportedTmosVersion) as ex:
+            ldap.test_CURDL(request, bigip)
+        assert 'Minimum TMOS version supported is 11.6.0' in ex.value.message
 
 # End ClientLdap tests
 
@@ -232,9 +250,25 @@ class TestClientSsl(object):
 
 
 class TestDhcpv4(object):
-    def test_CURDL(self, request, bigip):
+    @pytest.mark.skipif(
+        LooseVersion(pytest.config.getoption('--release'))
+        < LooseVersion('11.6.0'),
+        reason='This collection exists on 11.6.0 or greater.'
+    )
+    def test_CURDL_11_6_and_greater(self, request, bigip):
         dhcpv4 = HelperTest(end_lst, 4)
         dhcpv4.test_CURDL(request, bigip)
+
+    @pytest.mark.skipif(
+        LooseVersion(pytest.config.getoption('--release'))
+        >= LooseVersion('11.6.0'),
+        reason='This collection does not exist on 11.5.4 or less.'
+    )
+    def test_CURDL_11_5_4_and_less(self, request, bigip):
+        dhcpv4 = HelperTest(end_lst, 4)
+        with pytest.raises(UnsupportedTmosVersion) as ex:
+            dhcpv4.test_CURDL(request, bigip)
+        assert 'Minimum TMOS version supported is 11.6.0' in ex.value.message
 
 
 # End Dhcpv4 tests
@@ -243,11 +277,25 @@ class TestDhcpv4(object):
 
 
 class TestDhcpv6(object):
-    def test_CURDL(self, request, bigip):
+    @pytest.mark.skipif(
+        LooseVersion(pytest.config.getoption('--release'))
+        < LooseVersion('11.6.0'),
+        reason='This collection exists on 11.6.0 or greater.'
+    )
+    def test_CURDL_11_6_and_greater(self, request, bigip):
         dhcpv6 = HelperTest(end_lst, 5)
         dhcpv6.test_CURDL(request, bigip)
 
-
+    @pytest.mark.skipif(
+        LooseVersion(pytest.config.getoption('--release'))
+        >= LooseVersion('11.6.0'),
+        reason='This collection does not exist on 11.5.4 or less.'
+    )
+    def test_CURDL_11_5_4_and_less(self, request, bigip):
+        dhcpv4 = HelperTest(end_lst, 5)
+        with pytest.raises(UnsupportedTmosVersion) as ex:
+            dhcpv4.test_CURDL(request, bigip)
+        assert 'Minimum TMOS version supported is 11.6.0' in ex.value.message
 # End Dhcpv6 tests
 
 # Begin Diameter tests
@@ -374,9 +422,25 @@ class TestFtp(object):
 
 
 class TestGtp(object):
-    def test_CURDL(self, request, bigip):
+    @pytest.mark.skipif(
+        LooseVersion(pytest.config.getoption('--release'))
+        < LooseVersion('11.6.0'),
+        reason='This collection exists on 11.6.0 or greater.'
+    )
+    def test_CURDL_11_6_and_greater(self, request, bigip):
         gtp = HelperTest(end_lst, 13)
         gtp.test_CURDL(request, bigip)
+
+    @pytest.mark.skipif(
+        LooseVersion(pytest.config.getoption('--release'))
+        >= LooseVersion('11.6.0'),
+        reason='This collection does not exist on 11.5.4 or less.'
+    )
+    def test_CURDL_11_5_4_and_less(self, request, bigip):
+        dhcpv4 = HelperTest(end_lst, 13)
+        with pytest.raises(UnsupportedTmosVersion) as ex:
+            dhcpv4.test_CURDL(request, bigip)
+        assert 'Minimum TMOS version supported is 11.6.0' in ex.value.message
 
 
 # End GTP tests
@@ -418,9 +482,25 @@ class TestHttpCompress(object):
 
 
 class TestHttp2(object):
-    def test_CURDL(self, request, bigip):
+    @pytest.mark.skipif(
+        LooseVersion(pytest.config.getoption('--release'))
+        < LooseVersion('11.6.0'),
+        reason='This collection exists on 11.6.0 or greater.'
+    )
+    def test_CURDL_11_6_and_greater(self, request, bigip):
         http2 = HelperTest(end_lst, 17)
         http2.test_CURDL(request, bigip)
+
+    @pytest.mark.skipif(
+        LooseVersion(pytest.config.getoption('--release'))
+        >= LooseVersion('11.6.0'),
+        reason='This collection does not exist on 11.5.4 or less.'
+    )
+    def test_CURDL_11_5_4_and_less(self, request, bigip):
+        dhcpv4 = HelperTest(end_lst, 17)
+        with pytest.raises(UnsupportedTmosVersion) as ex:
+            dhcpv4.test_CURDL(request, bigip)
+        assert 'Minimum TMOS version supported is 11.6.0' in ex.value.message
 
 
 # End HTTP tests
@@ -542,7 +622,12 @@ def setup_dns_resolver(request, bigip, name):
 
 
 class TestOcspStaplingParams(object):
-    def test_CURDL(self, request, bigip):
+    @pytest.mark.skipif(
+        LooseVersion(pytest.config.getoption('--release'))
+        < LooseVersion('11.6.0'),
+        reason='This collection exists on 11.6.0 or greater.'
+    )
+    def test_CURDL_11_6_and_greater(self, request, bigip):
 
         # Setup DNS resolver as prerequisite
         dns = setup_dns_resolver(request, bigip, 'test_resolv')
@@ -577,6 +662,27 @@ class TestOcspStaplingParams(object):
 
         assert ocsp1.selfLink == ocsp2.selfLink
 
+    @pytest.mark.skipif(
+        LooseVersion(pytest.config.getoption('--release'))
+        >= LooseVersion('11.6.0'),
+        reason='This collection does not exist on 11.5.4 or less.'
+    )
+    def test_CURDL_11_6_and_less(self, request, bigip):
+
+        # Setup DNS resolver as prerequisite
+        dns = setup_dns_resolver(request, bigip, 'test_resolv')
+
+        # Test CURDL
+        ocsp = HelperTest(end_lst, 24)
+
+        # Testing create
+        with pytest.raises(UnsupportedTmosVersion) as ex:
+            ocsp.setup_test(
+                request, bigip, dnsResolver=dns.name,
+                trustedCa='/Common/ca-bundle.crt',
+                useProxyServer='disabled'
+            )
+        assert 'Minimum TMOS version supported is 11.6.0' in ex.value.message
 
 # End Ocsp Stapling Params tests
 
@@ -795,9 +901,25 @@ class TestSctps(object):
 
 
 class TestServerLdap(object):
-    def test_CURDL(self, request, bigip):
+    @pytest.mark.skipif(
+        LooseVersion(pytest.config.getoption('--release'))
+        < LooseVersion('11.6.0'),
+        reason='This collection exists on 11.6.0 or greater.'
+    )
+    def test_CURDL_11_6_and_greater(self, request, bigip):
         sldap = HelperTest(end_lst, 35)
         sldap.test_CURDL(request, bigip)
+
+    @pytest.mark.skipif(
+        LooseVersion(pytest.config.getoption('--release'))
+        >= LooseVersion('11.6.0'),
+        reason='This collection does not exist on 11.5.4 or less.'
+    )
+    def test_CURDL_11_5_4_and_less(self, request, bigip):
+        dhcpv4 = HelperTest(end_lst, 35)
+        with pytest.raises(UnsupportedTmosVersion) as ex:
+            dhcpv4.test_CURDL(request, bigip)
+        assert 'Minimum TMOS version supported is 11.6.0' in ex.value.message
 
 
 # End Server Ldap tests
@@ -828,9 +950,25 @@ class TestSip(object):
 
 
 class TestSmtp(object):
-    def test_CURDL(self, request, bigip):
+    @pytest.mark.skipif(
+        LooseVersion(pytest.config.getoption('--release'))
+        < LooseVersion('11.6.0'),
+        reason='This collection exists on 11.6.0 or greater.'
+    )
+    def test_CURDL_11_6_and_greater(self, request, bigip):
         smtp = HelperTest(end_lst, 38)
         smtp.test_CURDL(request, bigip)
+
+    @pytest.mark.skipif(
+        LooseVersion(pytest.config.getoption('--release'))
+        >= LooseVersion('11.6.0'),
+        reason='This collection does not exist on 11.5.4 or less.'
+    )
+    def test_CURDL_11_5_4_and_less(self, request, bigip):
+        dhcpv4 = HelperTest(end_lst, 38)
+        with pytest.raises(UnsupportedTmosVersion) as ex:
+            dhcpv4.test_CURDL(request, bigip)
+        assert 'Minimum TMOS version supported is 11.6.0' in ex.value.message
 
 
 # End Smtp tests

--- a/test/functional/tm/sys/test_failover.py
+++ b/test/functional/tm/sys/test_failover.py
@@ -93,6 +93,9 @@ class TestFailover(object):
         f = mgmt_root.tm.sys.failover
         f.exec_cmd('run', offline=True)
         get_activation_state(mgmt_root)
+        # Use the pollster to check for expected state. The pollster uses
+        # a method which checks for any exception. If one is found, it keeps
+        # trying.
         pollster(check_device_state_as_expected)(mgmt_root, 'forced-offline')
         fl.refresh()
         pp(fl.raw)


### PR DESCRIPTION
@zancas 
Close #558 before this one!
#### What's this change do?

Updates failover resource to use new ReduceBooleanPairToTrueMixin to reduce online and offline in that resource and remove local logic that was doing the same thing as the mixin. Also fixed the tests for this resource to teardown properly, leaving the device in an online state.
#### Any background context?

During functional testing in 11.5.4 device goes to forced offline and does not come back online. We also needed to remove sleeps from these tests to make them more event driven.
#### Where should the reviewer start?

Tests, then resource changes.
