### PR TITLE
Adds coverage tests for test_failover and test_sys_application

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -15,6 +15,7 @@
 
 from f5.bigip import BigIP
 from f5.bigip import ManagementRoot
+from f5.bigip.resource import UnsupportedOperation
 from f5.utils.testutils.registrytools import register_device
 from icontrol.session import iControlRESTSession
 import logging
@@ -217,7 +218,10 @@ def setup_device_snapshot(request, mgmt_root):
         after_snapshot = register_device(mgmt_root)
         diff = set(after_snapshot) - set(before_snapshot)
         for item in diff:
-            after_snapshot[item].delete()
+            try:
+                after_snapshot[item].delete()
+            except UnsupportedOperation:
+                pass
     request.addfinalizer(teardown)
     return before_snapshot
 

--- a/test/functional/tm/sys/test_failover.py
+++ b/test/functional/tm/sys/test_failover.py
@@ -76,6 +76,13 @@ class TestFailover(object):
         pp(f.raw)
         assert 'Failover active' in f.apiRawValues['apiAnonymous']
 
+    def test_toggle_bad_kwargs_standby(self, mgmt_root):
+        with pytest.raises(TypeError) as ex:
+            f = mgmt_root.tm.sys.failover
+            f.toggle_standby(trafficgroup="traffic-group-1",
+                             state=None, foo="bar")
+        assert "Unexpected **kwargs" in ex.value.message
+
     def test_attribute_values(self, bigip):
         fl = bigip.sys.failover
         # Testing both conditions

--- a/test/functional/tm/sys/test_sys_application.py
+++ b/test/functional/tm/sys/test_sys_application.py
@@ -94,7 +94,7 @@ def setup_service_test(request, bigip, name, partition, template_name, tgroup):
     return service_s, test_service
 
 
-def curdle_check(collection, resource, resource_name, **kwargs):
+def curdle_check2(collection, resource, resource_name, **kwargs):
     name = kwargs['name']
     assert resource.name == name
     second_resource = getattr(collection, resource_name).load(**kwargs)
@@ -110,6 +110,10 @@ def curdle_check(collection, resource, resource_name, **kwargs):
     second_resource.refresh()
     assert second_resource.generation == resource.generation
 
+
+def curdle_check(collection, resource, resource_name, **kwargs):
+    curdle_check2(collection, resource, resource_name, **kwargs)
+
     assert getattr(collection, resource_name).exists(**kwargs) is True
 
 
@@ -118,6 +122,48 @@ class TestApplication(object):
         app_org_s = setup_application_test(request, bigip)
         app_org_full_s = app_org_s.get_collection()
         assert len(app_org_full_s) == 4
+
+    def test_disallowed_params(self, request, bigip):
+        """Tests that a disallowed parameter is removed
+
+        This check does not test for failure. Instead, the code in the
+        associated class will pop the disallowed parameter off of the
+        kwargs.
+
+        Then, the kwargs will be sent through the check_load_parameters,
+        which checks for "name" and "partition".
+
+        Finally, the code will issue a GET request to BIG-IP. If this
+        method fails, then our disallowed parameter was not removed
+        properly.
+
+        :param mgmt_root:
+        :return:
+        """
+        serv_s, test_serv = setup_service_test(
+            request,
+            bigip,
+            'test_service2',
+            'Common',
+            'test_template2',
+            '/Common/traffic-group-local-only'
+        )
+        # Make sure the uri is what we expect
+        uri = ''.join([
+            bigip._meta_data['uri'],
+            'sys/application/service/~Common',
+            '~test_service2.app~test_service2'])
+        assert uri in test_serv._meta_data['uri']
+
+        curdle_check2(
+            serv_s,
+            test_serv,
+            'service',
+            name='test_service2',
+            partition='Common',
+            template="bar",
+            trafficGroup="foo"
+        )
 
 
 class TestTemplateCollection(object):


### PR DESCRIPTION
Issues:
Fixes #648

Problem:
coverage tests for sys/test_failover and sys/test_sys_application
were not complete

Analysis:
This patch completes those tests

Tests:
functional
