### PR TITLE
VCMP endpoints need to be added

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -46,6 +46,8 @@ def pytest_addoption(parser):
     parser.addoption("--release", action="store",
                      help="TMOS version, in dotted format, eg. 12.0.0",
                      default='11.6.0')
+    parser.addoption("--vcmp-host", action="store",
+                     help="IP address of VCMP enabled host.")
 
 
 @pytest.fixture
@@ -123,6 +125,11 @@ def opt_port(request):
 
 
 @pytest.fixture(scope='session')
+def opt_vcmp_host(request):
+    return request.config.getoption("--vcmp-host")
+
+
+@pytest.fixture(scope='session')
 def bigip(opt_bigip, opt_username, opt_password, opt_port, scope="module"):
     '''bigip fixture'''
     b = BigIP(opt_bigip, opt_username, opt_password, port=opt_port)
@@ -133,6 +140,14 @@ def bigip(opt_bigip, opt_username, opt_password, opt_port, scope="module"):
 def mgmt_root(opt_bigip, opt_username, opt_password, opt_port, scope="module"):
     '''bigip fixture'''
     m = ManagementRoot(opt_bigip, opt_username, opt_password, port=opt_port)
+    return m
+
+
+@pytest.fixture(scope='module')
+def vcmp_host(opt_vcmp_host, opt_username, opt_password, opt_port):
+    '''vcmp fixture'''
+    m = ManagementRoot(
+        opt_vcmp_host, opt_username, opt_password, port=opt_port)
     return m
 
 

--- a/f5/bigip/__init__.py
+++ b/f5/bigip/__init__.py
@@ -35,7 +35,6 @@ from f5.bigip.tm.shared import Shared as TmShared
 from f5.bigip.tm.sys import Sys
 from f5.bigip.tm import Tm
 from f5.bigip.tm.transaction import Transactions
-from f5.bigip.tm.vcmp import Vcmp
 
 
 class ManagementRoot(PathElement):
@@ -90,10 +89,15 @@ class ManagementRoot(PathElement):
 class BigIP(ManagementRoot):
     """A shim class used to access the default config resources in 'mgmt/tm.'
 
+    PLEASE DO NOT ADD ATTRIBUTES TO THIS CLASS.
+
+    This class is depcrated in favor of MangementRoot above. Do not add any
+    more objects to the allowed_lazy_attributes list here!
+
     This class is solely implemented for backwards compatibility.
     """
     def __init__(self, hostname, username, password, **kwargs):
         super(BigIP, self).__init__(hostname, username, password, **kwargs)
         self._meta_data['uri'] = self._meta_data['uri'] + 'tm/'
         self._meta_data['allowed_lazy_attributes'] =\
-            [TmAuth, TmCm, Ltm, Gtm, Net, TmShared, Sys, Transactions, Vcmp]
+            [TmAuth, TmCm, Ltm, Gtm, Net, TmShared, Sys, Transactions]

--- a/f5/bigip/__init__.py
+++ b/f5/bigip/__init__.py
@@ -35,6 +35,7 @@ from f5.bigip.tm.shared import Shared as TmShared
 from f5.bigip.tm.sys import Sys
 from f5.bigip.tm import Tm
 from f5.bigip.tm.transaction import Transactions
+from f5.bigip.tm.vcmp import Vcmp
 
 
 class ManagementRoot(PathElement):
@@ -95,4 +96,4 @@ class BigIP(ManagementRoot):
         super(BigIP, self).__init__(hostname, username, password, **kwargs)
         self._meta_data['uri'] = self._meta_data['uri'] + 'tm/'
         self._meta_data['allowed_lazy_attributes'] =\
-            [TmAuth, TmCm, Ltm, Gtm, Net, TmShared, Sys, Transactions]
+            [TmAuth, TmCm, Ltm, Gtm, Net, TmShared, Sys, Transactions, Vcmp]

--- a/f5/bigip/tm/__init__.py
+++ b/f5/bigip/tm/__init__.py
@@ -26,6 +26,7 @@ from f5.bigip.tm.net import Net
 from f5.bigip.tm.shared import Shared
 from f5.bigip.tm.sys import Sys
 from f5.bigip.tm.transaction import Transactions
+from f5.bigip.tm.vcmp import Vcmp
 
 
 class Tm(OrganizingCollection):
@@ -40,5 +41,6 @@ class Tm(OrganizingCollection):
             Net,
             Shared,
             Sys,
-            Transactions
+            Transactions,
+            Vcmp
         ]

--- a/f5/bigip/tm/vcmp/__init__.py
+++ b/f5/bigip/tm/vcmp/__init__.py
@@ -1,0 +1,37 @@
+# coding=utf-8
+#
+# Copyright 2016 F5 Networks Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""BIG-IP® VCMP (vcmp) module
+
+REST URI
+    ``http://localhost/mgmt/tm/vcmp/``
+
+GUI Path
+    ``vCMP``
+
+REST Kind
+    ``tm:vcmp:*``
+"""
+
+from f5.bigip.resource import OrganizingCollection
+from f5.bigip.tm.vcmp.guest import Guests
+
+
+class Vcmp(OrganizingCollection):
+    def __init__(self, tm):
+        super(Vcmp, self).__init__(tm)
+        self._meta_data['allowed_lazy_attributes'] = [Guests]

--- a/f5/bigip/tm/vcmp/guest.py
+++ b/f5/bigip/tm/vcmp/guest.py
@@ -1,0 +1,50 @@
+# coding=utf-8
+#
+# Copyright 2016 F5 Networks Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""BIG-IP® Guest (vcmp) module
+
+REST URI
+    ``http://localhost/mgmt/tm/vcmp/guest/``
+
+GUI Path
+    ``Guest List``
+
+REST Kind
+    ``tm:vcmp:guest:*``
+"""
+
+from f5.bigip.resource import Collection
+from f5.bigip.resource import Resource
+
+
+class Guests(Collection):
+    """BIG-IP® Guests collection."""
+    def __init__(self, vcmp):
+        super(Guests, self).__init__(vcmp)
+        self._meta_data['allowed_lazy_attributes'] = [Guest]
+        self._meta_data['required_json_kind'] =\
+            'tm:vcmp:guest:guestcollectionstate'
+        self._meta_data['attribute_registry'] =\
+            {'tm:vcmp:guest:gueststate': Guest}
+
+
+class Guest(Resource):
+    """BIG-IP® Guest resource."""
+    def __init__(self, guests):
+        super(Guest, self).__init__(guests)
+        self._meta_data['required_json_kind'] =\
+            'tm:vcmp:guest:gueststate'

--- a/f5/bigip/tm/vcmp/guest.py
+++ b/f5/bigip/tm/vcmp/guest.py
@@ -29,6 +29,17 @@ REST Kind
 
 from f5.bigip.resource import Collection
 from f5.bigip.resource import Resource
+from f5.sdk_exception import F5SDKError
+
+
+class DisallowedCreationParameter(F5SDKError):
+    """Exception when partition is passed to create for guest resource."""
+    pass
+
+
+class DisallowedReadParameter(F5SDKError):
+    """Exception when partition is passed to load for guest resource."""
+    pass
 
 
 class Guests(Collection):
@@ -48,3 +59,33 @@ class Guest(Resource):
         super(Guest, self).__init__(guests)
         self._meta_data['required_json_kind'] =\
             'tm:vcmp:guest:gueststate'
+
+    def _check_load_parameters(self, **kwargs):
+        """Override method for one in resource.py to check partition
+
+        The partition cannot be included as a parameter to load a guest.
+        Raise an exception if a consumer gives the partition.
+
+        :raises: DisallowedReadParameter
+        """
+
+        if 'partition' in kwargs:
+            msg = "'partition' is not allowed as a load parameter. Vcmp " \
+                "guests are accessed by name."
+            raise DisallowedReadParameter(msg)
+        super(Guest, self)._check_load_parameters(**kwargs)
+
+    def _check_create_parameters(self, **kwargs):
+        """Override method for one in resource.py to check partition
+
+        The partition cannot be included as a parameter to create a guest.
+        Raise an exception if a consumer gives the partition.
+
+        :raises: DisallowedCreationParameter
+        """
+
+        if 'partition' in kwargs:
+            msg = "'partition' is not allowed as a create parameter. Vcmp " \
+                "guests are created with the 'name' at least."
+            raise DisallowedCreationParameter(msg)
+        super(Guest, self)._check_create_parameters(**kwargs)

--- a/f5/bigip/tm/vcmp/guest.py
+++ b/f5/bigip/tm/vcmp/guest.py
@@ -64,7 +64,7 @@ class Guest(Resource):
         """Override method for one in resource.py to check partition
 
         The partition cannot be included as a parameter to load a guest.
-        Raise an exception if a consumer gives the partition.
+        Raise an exception if a consumer gives the partition parameter.
 
         :raises: DisallowedReadParameter
         """
@@ -79,7 +79,7 @@ class Guest(Resource):
         """Override method for one in resource.py to check partition
 
         The partition cannot be included as a parameter to create a guest.
-        Raise an exception if a consumer gives the partition.
+        Raise an exception if a consumer gives the partition parameter.
 
         :raises: DisallowedCreationParameter
         """

--- a/f5/bigip/tm/vcmp/test/test_guest.py
+++ b/f5/bigip/tm/vcmp/test/test_guest.py
@@ -17,6 +17,8 @@ import mock
 import pytest
 
 from f5.bigip.resource import MissingRequiredCreationParameter
+from f5.bigip.tm.vcmp.guest import DisallowedCreationParameter
+from f5.bigip.tm.vcmp.guest import DisallowedReadParameter
 from f5.bigip.tm.vcmp.guest import Guest
 
 
@@ -30,3 +32,17 @@ def test_create_no_args(FakeGuest):
     with pytest.raises(MissingRequiredCreationParameter) as ex:
         FakeGuest.create()
     assert "Missing required params: ['name']" in ex.value.message
+
+
+def test_create_with_parition(FakeGuest):
+    with pytest.raises(DisallowedCreationParameter) as ex:
+        FakeGuest.create(name='test', partition='Common')
+    assert "'partition' is not allowed as a create parameter" in \
+        ex.value.message
+
+
+def test_load_with_partition(FakeGuest):
+    with pytest.raises(DisallowedReadParameter) as ex:
+        FakeGuest.load(name='test', partition='Common')
+    assert "'partition' is not allowed as a load parameter" in \
+        ex.value.message

--- a/f5/bigip/tm/vcmp/test/test_guest.py
+++ b/f5/bigip/tm/vcmp/test/test_guest.py
@@ -1,0 +1,32 @@
+# Copyright 2016 F5 Networks Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import mock
+import pytest
+
+from f5.bigip.resource import MissingRequiredCreationParameter
+from f5.bigip.tm.vcmp.guest import Guest
+
+
+@pytest.fixture
+def FakeGuest():
+    fake_guests = mock.MagicMock()
+    return Guest(fake_guests)
+
+
+def test_create_no_args(FakeGuest):
+    with pytest.raises(MissingRequiredCreationParameter) as ex:
+        FakeGuest.create()
+    assert "Missing required params: ['name']" in ex.value.message

--- a/test/functional/tm/vcmp/test_guest.py
+++ b/test/functional/tm/vcmp/test_guest.py
@@ -1,0 +1,105 @@
+# Copyright 2016 F5 Networks Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+from f5.bigip.resource import MissingRequiredCreationParameter
+from f5.bigip.resource import MissingRequiredReadParameter
+from icontrol.session import iControlUnexpectedHTTPError
+
+import copy
+import pytest
+
+
+try:
+    vcmp_host = pytest.config.getoption('--vcmp-host')
+except Exception as ex:
+    vcmp_host = None
+
+
+@pytest.fixture
+def setup_guest_test(request, vcmp_host):
+    def teardown():
+        guest.delete()
+    request.addfinalizer(teardown)
+    guests = vcmp_host.tm.vcmp.guests
+    guest = guests.guest.create(name='test')
+    return guests, guest
+
+
+@pytest.mark.skipif(vcmp_host is None,
+                    reason='Provide --vcmp-host to run vcmp tests.')
+class TestGuest(object):
+    def test_guests_get_collection(self, setup_guest_test):
+        guests, guest1 = setup_guest_test
+        gc = list(guests.get_collection())
+        assert len(gc) > 1
+
+    def test_guest_create_refresh_update_delete_load_modify(
+            self, setup_guest_test
+    ):
+        guests, guest1 = setup_guest_test
+        assert guest1.name == 'test'
+        assert guest1.managementNetwork == 'bridged'
+        guest1.managementGw = '10.190.0.1'
+        guest1.update()
+        assert guest1.managementGw == '10.190.0.1'
+        old_sslmode = guest1.sslMode
+        guest1.sslMode = 'dedicated'
+        guest1.refresh()
+        assert guest1.sslMode == old_sslmode
+        guest2 = guests.guest.load(name='test')
+        assert guest1.selfLink == guest2.selfLink
+        guest2.modify(sslMode='dedicated')
+        guest1.refresh()
+        assert guest2.sslMode == guest1.sslMode
+
+    def test_guest_modify(self, setup_guest_test):
+        guests, guest1 = setup_guest_test
+        original_dict = copy.copy(guest1.__dict__)
+        gw = 'managementGw'
+        guest1.modify(managementGw='10.190.0.1')
+        for k, v in original_dict.items():
+            if k != gw:
+                original_dict[k] = guest1.__dict__[k]
+            elif k == gw:
+                guest1.__dict__[k] == '10.190.0.1'
+
+    def test_guest_no_creation_args(self, vcmp_host):
+        with pytest.raises(MissingRequiredCreationParameter) as ex:
+            vcmp_host.tm.vcmp.guests.guest.create()
+        assert 'name' in ex.value.message
+
+    def test_guest_bad_creation_args(self, vcmp_host):
+        with pytest.raises(iControlUnexpectedHTTPError) as ex:
+            vcmp_host.tm.vcmp.guests.guest.create(
+                name='test', partition='Common')
+        assert '(/Common/test) is invalid' in ex.value.message
+
+    def test_guest_no_load_args(self, vcmp_host):
+        with pytest.raises(MissingRequiredReadParameter) as ex:
+            vcmp_host.tm.vcmp.guests.guest.load()
+        assert 'name' in ex.value.message
+
+    def test_guest_bad_load_args(self, vcmp_host):
+        with pytest.raises(iControlUnexpectedHTTPError) as ex:
+            vcmp_host.tm.vcmp.guests.guest.load(
+                name='test', partition='test-bad-arg')
+        assert 'The requested VCMP (/test-bad-arg/test) was not found' in \
+            ex.value.message
+
+    def test_guest_bad_modify(self, setup_guest_test):
+        guests, guest1 = setup_guest_test
+        with pytest.raises(iControlUnexpectedHTTPError) as ex:
+            guest1.modify(generation=34)
+        assert 'one or more properties must be specified' in ex.value.message


### PR DESCRIPTION
changing this to @caphrim007 

Issues:
Fixes #666

Problem:
The VCMP endpoints should be added in the tm organizing collection. A
VCMP has a collection of guests. We should be able to retrieve the vlan
and management address for a particular guest as well.

Analysis:
Added the VCMP OrganizingCollection, the Guests Collection, and the
Guest Resource. Added a unit test and some functional tests. The
functional tests can only be run against a vcmp host. So I added a
pytest config option of --vcmp-host, which allows a user to provide an
IP address for a vcmp configured host. Only then will the functional
tests be run.

Tests:
All tests pass against the vcmp host in the Boulder lab
