### PR TITLE
Fixes some 11.6.1 test issues

### DIFF
--- a/test/functional/tm/sys/test_snmp.py
+++ b/test/functional/tm/sys/test_snmp.py
@@ -338,7 +338,17 @@ class TestCommunity(object):
         )
 
         assert comm1.communityName == 'commtest1'
-        assert comm1.name == 'commtest1'
+
+        # In 11.6.1 and later they started prepending the partition name
+        # to the name attribute here. So we handle this case for our tests.
+        #
+        # According to Narendra, they should always have behaved this way
+        # so this must have been a bugfix
+        if pytest.config.getoption('--release') < LooseVersion('11.6.1'):
+            assert comm1.name == 'commtest1'
+        else:
+            assert comm1.name == '/Common/commtest1'
+
         assert comm1.access == 'ro'
         assert comm1.ipv6 == 'disabled'
 


### PR DESCRIPTION
Issues:
Fixes #658

Problem:
In 11.6.1, some of the resource endpoints gained a partition prefix
and lost a partition attribute. Therefore, those tests would work in
versions prior to 11.6.1, but fail afterwards

Analysis:
The names in version 11.6.1 gained a partition prefix and lost a partition
attribute. The tests need to take this into consideration

Tests:
exiting
