### PR TITLE
Change update from put to patch

### DIFF
--- a/f5/bigip/resource.py
+++ b/f5/bigip/resource.py
@@ -474,7 +474,7 @@ class ResourceBase(PathElement, ToDictMixin):
 
         data_dict.update(kwargs)
 
-        response = session.put(update_uri, json=data_dict, **requests_params)
+        response = session.patch(update_uri, json=data_dict, **requests_params)
         self._meta_data = temp_meta
         self._local_update(response.json())
 
@@ -492,7 +492,7 @@ class ResourceBase(PathElement, ToDictMixin):
 
         :param kwargs: keys and associated values to alter on the device
         NOTE: If kwargs has a 'requests_params' key the corresponding dict will
-        be passed to the underlying requests.session.put method where it will
+        be passed to the underlying requests.session.patch method where it will
         be handled according to that API. THIS IS HOW TO PASS QUERY-ARGS!
 
         """

--- a/f5/bigip/test/test_resource.py
+++ b/f5/bigip/test/test_resource.py
@@ -56,7 +56,7 @@ def fake_rsrc():
     r._meta_data['allowed_lazy_attributes'] = []
     r._meta_data['uri'] = 'URI'
     r._meta_data['read_only_attributes'] = [u"READONLY"]
-    attrs = {'put.return_value': MockResponse({u"generation": 0}),
+    attrs = {'patch.return_value': MockResponse({u"generation": 0}),
              'get.return_value': MockResponse({u"generation": 0})}
     mock_session = mock.MagicMock(**attrs)
     r._meta_data['bigip']._meta_data = {'icr_session': mock_session}
@@ -237,7 +237,7 @@ class TestResource_update(object):
         r._meta_data['uri'] = 'URI'
         r._meta_data['bigip']._meta_data['icr_session'].get.return_value =\
             MockResponse({u"generation": 0})
-        r._meta_data['bigip']._meta_data['icr_session'].put.return_value =\
+        r._meta_data['bigip']._meta_data['icr_session'].patch.return_value =\
             MockResponse({u"generation": 0})
         r.generation = 0
         pre_meta = r._meta_data.copy()
@@ -248,7 +248,7 @@ class TestResource_update(object):
         r = Resource(mock.MagicMock())
         r._meta_data['allowed_lazy_attributes'] = []
         r._meta_data['uri'] = 'URI'
-        attrs = {'put.return_value': MockResponse({u"generation": 0}),
+        attrs = {'patch.return_value': MockResponse({u"generation": 0}),
                  'get.return_value': MockResponse({u"generation": 0})}
         mock_session = mock.MagicMock(**attrs)
         r._meta_data['bigip']._meta_data = {'icr_session': mock_session}
@@ -257,7 +257,7 @@ class TestResource_update(object):
         assert 'contained' in r.__dict__
         r.update(a=u"b")
         submitted = r._meta_data['bigip']. \
-            _meta_data['icr_session'].put.call_args[1]['json']
+            _meta_data['icr_session'].patch.call_args[1]['json']
 
         assert 'contained' not in submitted
 
@@ -266,7 +266,7 @@ class TestResource_update(object):
         r._meta_data['allowed_lazy_attributes'] = []
         r._meta_data['uri'] = 'URI'
         r._meta_data['read_only_attributes'] = [u"READONLY"]
-        attrs = {'put.return_value': MockResponse({u"generation": 0}),
+        attrs = {'patch.return_value': MockResponse({u"generation": 0}),
                  'get.return_value': MockResponse({u"generation": 0})}
         mock_session = mock.MagicMock(**attrs)
         r._meta_data['bigip']._meta_data = {'icr_session': mock_session}
@@ -275,26 +275,26 @@ class TestResource_update(object):
         assert 'READONLY' in r.__dict__
         r.update(a=u"b")
         submitted = r._meta_data['bigip'].\
-            _meta_data['icr_session'].put.call_args[1]['json']
+            _meta_data['icr_session'].patch.call_args[1]['json']
         assert 'READONLY' not in submitted
 
     def test_reduce_boolean_removes_enabled(self, fake_rsrc):
         fake_rsrc.update(enabled=False)
-        pos, kwargs = fake_rsrc._meta_data['bigip']._meta_data['icr_session'].put.\
+        pos, kwargs = fake_rsrc._meta_data['bigip']._meta_data['icr_session'].patch.\
             call_args
         assert kwargs['json']['disabled'] is True
         assert 'enabled' not in kwargs['json']
 
     def test_reduce_boolean_removes_disabled(self, fake_rsrc):
         fake_rsrc.update(disabled=False)
-        pos, kwargs = fake_rsrc._meta_data['bigip']._meta_data['icr_session'].put.\
+        pos, kwargs = fake_rsrc._meta_data['bigip']._meta_data['icr_session'].patch.\
             call_args
         assert kwargs['json']['enabled'] is True
         assert 'disabled' not in kwargs['json']
 
     def test_reduce_boolean_removes_nothing(self, fake_rsrc):
         fake_rsrc.update(partition='Common', name='test_create', enabled=True)
-        pos, kwargs = fake_rsrc._meta_data['bigip']._meta_data['icr_session'].put.\
+        pos, kwargs = fake_rsrc._meta_data['bigip']._meta_data['icr_session'].patch.\
             call_args
         assert kwargs['json']['enabled'] is True
         assert 'disabled' not in kwargs['json']
@@ -406,7 +406,7 @@ class TestResource_load(object):
         r._meta_data['allowed_lazy_attributes'] = []
         r._meta_data['uri'] = 'URI'
         r._meta_data['icontrol_version'] = '11.6.0'
-        attrs = {'put.return_value': MockResponse({u"generation": 0}),
+        attrs = {'patch.return_value': MockResponse({u"generation": 0}),
                  'get.return_value': MockResponse({u"generation": 0})}
         mock_session = mock.MagicMock(**attrs)
         r._meta_data['bigip']._meta_data = {'icr_session': mock_session}
@@ -415,14 +415,14 @@ class TestResource_load(object):
         assert 'contained' in r.__dict__
         r.update(a=u"b")
         submitted = r._meta_data['bigip']. \
-            _meta_data['icr_session'].put.call_args[1]['params']
+            _meta_data['icr_session'].patch.call_args[1]['params']
         assert submitted['ver'] == '11.6.0'
 
     def test_icontrol_version_default(self):
         r = Resource(mock.MagicMock())
         r._meta_data['allowed_lazy_attributes'] = []
         r._meta_data['uri'] = 'URI'
-        attrs = {'put.return_value': MockResponse({u"generation": 0}),
+        attrs = {'patch.return_value': MockResponse({u"generation": 0}),
                  'get.return_value': MockResponse({u"generation": 0})}
         mock_session = mock.MagicMock(**attrs)
         r._meta_data['bigip']._meta_data = {'icr_session': mock_session}
@@ -431,7 +431,7 @@ class TestResource_load(object):
         assert 'contained' in r.__dict__
         r.update(a=u"b")
         submitted = r._meta_data['bigip']. \
-            _meta_data['icr_session'].put.call_args
+            _meta_data['icr_session'].patch.call_args
         assert 'params' not in submitted
 
     def test_success(self):

--- a/f5/bigip/tm/sys/test/test_sys_application.py
+++ b/f5/bigip/tm/sys/test/test_sys_application.py
@@ -112,13 +112,13 @@ def MakeFakeContainer(FakeService, fake_bigip_data):
             self._meta_data.update(meta_data_defaults)
     mock_session = mock.MagicMock(name='mock_session')
     mock_get_response = mock.MagicMock(name='mock_get_response')
-    mock_put_response = mock.MagicMock(name='mock_put_response')
+    mock_patch_response = mock.MagicMock(name='mock_patch_response')
     mock_get_response.json.return_value = fake_bigip_data.copy()
-    mock_put_response.json.return_value = SUCCESSFUL_CREATE.copy()
-    # Mock the get and put when the container calls icr_session.get/put
+    mock_patch_response.json.return_value = SUCCESSFUL_CREATE.copy()
+    # Mock the get and patch when the container calls icr_session.get/patch
     mock_session.get.return_value = mock_get_response
-    mock_session.put.return_value = mock_put_response
-    mock_session.post.return_value = mock_put_response
+    mock_session.patch.return_value = mock_patch_response
+    mock_session.post.return_value = mock_patch_response
     FakeService._meta_data = {
         'hostname': 'testhost',
         'icr_session': mock_session,

--- a/test/functional/tm/ltm/test_pool.py
+++ b/test/functional/tm/ltm/test_pool.py
@@ -24,9 +24,8 @@ TESTDESCRIPTION = 'TESTDESCRIPTION'
 
 
 def delete_pool(bigip, name, partition):
-    p = bigip.ltm.pools.pool
     try:
-        p.load(name=name, partition=partition)
+        p = bigip.ltm.pools.pool.load(name=name, partition=partition)
     except HTTPError as err:
         if err.response.status_code != 404:
             raise
@@ -44,8 +43,7 @@ def setup_basic_test(request, bigip, name, partition):
     def teardown():
         delete_pool(bigip, name, partition)
 
-    pool1 = bigip.ltm.pools.pool
-    pool1.create(name=name, partition=partition)
+    pool1 = bigip.ltm.pools.pool.create(name=name, partition=partition)
     request.addfinalizer(teardown)
     return pool1
 
@@ -53,8 +51,8 @@ def setup_basic_test(request, bigip, name, partition):
 def setup_member_test(request, bigip, name, partition,
                       memname="192.168.15.15:80"):
     p1 = setup_basic_test(request, bigip, name, partition)
-    member = p1.members_s.members
-    member.create(name=memname, partition=partition)
+    member = p1.members_s.members.create(
+        name=memname, partition=partition)
     assert member.name == "192.168.15.15:80"
     return member, p1
 
@@ -121,8 +119,8 @@ class TestPoolMembers(object):
                                            'Common')
         member1.description = TESTDESCRIPTION
         member1.update(state=None)
-        member2 = pool1.members_s.members
-        member2.load(name='192.168.15.15:80', partition='Common')
+        member2 = pool1.members_s.members.load(
+            name='192.168.15.15:80', partition='Common')
         assert member2.description == TESTDESCRIPTION
         assert member2.selfLink == member1.selfLink
         member1.delete()
@@ -146,8 +144,7 @@ class TestPool(object):
 
     def test_create(self, request, bigip):
         setup_create_test(request, bigip, 'pool1', 'Common')
-        pool1 = bigip.ltm.pools.pool
-        pool1.create(name='pool1', partition='Common')
+        pool1 = bigip.ltm.pools.pool.create(name='pool1', partition='Common')
         assert pool1.name == 'pool1'
         assert pool1.partition == 'Common'
         assert pool1.generation and isinstance(pool1.generation, int)

--- a/test/functional/tm/ltm/test_pool.py
+++ b/test/functional/tm/ltm/test_pool.py
@@ -94,9 +94,6 @@ class TestPoolMembers(object):
         member, _ = setup_member_test(request, bigip, 'membertestpool1',
                                       'Common')
 
-    @pytest.skip('A known issue with generation number.'
-                 'See: https://github.com/F5Networks/'
-                 'f5-common-python/issues/334')
     def test_update_member(self, request, bigip):
         member, _ = setup_member_test(request, bigip, 'membertestpool1',
                                       'Common')


### PR DESCRIPTION
@caphrim007 
Please reassign to @pjbreaux , and @wojtek0806 , after review comments...   I want to make sure all core developers look at this before merge.
Issues:
Fixes #578 #564

Problem: The use of PUT in update was causing unintended side-effects.
This is costly behavior..  we probably shouldn't force the user to
submit more data than they intend!

Analysis: I've changed "put" to "patch" in the update method.
This seems like a major change, so I'd appreciate lots of feedback.

Among other things I'd like to validate that the f5-openstack-agent
consumer does _not_ break against this new version.

Tests:
- f5/bigip/test/test_resource.py
- f5/bigip/tm/sys/test/test_sys_application.py
