### PR TITLE
Completes test coverage of bigip __init__ class

### DIFF
--- a/f5/bigip/test/test___init__.py
+++ b/f5/bigip/test/test___init__.py
@@ -55,6 +55,16 @@ def test___get__attr(FakeBigIP):
     assert FakeBigIP.hostname == 'FakeHostName'
 
 
+def test_invalid_args():
+    with pytest.raises(TypeError) as err:
+        BigIP('FakeHostName', 'admin', 'admin', badArgs='foobar')
+    assert 'Unexpected **kwargs' in err.value.message
+
+
+def test_icontrol_version(FakeBigIPWithPort):
+    assert hasattr(FakeBigIPWithPort, 'icontrol_version')
+
+
 def test_non_default_port_number(FakeBigIPWithPort):
     uri = urlparse.urlsplit(FakeBigIPWithPort._meta_data['uri'])
     assert uri.port == 10443

--- a/test/functional/test/test__init__.py
+++ b/test/functional/test/test__init__.py
@@ -1,0 +1,29 @@
+# Copyright 2016 F5 Networks Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pytest
+
+from f5.bigip import ManagementRoot
+
+
+def test_invalid_args(opt_bigip, opt_username, opt_password, opt_port):
+    with pytest.raises(TypeError) as err:
+        ManagementRoot(opt_bigip, opt_username, opt_password, port=opt_port,
+                       badArgs='foobar')
+    assert 'Unexpected **kwargs' in err.value.message
+
+
+def test_icontrol_version(opt_bigip, opt_username, opt_password, opt_port):
+    m = ManagementRoot(opt_bigip, opt_username, opt_password, port=opt_port)
+    assert hasattr(m, 'icontrol_version')


### PR DESCRIPTION
Issues:
Fixes #629

Problem:
Test coverage was not complete for this class in Coveralls

Analysis:
This change completes functional and unit tests for this class

Tests:
Unit and functional
