### PR TITLE
The skipped tests of #509 had aliases

### DIFF
--- a/test/functional/tm/ltm/test_pool.py
+++ b/test/functional/tm/ltm/test_pool.py
@@ -24,9 +24,8 @@ TESTDESCRIPTION = 'TESTDESCRIPTION'
 
 
 def delete_pool(bigip, name, partition):
-    p = bigip.ltm.pools.pool
     try:
-        p.load(name=name, partition=partition)
+        p = bigip.ltm.pools.pool.load(name=name, partition=partition)
     except HTTPError as err:
         if err.response.status_code != 404:
             raise
@@ -44,8 +43,7 @@ def setup_basic_test(request, bigip, name, partition):
     def teardown():
         delete_pool(bigip, name, partition)
 
-    pool1 = bigip.ltm.pools.pool
-    pool1.create(name=name, partition=partition)
+    pool1 = bigip.ltm.pools.pool.create(name=name, partition=partition)
     request.addfinalizer(teardown)
     return pool1
 
@@ -53,8 +51,8 @@ def setup_basic_test(request, bigip, name, partition):
 def setup_member_test(request, bigip, name, partition,
                       memname="192.168.15.15:80"):
     p1 = setup_basic_test(request, bigip, name, partition)
-    member = p1.members_s.members
-    member.create(name=memname, partition=partition)
+    member = p1.members_s.members.create(
+        name=memname, partition=partition)
     assert member.name == "192.168.15.15:80"
     return member, p1
 
@@ -121,8 +119,8 @@ class TestPoolMembers(object):
                                            'Common')
         member1.description = TESTDESCRIPTION
         member1.update(state=None)
-        member2 = pool1.members_s.members
-        member2.load(name='192.168.15.15:80', partition='Common')
+        member2 = pool1.members_s.members.load(
+            name='192.168.15.15:80', partition='Common')
         assert member2.description == TESTDESCRIPTION
         assert member2.selfLink == member1.selfLink
         member1.delete()
@@ -146,8 +144,7 @@ class TestPool(object):
 
     def test_create(self, request, bigip):
         setup_create_test(request, bigip, 'pool1', 'Common')
-        pool1 = bigip.ltm.pools.pool
-        pool1.create(name='pool1', partition='Common')
+        pool1 = bigip.ltm.pools.pool.create(name='pool1', partition='Common')
         assert pool1.name == 'pool1'
         assert pool1.partition == 'Common'
         assert pool1.generation and isinstance(pool1.generation, int)


### PR DESCRIPTION
@caphrim007 
Issues:
Fixes #509

Problem: test_pool.py was being skipped.  Tests were failing because
of aliasing.   I've fixed the aliasing issues after applying @caphrim007s
removal of the skip.

Analysis: These tests should be run!

Tests: test/functional/tm/ltm/test_pool.py
