### PR TITLE
Make transaction IDs strings to work with python requests 2.11

### DIFF
--- a/f5/bigip/contexts.py
+++ b/f5/bigip/contexts.py
@@ -50,7 +50,7 @@ class TransactionContextManager(object):
         self.transaction = self.transaction.create()
 
         self.icr.session.headers.update({
-            'X-F5-REST-Coordination-Id': self.transaction.transId
+            'X-F5-REST-Coordination-Id': str(self.transaction.transId)
         })
         return self.bigip
 


### PR DESCRIPTION
Issues:
Fixes #641

Problem:
requests 2.11 changed compatibility to disallow integers inside of headers.
The result was that the transaction functionality in the SDK broke because
transaction IDs are integers and sent in the headers of the request
(X-F5-REST-Coordination-Id).

Analysis:
This patch casts the integers to strings to correct the problem.

Tests:
none
