### PR TITLE
Jenkins failure in datacenter.py relating to enabled/disabled

### DIFF
--- a/f5/bigip/tm/gtm/datacenter.py
+++ b/f5/bigip/tm/gtm/datacenter.py
@@ -131,9 +131,8 @@ class Datacenter(Resource, ExclusiveAttributesMixin):
         return self
 
     def update(self, **kwargs):
-        if 'enabled' in self.__dict__ and 'enabled' not in kwargs:
-            kwargs['enabled'] = self.__dict__.pop('enabled')
-        elif 'disabled' in self.__dict__ and 'disabled' not in kwargs:
-            kwargs['disabled'] = self.__dict__.pop('disabled')
+        if 'enabled' in kwargs or 'disabled' in kwargs:
+            self.__dict__.pop('enabled')
+            self.__dict__.pop('disabled')
         self._update(**kwargs)
         self._endis_attrs()


### PR DESCRIPTION
Issues:
Fixes #585

Problem:
This failure occurs due to the way an update is manually handled in the
datacenter. On an update, the enabled/disabled attributes should be
evicted just prior to contacting the device, that way the device reports
back the correct state and updates the object accordingly. If any kwargs
are given to update with enable/disable, then those will be applied
prior to contacting the device as well.

Analysis:
Updated the udpate according to @tar's suggestion, which applies good
logic to evict enabled/disabled from the object's attributes before
updating. Any kwargs with those keys also have the reduce boolean pair
logic applied before contacting the device.

Tests:
