### PR TITLE
During functional testing against 12.1.0, sys/application test fails and errors out

### DIFF
--- a/f5/bigip/tm/sys/application.py
+++ b/f5/bigip/tm/sys/application.py
@@ -111,7 +111,7 @@ class Service(Resource):
         '''
 
         try:
-            super(Service, self)._create(**kwargs)
+            return super(Service, self)._create(**kwargs)
         except HTTPError as ex:
             if "The configuration was updated successfully but could not be " \
                     "retrieved" not in ex.response.text:

--- a/test/functional/tm/sys/test_sys_application.py
+++ b/test/functional/tm/sys/test_sys_application.py
@@ -13,16 +13,14 @@
 # limitations under the License.
 #
 
-from pprint import pprint as pp
 from requests import HTTPError
 
 from f5.bigip.tm.sys.application import Service
 from f5.bigip.tm.sys.application import Template
 
-pp(__file__)
 TESTDESCRIPTION = 'TESTDESCRIPTION'
 
-# Application Service Dictionary
+# Application service dictionary, which matches JSON structure
 sections = {
     'implementation': '',
     'presentation': ''
@@ -56,6 +54,7 @@ def setup_template_test(request, bigip, name, partition):
 
     def teardown():
         delete_resource(test_template)
+
     request.addfinalizer(teardown)
     test_template = template_s.template.create(
         name=name,
@@ -63,6 +62,7 @@ def setup_template_test(request, bigip, name, partition):
         actions=definition
     )
     assert isinstance(test_template, Template)
+    assert id(test_template) != id(template_s.template)
     return template_s, test_template
 
 
@@ -70,6 +70,7 @@ def setup_service_test(request, bigip, name, partition, template_name, tgroup):
     service_s = setup_service_collection_test(request, bigip)
 
     def teardown():
+        # Delete the service first, then the template
         delete_resource(test_service)
         delete_resource(test_template)
 
@@ -80,6 +81,7 @@ def setup_service_test(request, bigip, name, partition, template_name, tgroup):
         actions=definition
     )
     assert isinstance(test_template, Template)
+    assert id(test_template) != id(template_factory)
     test_service = service_s.service.create(
         name=name,
         partition=partition,
@@ -87,6 +89,7 @@ def setup_service_test(request, bigip, name, partition, template_name, tgroup):
         trafficGroup=tgroup
     )
     assert isinstance(test_service, Service)
+    assert id(test_service) != id(service_s.service)
     request.addfinalizer(teardown)
     return service_s, test_service
 

--- a/test/functional/tm/sys/test_sys_application.py
+++ b/test/functional/tm/sys/test_sys_application.py
@@ -59,6 +59,7 @@ def setup_template_test(request, bigip, name, partition):
         partition=partition,
         actions=definition
     )
+    assert test_template is not None
     return template_s, test_template
 
 
@@ -75,12 +76,14 @@ def setup_service_test(request, bigip, name, partition, template_name, tgroup):
         partition=partition,
         actions=definition
     )
+    assert test_template is not None
     test_service = service_s.service.create(
         name=name,
         partition=partition,
         template=template_name,
         trafficGroup=tgroup
     )
+    assert test_service is not None
     request.addfinalizer(teardown)
     return service_s, test_service
 

--- a/test/functional/tm/sys/test_sys_application.py
+++ b/test/functional/tm/sys/test_sys_application.py
@@ -16,6 +16,9 @@
 from pprint import pprint as pp
 from requests import HTTPError
 
+from f5.bigip.tm.sys.application import Service
+from f5.bigip.tm.sys.application import Template
+
 pp(__file__)
 TESTDESCRIPTION = 'TESTDESCRIPTION'
 
@@ -59,7 +62,7 @@ def setup_template_test(request, bigip, name, partition):
         partition=partition,
         actions=definition
     )
-    assert test_template is not None
+    assert isinstance(test_template, Template)
     return template_s, test_template
 
 
@@ -76,14 +79,14 @@ def setup_service_test(request, bigip, name, partition, template_name, tgroup):
         partition=partition,
         actions=definition
     )
-    assert test_template is not None
+    assert isinstance(test_template, Template)
     test_service = service_s.service.create(
         name=name,
         partition=partition,
         template=template_name,
         trafficGroup=tgroup
     )
-    assert test_service is not None
+    assert isinstance(test_service, Service)
     request.addfinalizer(teardown)
     return service_s, test_service
 


### PR DESCRIPTION
@caphrim007 
#### What's this change do?

Added return to the super call in the overridden version of _create in
Service. Added checks in each of the functional tests to ensure that the
thing that is returned from a create is not None.
#### Any background context?

This is a bug in application.py where we expected the call to create an
application service to raise an HTTPError, which was happening in
versions prior to 12.1.0. This is now fixed on the BIG-IP and when
testing against 12.1.0, it revealed a bug in our code where (in the
happy path) we weren't returning the result from the call to
super()._create(). That was returning None as the object back from a
create call.
#### Where should the reviewer start?

Review the code change, then checkout the functional test changes.
