### PR TITLE
Revert update to use `put`

### DIFF
--- a/f5/bigip/resource.py
+++ b/f5/bigip/resource.py
@@ -474,7 +474,7 @@ class ResourceBase(PathElement, ToDictMixin):
 
         data_dict.update(kwargs)
 
-        response = session.patch(update_uri, json=data_dict, **requests_params)
+        response = session.put(update_uri, json=data_dict, **requests_params)
         self._meta_data = temp_meta
         self._local_update(response.json())
 
@@ -492,7 +492,7 @@ class ResourceBase(PathElement, ToDictMixin):
 
         :param kwargs: keys and associated values to alter on the device
         NOTE: If kwargs has a 'requests_params' key the corresponding dict will
-        be passed to the underlying requests.session.patch method where it will
+        be passed to the underlying requests.session.put method where it will
         be handled according to that API. THIS IS HOW TO PASS QUERY-ARGS!
 
         """

--- a/f5/bigip/test/big_ip_mock.py
+++ b/f5/bigip/test/big_ip_mock.py
@@ -76,7 +76,7 @@ class BigIPMock(object):
         icr_session = mock.Mock()
         icr_session.delete = mock_response
         icr_session.get = mock_response
-        icr_session.patch = mock_response
+        icr_session.put = mock_response
         icr_session.post = mock_response
         icr_session.put = mock_response
 

--- a/f5/bigip/test/test_resource.py
+++ b/f5/bigip/test/test_resource.py
@@ -56,7 +56,7 @@ def fake_rsrc():
     r._meta_data['allowed_lazy_attributes'] = []
     r._meta_data['uri'] = 'URI'
     r._meta_data['read_only_attributes'] = [u"READONLY"]
-    attrs = {'patch.return_value': MockResponse({u"generation": 0}),
+    attrs = {'put.return_value': MockResponse({u"generation": 0}),
              'get.return_value': MockResponse({u"generation": 0})}
     mock_session = mock.MagicMock(**attrs)
     r._meta_data['bigip']._meta_data = {'icr_session': mock_session}
@@ -237,7 +237,7 @@ class TestResource_update(object):
         r._meta_data['uri'] = 'URI'
         r._meta_data['bigip']._meta_data['icr_session'].get.return_value =\
             MockResponse({u"generation": 0})
-        r._meta_data['bigip']._meta_data['icr_session'].patch.return_value =\
+        r._meta_data['bigip']._meta_data['icr_session'].put.return_value =\
             MockResponse({u"generation": 0})
         r.generation = 0
         pre_meta = r._meta_data.copy()
@@ -248,7 +248,7 @@ class TestResource_update(object):
         r = Resource(mock.MagicMock())
         r._meta_data['allowed_lazy_attributes'] = []
         r._meta_data['uri'] = 'URI'
-        attrs = {'patch.return_value': MockResponse({u"generation": 0}),
+        attrs = {'put.return_value': MockResponse({u"generation": 0}),
                  'get.return_value': MockResponse({u"generation": 0})}
         mock_session = mock.MagicMock(**attrs)
         r._meta_data['bigip']._meta_data = {'icr_session': mock_session}
@@ -257,7 +257,7 @@ class TestResource_update(object):
         assert 'contained' in r.__dict__
         r.update(a=u"b")
         submitted = r._meta_data['bigip']. \
-            _meta_data['icr_session'].patch.call_args[1]['json']
+            _meta_data['icr_session'].put.call_args[1]['json']
 
         assert 'contained' not in submitted
 
@@ -266,7 +266,7 @@ class TestResource_update(object):
         r._meta_data['allowed_lazy_attributes'] = []
         r._meta_data['uri'] = 'URI'
         r._meta_data['read_only_attributes'] = [u"READONLY"]
-        attrs = {'patch.return_value': MockResponse({u"generation": 0}),
+        attrs = {'put.return_value': MockResponse({u"generation": 0}),
                  'get.return_value': MockResponse({u"generation": 0})}
         mock_session = mock.MagicMock(**attrs)
         r._meta_data['bigip']._meta_data = {'icr_session': mock_session}
@@ -275,26 +275,26 @@ class TestResource_update(object):
         assert 'READONLY' in r.__dict__
         r.update(a=u"b")
         submitted = r._meta_data['bigip'].\
-            _meta_data['icr_session'].patch.call_args[1]['json']
+            _meta_data['icr_session'].put.call_args[1]['json']
         assert 'READONLY' not in submitted
 
     def test_reduce_boolean_removes_enabled(self, fake_rsrc):
         fake_rsrc.update(enabled=False)
-        pos, kwargs = fake_rsrc._meta_data['bigip']._meta_data['icr_session'].patch.\
+        pos, kwargs = fake_rsrc._meta_data['bigip']._meta_data['icr_session'].put.\
             call_args
         assert kwargs['json']['disabled'] is True
         assert 'enabled' not in kwargs['json']
 
     def test_reduce_boolean_removes_disabled(self, fake_rsrc):
         fake_rsrc.update(disabled=False)
-        pos, kwargs = fake_rsrc._meta_data['bigip']._meta_data['icr_session'].patch.\
+        pos, kwargs = fake_rsrc._meta_data['bigip']._meta_data['icr_session'].put.\
             call_args
         assert kwargs['json']['enabled'] is True
         assert 'disabled' not in kwargs['json']
 
     def test_reduce_boolean_removes_nothing(self, fake_rsrc):
         fake_rsrc.update(partition='Common', name='test_create', enabled=True)
-        pos, kwargs = fake_rsrc._meta_data['bigip']._meta_data['icr_session'].patch.\
+        pos, kwargs = fake_rsrc._meta_data['bigip']._meta_data['icr_session'].put.\
             call_args
         assert kwargs['json']['enabled'] is True
         assert 'disabled' not in kwargs['json']
@@ -406,7 +406,7 @@ class TestResource_load(object):
         r._meta_data['allowed_lazy_attributes'] = []
         r._meta_data['uri'] = 'URI'
         r._meta_data['icontrol_version'] = '11.6.0'
-        attrs = {'patch.return_value': MockResponse({u"generation": 0}),
+        attrs = {'put.return_value': MockResponse({u"generation": 0}),
                  'get.return_value': MockResponse({u"generation": 0})}
         mock_session = mock.MagicMock(**attrs)
         r._meta_data['bigip']._meta_data = {'icr_session': mock_session}
@@ -415,14 +415,14 @@ class TestResource_load(object):
         assert 'contained' in r.__dict__
         r.update(a=u"b")
         submitted = r._meta_data['bigip']. \
-            _meta_data['icr_session'].patch.call_args[1]['params']
+            _meta_data['icr_session'].put.call_args[1]['params']
         assert submitted['ver'] == '11.6.0'
 
     def test_icontrol_version_default(self):
         r = Resource(mock.MagicMock())
         r._meta_data['allowed_lazy_attributes'] = []
         r._meta_data['uri'] = 'URI'
-        attrs = {'patch.return_value': MockResponse({u"generation": 0}),
+        attrs = {'put.return_value': MockResponse({u"generation": 0}),
                  'get.return_value': MockResponse({u"generation": 0})}
         mock_session = mock.MagicMock(**attrs)
         r._meta_data['bigip']._meta_data = {'icr_session': mock_session}
@@ -431,7 +431,7 @@ class TestResource_load(object):
         assert 'contained' in r.__dict__
         r.update(a=u"b")
         submitted = r._meta_data['bigip']. \
-            _meta_data['icr_session'].patch.call_args
+            _meta_data['icr_session'].put.call_args
         assert 'params' not in submitted
 
     def test_success(self):

--- a/f5/bigip/tm/sys/test/test_sys_application.py
+++ b/f5/bigip/tm/sys/test/test_sys_application.py
@@ -112,13 +112,13 @@ def MakeFakeContainer(FakeService, fake_bigip_data):
             self._meta_data.update(meta_data_defaults)
     mock_session = mock.MagicMock(name='mock_session')
     mock_get_response = mock.MagicMock(name='mock_get_response')
-    mock_patch_response = mock.MagicMock(name='mock_patch_response')
+    mock_put_response = mock.MagicMock(name='mock_put_response')
     mock_get_response.json.return_value = fake_bigip_data.copy()
-    mock_patch_response.json.return_value = SUCCESSFUL_CREATE.copy()
-    # Mock the get and patch when the container calls icr_session.get/patch
+    mock_put_response.json.return_value = SUCCESSFUL_CREATE.copy()
+    # Mock the get and put when the container calls icr_session.get/patch
     mock_session.get.return_value = mock_get_response
-    mock_session.patch.return_value = mock_patch_response
-    mock_session.post.return_value = mock_patch_response
+    mock_session.put.return_value = mock_put_response
+    mock_session.post.return_value = mock_put_response
     FakeService._meta_data = {
         'hostname': 'testhost',
         'icr_session': mock_session,


### PR DESCRIPTION
@pjbreaux 

This is a very conservative reversion to the former mode of operation for `update`.
Issues:
Fixes #608

Problem: We've decided to implement `modify` as the API level function that
supports HTTP PATCH, update will revert to its former role as the wrapper
of HTTP PUT.

Tests: f5/bigip/test/big_ip_mock.py f5/bigip/test/test_resource.py f5/bigip/tm/sys/test/test_sys_application.py
