### PR TITLE
Fix broken backwards compat in regards to tmos_version

### DIFF
--- a/f5/bigip/__init__.py
+++ b/f5/bigip/__init__.py
@@ -71,6 +71,10 @@ class ManagementRoot(PathElement):
     def icontrol_version(self):
         return self._meta_data['icontrol_version']
 
+    @property
+    def tmos_version(self):
+        return self._meta_data['tmos_version']
+
     def _get_tmos_version(self):
         connect = self._meta_data['bigip']._meta_data['icr_session']
         base_uri = self._meta_data['uri'] + 'tm/sys/'

--- a/f5/bigip/mixins.py
+++ b/f5/bigip/mixins.py
@@ -114,7 +114,7 @@ class LazyAttributeMixin(object):
                 return attribute
 
     def _check_supported_versions(self, container, attribute):
-        tmos_v = container._meta_data['bigip']._meta_data['tmos_version']
+        tmos_v = container._meta_data['bigip'].tmos_version
         minimum = attribute._meta_data['minimum_version']
         if LooseVersion(tmos_v) < LooseVersion(minimum):
             error = "There was an attempt to access resource: \n{}\n which " \

--- a/f5/bigip/test/test_resource.py
+++ b/f5/bigip/test/test_resource.py
@@ -797,6 +797,8 @@ class TestStats(object):
                      })
                   ]}
         mock_session = mock.MagicMock(**attrs)
+        ver_mock = mock.PropertyMock(return_value='11.5.0')
+        type(r._meta_data['bigip']).tmos_version = ver_mock
         r._meta_data['bigip']._meta_data =\
             {'icr_session': mock_session,
              'hostname': 'TESTDOMAINNAME',

--- a/f5/bigip/tm/sys/test/test_db.py
+++ b/f5/bigip/tm/sys/test/test_db.py
@@ -23,7 +23,7 @@ import pytest
 def fake_dbs():
     fake_sys = mock.MagicMock()
     dbs = Dbs(fake_sys)
-    dbs._meta_data['bigip']._meta_data = {'tmos_version': '11.6.0'}
+    dbs._meta_data['bigip'].tmos_version = '11.6.0'
     return dbs
 
 

--- a/f5/bigip/tm/sys/test/test_folder.py
+++ b/f5/bigip/tm/sys/test/test_folder.py
@@ -24,7 +24,7 @@ from f5.bigip.tm.sys.folder import Folders
 def FakeFolders():
     fake_sys = mock.MagicMock()
     folders = Folders(fake_sys)
-    folders._meta_data['bigip']._meta_data = {'tmos_version': '11.6.0'}
+    folders._meta_data['bigip'].tmos_version = '11.6.0'
     return folders
 
 

--- a/f5/bigip/tm/sys/test/test_performance.py
+++ b/f5/bigip/tm/sys/test/test_performance.py
@@ -25,7 +25,7 @@ from f5.bigip.tm.sys.performance import Performances
 def FakePerformance():
     fake_sys = mock.MagicMock()
     performances = Performances(fake_sys)
-    performances._meta_data['bigip']._meta_data = {'tmos_version': '11.6.0'}
+    performances._meta_data['bigip'].tmos_version = '11.6.0'
     return performances
 
 

--- a/requirements.test.txt
+++ b/requirements.test.txt
@@ -9,3 +9,4 @@ pytest==2.9.1
 pytest-cov>=2.2.1
 git+https://github.com/F5Networks/pytest-symbols.git
 python-coveralls
+pyopenssl

--- a/test/functional/test/test__init__.py
+++ b/test/functional/test/test__init__.py
@@ -27,3 +27,10 @@ def test_invalid_args(opt_bigip, opt_username, opt_password, opt_port):
 def test_icontrol_version(opt_bigip, opt_username, opt_password, opt_port):
     m = ManagementRoot(opt_bigip, opt_username, opt_password, port=opt_port)
     assert hasattr(m, 'icontrol_version')
+
+
+def test_tmos_version(mgmt_root):
+    assert mgmt_root.tmos_version == \
+        mgmt_root._meta_data['bigip']._meta_data['tmos_version']
+    assert mgmt_root.tmos_version is not None
+    assert mgmt_root._meta_data['bigip']._meta_data['tmos_version'] != ''


### PR DESCRIPTION
@jlongstaf  and @mattgreene 

Issues:
Fixes #638

Problem:
The tmos_version attribute was changed from being a property to being a
key in the _meta_data dictionary on the bigip container. This change
broken backwards compat without use realizing immediately, and we need
to support both methods until we're ready to bump the release to 2.0.0.

Analysis:
Added the @property back to the f5/bigip/**init**.py for tmos_version.
Both ways of accessing tmos_version are now supported

Tests:
Added a test to ensure we can access the tmos_version both ways
