### PR TITLE
Fixes transactions and adds functional tests

### DIFF
--- a/f5/bigip/contexts.py
+++ b/f5/bigip/contexts.py
@@ -47,7 +47,8 @@ class TransactionContextManager(object):
         be able to use the API object as you normally would.
         """
 
-        self.transaction.create()
+        self.transaction = self.transaction.create()
+
         self.icr.session.headers.update({
             'X-F5-REST-Coordination-Id': self.transaction.transId
         })

--- a/test/functional/tm/transaction/test_transaction.py
+++ b/test/functional/tm/transaction/test_transaction.py
@@ -1,0 +1,37 @@
+# Copyright 2016 F5 Networks Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import pytest
+
+from f5.bigip.contexts import TransactionContextManager
+from f5.bigip.contexts import TransactionSubmitException
+
+
+class TestTransaction(object):
+    def test_create_empty(self, mgmt_root):
+        tx = mgmt_root.tm.transactions.transaction
+        with pytest.raises(TransactionSubmitException) as ex:
+            # Do not remove this "NOQA". It is suppressing a flake8
+            # exception that would be raised about "not using the
+            # 'api' variable".
+            #
+            # This is, however, exactly what we want to do in this
+            # test. By not using the 'api' variable, I am forcing
+            # this context to raise the expected exception, and testing
+            # that that exception is raised.
+            with TransactionContextManager(tx) as api:  # NOQA
+                pass
+        assert "there is no command to commit in the transaction" \
+               in str(ex.value.message)


### PR DESCRIPTION
@zancas @pjbreaux 

Issues:
Fixes #603

Problem:
The transaction classes became non-functional when the create() methods
switched to returning an object instead of modifying the object in place.
Due to a lack of functional testing for transactions, this caused them
to break without any knowledge to us.

Analysis:
This change fixes the transaction classes to handle returned objects instead
of objects that are modified in place. Additionally, it creates a functional
test to prevent this issue from creeping up in the future.

Tests:
tests/functional/tm/transaction/test_transaction.py
