### PR TITLE
Fixes coverage tests for util exceptions and setup.py

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -8,3 +8,4 @@ omit =
     devtools/*
     # omit the conftest?
     conftest.py
+    setup.py

--- a/f5/utils/test/test_util_exceptions.py
+++ b/f5/utils/test/test_util_exceptions.py
@@ -1,0 +1,24 @@
+# Copyright 2016 F5 Networks Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+from f5.utils.util_exceptions import UtilError
+
+import pytest
+
+
+def test_util_error():
+    with pytest.raises(UtilError) as err:
+        raise UtilError
+    assert isinstance(err.value, UtilError)

--- a/test/functional/utils/test_util_exceptions.py
+++ b/test/functional/utils/test_util_exceptions.py
@@ -1,0 +1,24 @@
+# Copyright 2016 F5 Networks Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+from f5.utils.util_exceptions import UtilError
+
+import pytest
+
+
+def test_util_error():
+    with pytest.raises(UtilError) as err:
+        raise UtilError
+    assert isinstance(err.value, UtilError)


### PR DESCRIPTION
Issues:
Fixes #631

Problem:
setup.py is being included in the functional tests, which is not
needed. Additionally, the functional tests for util exceptions
is low

Analysis:
this patch removes the setup.py from coverage and adds tests for
the util exceptions

Tests:
unit and functional
