### PR TITLE
During functional testing in 11.5.4 in ltm/profile some tests fail at setup

### DIFF
--- a/f5/bigip/mixins.py
+++ b/f5/bigip/mixins.py
@@ -118,8 +118,8 @@ class LazyAttributeMixin(object):
         minimum = attribute._meta_data['minimum_version']
         if LooseVersion(tmos_v) < LooseVersion(minimum):
             error = "There was an attempt to access resource: \n{}\n which " \
-                    "is not implemented in the device's TMOS version: {}. "\
-                    "The minimum TMOS version in which this resource *is*"\
+                    "is not implemented in the device's TMOS version: {}. " \
+                    "The minimum TMOS version in which this resource *is* " \
                     "supported is {}".format(
                         attribute._meta_data['uri'],
                         tmos_v,

--- a/test/functional/tm/ltm/test_profile.py
+++ b/test/functional/tm/ltm/test_profile.py
@@ -231,7 +231,8 @@ class TestClientLdap(object):
         ldap = HelperTest(end_lst, 2)
         with pytest.raises(UnsupportedTmosVersion) as ex:
             ldap.test_CURDL(request, bigip)
-        assert 'Minimum TMOS version supported is 11.6.0' in ex.value.message
+        assert 'minimum TMOS version in which this resource *is* supported ' \
+            'is 11.6.0' in ex.value.message
 
 # End ClientLdap tests
 
@@ -268,7 +269,8 @@ class TestDhcpv4(object):
         dhcpv4 = HelperTest(end_lst, 4)
         with pytest.raises(UnsupportedTmosVersion) as ex:
             dhcpv4.test_CURDL(request, bigip)
-        assert 'Minimum TMOS version supported is 11.6.0' in ex.value.message
+        assert 'minimum TMOS version in which this resource *is* supported ' \
+            'is 11.6.0' in ex.value.message
 
 
 # End Dhcpv4 tests
@@ -295,7 +297,8 @@ class TestDhcpv6(object):
         dhcpv4 = HelperTest(end_lst, 5)
         with pytest.raises(UnsupportedTmosVersion) as ex:
             dhcpv4.test_CURDL(request, bigip)
-        assert 'Minimum TMOS version supported is 11.6.0' in ex.value.message
+        assert 'minimum TMOS version in which this resource *is* supported ' \
+            'is 11.6.0' in ex.value.message
 # End Dhcpv6 tests
 
 # Begin Diameter tests
@@ -440,7 +443,8 @@ class TestGtp(object):
         dhcpv4 = HelperTest(end_lst, 13)
         with pytest.raises(UnsupportedTmosVersion) as ex:
             dhcpv4.test_CURDL(request, bigip)
-        assert 'Minimum TMOS version supported is 11.6.0' in ex.value.message
+        assert 'minimum TMOS version in which this resource *is* supported ' \
+            'is 11.6.0' in ex.value.message
 
 
 # End GTP tests
@@ -500,7 +504,8 @@ class TestHttp2(object):
         dhcpv4 = HelperTest(end_lst, 17)
         with pytest.raises(UnsupportedTmosVersion) as ex:
             dhcpv4.test_CURDL(request, bigip)
-        assert 'Minimum TMOS version supported is 11.6.0' in ex.value.message
+        assert 'minimum TMOS version in which this resource *is* supported ' \
+            'is 11.6.0' in ex.value.message
 
 
 # End HTTP tests
@@ -682,7 +687,8 @@ class TestOcspStaplingParams(object):
                 trustedCa='/Common/ca-bundle.crt',
                 useProxyServer='disabled'
             )
-        assert 'Minimum TMOS version supported is 11.6.0' in ex.value.message
+        assert 'minimum TMOS version in which this resource *is* supported ' \
+            'is 11.6.0' in ex.value.message
 
 # End Ocsp Stapling Params tests
 
@@ -919,7 +925,8 @@ class TestServerLdap(object):
         dhcpv4 = HelperTest(end_lst, 35)
         with pytest.raises(UnsupportedTmosVersion) as ex:
             dhcpv4.test_CURDL(request, bigip)
-        assert 'Minimum TMOS version supported is 11.6.0' in ex.value.message
+        assert 'minimum TMOS version in which this resource *is* supported ' \
+            'is 11.6.0' in ex.value.message
 
 
 # End Server Ldap tests
@@ -968,7 +975,8 @@ class TestSmtp(object):
         dhcpv4 = HelperTest(end_lst, 38)
         with pytest.raises(UnsupportedTmosVersion) as ex:
             dhcpv4.test_CURDL(request, bigip)
-        assert 'Minimum TMOS version supported is 11.6.0' in ex.value.message
+        assert 'minimum TMOS version in which this resource *is* supported ' \
+            'is 11.6.0' in ex.value.message
 
 
 # End Smtp tests


### PR DESCRIPTION
@zancas 
#### What's this change do?

After further inspection, it's simply that these collections (such as Client_Ldaps) do not exist on the 11.5.4 device. Added minimum tmos version to these collections, so they will not be instantiated by a user. Added some tests to ensure that the correct exception is raised if a user does try to instantiate one of these collections.
#### Any background context?

We have 8 test failures against 11.5.4 and all but one have the same signature: Found unexpected json pair at module
#### Where should the reviewer start?

Start at the test changes and go to the profile module from there.
