### PR TITLE
Completes coverage tests for sys/config

### DIFF
--- a/f5/bigip/tm/sys/config.py
+++ b/f5/bigip/tm/sys/config.py
@@ -27,6 +27,7 @@ REST Kind
 """
 from f5.bigip.mixins import CommandExecutionMixin
 from f5.bigip.resource import UnnamedResource
+from f5.sdk_exception import UnsupportedMethod
 
 
 class Config(UnnamedResource,
@@ -43,6 +44,6 @@ class Config(UnnamedResource,
 
         :raises: UnsupportedOperation
         '''
-        raise self.UnsupportedMethod(
+        raise UnsupportedMethod(
             "%s does not support the update method" % self.__class__.__name__
         )

--- a/test/functional/tm/sys/test_config.py
+++ b/test/functional/tm/sys/test_config.py
@@ -13,8 +13,17 @@
 # limitations under the License.
 #
 
+from f5.sdk_exception import UnsupportedMethod
+
+import pytest
+
 
 class TestConfig(object):
     def test_save(self, bigip):
         c = bigip.sys.config
         c.exec_cmd('save')
+
+    def test_update(selfself, mgmt_root):
+        with pytest.raises(UnsupportedMethod) as ex:
+            mgmt_root.tm.sys.config.update(foo="bar")
+        assert 'does not support the update method' in ex.value.message


### PR DESCRIPTION
Issues:
Fixes #645

Problem:
The coverage tests for sys/config were not complete

Analysis:
This patch completes the coverage tests for this module

Tests:
functional
