### PR TITLE
Adding GTM wideips - Branched out of Servers PR, merge this after PR(#673)

### DIFF
--- a/f5/bigip/tm/gtm/__init__.py
+++ b/f5/bigip/tm/gtm/__init__.py
@@ -32,6 +32,7 @@ from f5.bigip.resource import OrganizingCollection
 from f5.bigip.tm.gtm.datacenter import Datacenters
 from f5.bigip.tm.gtm.rule import Rules
 from f5.bigip.tm.gtm.server import Servers
+from f5.bigip.tm.gtm.wideip import Wideips
 
 
 class Gtm(OrganizingCollection):
@@ -42,4 +43,5 @@ class Gtm(OrganizingCollection):
             Datacenters,
             Rules,
             Servers,
+            Wideips,
         ]

--- a/f5/bigip/tm/gtm/__init__.py
+++ b/f5/bigip/tm/gtm/__init__.py
@@ -31,6 +31,7 @@ REST Kind
 from f5.bigip.resource import OrganizingCollection
 from f5.bigip.tm.gtm.datacenter import Datacenters
 from f5.bigip.tm.gtm.rule import Rules
+from f5.bigip.tm.gtm.server import Servers
 
 
 class Gtm(OrganizingCollection):
@@ -39,5 +40,6 @@ class Gtm(OrganizingCollection):
         super(Gtm, self).__init__(tm)
         self._meta_data['allowed_lazy_attributes'] = [
             Datacenters,
-            Rules
+            Rules,
+            Servers,
         ]

--- a/f5/bigip/tm/gtm/server.py
+++ b/f5/bigip/tm/gtm/server.py
@@ -1,0 +1,75 @@
+# coding=utf-8
+#
+#  Copyright 2014-2016 F5 Networks Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""BIG-IP® Global Traffic Manager™ (GTM®) pool module.
+
+REST URI
+    ``http://localhost/mgmt/tm/gtm/server``
+
+GUI Path
+    ``DNS --> GSLB : Servers``
+
+REST Kind
+    ``tm:gtm:server:*``
+"""
+
+from f5.bigip.resource import Collection
+from f5.bigip.resource import Resource
+
+
+class Servers(Collection):
+    """BIG-IP® GTM server collection"""
+    def __init__(self, gtm):
+        super(Servers, self).__init__(gtm)
+        self._meta_data['allowed_lazy_attributes'] = [Server]
+        self._meta_data['attribute_registry'] = \
+            {'tm:gtm:server:serverstate': Server}
+
+
+class Server(Resource):
+    """BIG-IP® GTM server resource"""
+    def __init__(self, servers):
+        super(Server, self).__init__(servers)
+        self._meta_data['required_json_kind'] = 'tm:gtm:server:serverstate'
+        self._meta_data['required_creation_parameters'].update(
+            ('datacenter', 'addresses'))
+        self._meta_data['attribute_registry'] = {
+            'tm:gtm:server:virtual-servers:virtual-serverscollectionstate':
+                Virtual_Servers_s
+        }
+
+
+class Virtual_Servers_s(Collection):
+    """BIG-IP® GTM virtual server sub-collection"""
+    def __init__(self, server):
+        super(Virtual_Servers_s, self).__init__(server)
+        self._meta_data['allowed_lazy_attributes'] = [Virtual_Servers]
+        self._meta_data['required_json_kind'] = \
+            'tm:gtm:server:virtual-servers:virtual-serverscollectionstate'
+        self._meta_data['attribute_registry'] = {
+            'tm:gtm:server:virtual-servers:virtual-serversstate':
+                Virtual_Servers}
+
+
+class Virtual_Servers(Resource):
+    """BIG-IP® GTM virtual server resource"""
+    def __init__(self, virtual_servers_s):
+        super(Virtual_Servers, self).__init__(virtual_servers_s)
+        self._meta_data['required_creation_parameters'].update((
+            'destination',))
+        self._meta_data['required_json_kind'] = \
+            'tm:gtm:server:virtual-servers:virtual-serversstate'

--- a/f5/bigip/tm/gtm/test/test_server.py
+++ b/f5/bigip/tm/gtm/test/test_server.py
@@ -1,0 +1,70 @@
+# Copyright 2015 F5 Networks Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import mock
+import pytest
+
+from f5.bigip import ManagementRoot
+from f5.bigip.resource import MissingRequiredCreationParameter
+from f5.bigip.tm.gtm.server import Server
+from f5.bigip.tm.gtm.server import Virtual_Servers
+
+
+@pytest.fixture
+def FakeServer():
+    fake_servers = mock.MagicMock()
+    fake_server = Server(fake_servers)
+    return fake_server
+
+
+@pytest.fixture
+def FakeVS():
+    fake_server = mock.MagicMock()
+    fake_vs = Virtual_Servers(fake_server)
+    return fake_vs
+
+
+class TestCreate(object):
+    def test_create_two(self, fakeicontrolsession):
+        b = ManagementRoot('192.168.1.1', 'admin', 'admin')
+        s1 = b.tm.gtm.servers.server
+        s2 = b.tm.gtm.servers.server
+        assert s1 is not s2
+
+    def test_create_no_args(self, FakeServer):
+        with pytest.raises(MissingRequiredCreationParameter):
+            FakeServer.create()
+
+    def test_create_no_datacenter(self, FakeServer):
+        with pytest.raises(MissingRequiredCreationParameter):
+            FakeServer.create(name='fakeserver',
+                              addresses=[{'name': '1.1.1.1'}])
+
+    def test_create_no_address(self, FakeServer):
+        with pytest.raises(MissingRequiredCreationParameter):
+            FakeServer.create(name='fakeserver', datacenter='fakedc')
+
+
+class Test_VS_Subcoll(object):
+    def test_vs_attr_exists(self, fakeicontrolsession):
+        b = ManagementRoot('192.168.1.1', 'admin', 'admin')
+        s = b.tm.gtm.servers.server
+        test_meta = s._meta_data['attribute_registry']
+        kind = 'tm:gtm:server:virtual-servers:virtual-serverscollectionstate'
+        assert kind in test_meta.keys()
+
+    def test_create_no_args(self, FakeVS):
+        with pytest.raises(MissingRequiredCreationParameter):
+            FakeVS.create()

--- a/f5/bigip/tm/gtm/test/test_wideip.py
+++ b/f5/bigip/tm/gtm/test/test_wideip.py
@@ -1,0 +1,181 @@
+# Copyright 2015 F5 Networks Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import mock
+import pytest
+
+from f5.bigip import ManagementRoot
+from f5.bigip.resource import Collection
+from f5.bigip.resource import MissingRequiredCreationParameter
+from f5.bigip.resource import OrganizingCollection
+from f5.bigip.tm.gtm.wideip import A
+from f5.bigip.tm.gtm.wideip import Aaaa
+from f5.bigip.tm.gtm.wideip import Cname
+from f5.bigip.tm.gtm.wideip import Mx
+from f5.bigip.tm.gtm.wideip import Naptr
+from f5.bigip.tm.gtm.wideip import Srv
+from f5.bigip.tm.gtm.wideip import Wideip
+from f5.bigip.tm.gtm.wideip import WideipCollection
+
+
+@pytest.fixture
+def FakeWideipv11():
+    fake_gtm = mock.MagicMock()
+    fake_wideip = WideipCollection(fake_gtm)
+    fake_wideip._meta_data['bigip'].tmos_version = '11.6.0'
+    return fake_wideip
+
+
+class TestWideips(object):
+    def test_new_method_v11(self, fakeicontrolsession):
+        b = ManagementRoot('192.168.1.1', 'admin', 'admin')
+        w1 = b.tm.gtm.wideips
+        assert isinstance(w1, Collection)
+        assert hasattr(w1, 'wideip')
+        assert not hasattr(w1, 'a_s')
+        assert not hasattr(w1, 'aaaas')
+        assert not hasattr(w1, 'cnames')
+        assert not hasattr(w1, 'mxs')
+        assert not hasattr(w1, 'naptrs')
+        assert not hasattr(w1, 'srvs')
+
+    def test_new_method_v12(self, fakeicontrolsession_v12):
+        b = ManagementRoot('192.168.1.1', 'admin', 'admin')
+        w1 = b.tm.gtm.wideips
+        assert isinstance(w1, OrganizingCollection)
+        assert hasattr(w1, 'a_s')
+        assert hasattr(w1, 'aaaas')
+        assert hasattr(w1, 'cnames')
+        assert hasattr(w1, 'mxs')
+        assert hasattr(w1, 'naptrs')
+        assert hasattr(w1, 'srvs')
+        assert not hasattr(w1, 'wideip')
+
+
+class TestCreatev11(object):
+    def test_create_two_v11(self, fakeicontrolsession):
+        b = ManagementRoot('192.168.1.1', 'admin', 'admin')
+        w1 = b.tm.gtm.wideips.wideip
+        w2 = b.tm.gtm.wideips.wideip
+        assert w1 is not w2
+
+    def test_create_no_args_v11(self, FakeWideipv11):
+        with pytest.raises(MissingRequiredCreationParameter):
+            FakeWideipv11.wideip.create()
+
+
+class TestCollectionv11(object):
+    def test_wideip_attr_exists(self, fakeicontrolsession):
+        b = ManagementRoot('192.168.1.1', 'admin', 'admin')
+        w = b.tm.gtm.wideips
+        test_meta = w._meta_data['attribute_registry']
+        test_meta2 = w._meta_data['allowed_lazy_attributes']
+        kind = 'tm:gtm:wideip:wideipstate'
+        assert kind in test_meta.keys()
+        assert Wideip in test_meta2
+
+
+# Start v12.x Tests
+# Helper class to limit code repetition
+class HelperTest(object):
+    def __init__(self, collection_name):
+        self.lowered = collection_name.lower()
+        self.kinds = {'a': 'tm:gtm:wideip:a:astate',
+                      'aaaa': 'tm:gtm:wideip:aaaa:aaaastate',
+                      'cname': 'tm:gtm:wideip:cname:cnamestate',
+                      'mx': 'tm:gtm:wideip:mx:mxstate',
+                      'naptr': 'tm:gtm:wideip:naptr:naptrstate',
+                      'srv': 'tm:gtm:wideip:srv:srvstate'}
+
+    def urielementname(self):
+        if self.lowered[-2:] == '_s':
+            endind = 2
+        else:
+            endind = 1
+        return self.lowered[:-endind]
+
+    def set_resources(self, fakeicontrolsession_v12):
+        mr = ManagementRoot('192.168.1.1', 'admin', 'admin')
+        b = mr.tm
+        resourcecollection =\
+            getattr(getattr(getattr(b, 'gtm'), 'wideips'),
+                    self.lowered)
+        resource1 = getattr(resourcecollection, self.urielementname())
+        resource2 = getattr(resourcecollection, self.urielementname())
+        return resource1, resource2
+
+    def set_collections(self, fakeicontrolsession_v12):
+        mr = ManagementRoot('192.168.1.1', 'admin', 'admin')
+        b = mr.tm
+        resourcecollection =\
+            getattr(getattr(getattr(b, 'gtm'), 'wideips'),
+                    self.lowered)
+        return resourcecollection
+
+    def test_collections(self, fakeicontrolsession_v12, klass):
+        rc = self.set_collections(fakeicontrolsession_v12)
+        test_meta = rc._meta_data['attribute_registry']
+        test_meta2 = rc._meta_data['allowed_lazy_attributes']
+        kind = self.kinds[self.urielementname()]
+        assert kind in test_meta.keys()
+        assert klass in test_meta2
+
+    def test_create_two_v12(self, fakeicontrolsession_v12):
+        r1, r2, = self.set_resources(fakeicontrolsession_v12)
+        assert r1 is not r2
+
+    def test_create_no_args_v12(self, fakeicontrolsession_v12):
+        r1, r2, = self.set_resources(fakeicontrolsession_v12)
+        del r2
+        with pytest.raises(MissingRequiredCreationParameter):
+            r1.create()
+
+
+class Testv12(object):
+    def test_wideip_type_a(self, fakeicontrolsession_v12):
+        w = HelperTest('a_s')
+        w.test_collections(fakeicontrolsession_v12, A)
+        w.test_create_two_v12(fakeicontrolsession_v12)
+        w.test_create_no_args_v12(fakeicontrolsession_v12)
+
+    def test_wideip_type_aaaa(self, fakeicontrolsession_v12):
+        w = HelperTest('aaaas')
+        w.test_collections(fakeicontrolsession_v12, Aaaa)
+        w.test_create_two_v12(fakeicontrolsession_v12)
+        w.test_create_no_args_v12(fakeicontrolsession_v12)
+
+    def test_wideip_type_cname(self, fakeicontrolsession_v12):
+        w = HelperTest('cnames')
+        w.test_collections(fakeicontrolsession_v12, Cname)
+        w.test_create_two_v12(fakeicontrolsession_v12)
+        w.test_create_no_args_v12(fakeicontrolsession_v12)
+
+    def test_wideip_type_mx(self, fakeicontrolsession_v12):
+        w = HelperTest('Mxs')
+        w.test_collections(fakeicontrolsession_v12, Mx)
+        w.test_create_two_v12(fakeicontrolsession_v12)
+        w.test_create_no_args_v12(fakeicontrolsession_v12)
+
+    def test_wideip_type_naptr(self, fakeicontrolsession_v12):
+        w = HelperTest('Naptrs')
+        w.test_collections(fakeicontrolsession_v12, Naptr)
+        w.test_create_two_v12(fakeicontrolsession_v12)
+        w.test_create_no_args_v12(fakeicontrolsession_v12)
+
+    def test_wideip_type_srv(self, fakeicontrolsession_v12):
+        w = HelperTest('Srvs')
+        w.test_collections(fakeicontrolsession_v12, Srv)
+        w.test_create_two_v12(fakeicontrolsession_v12)
+        w.test_create_no_args_v12(fakeicontrolsession_v12)

--- a/f5/bigip/tm/gtm/wideip.py
+++ b/f5/bigip/tm/gtm/wideip.py
@@ -1,0 +1,208 @@
+# coding=utf-8
+#
+#  Copyright 2014-2016 F5 Networks Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""BIG-IP® Global Traffic Manager™ (GTM®) pool module.
+
+REST URI
+    ``http://localhost/mgmt/tm/gtm/wideip``
+
+GUI Path
+    ``DNS --> GSLB : Wide IPs``
+
+REST Kind
+    ``tm:gtm:pools:*``
+"""
+
+from distutils.version import LooseVersion
+
+from f5.bigip.resource import Collection
+from f5.bigip.resource import OrganizingCollection
+from f5.bigip.resource import Resource
+
+
+class Wideips(object):
+    """BIG-IP® GTM WideIP factory
+
+       The GTM WideIP factory object is used to provide a consistent user
+       experience across the SDK, while supporting the breaking changes in
+       the BIG-IP APIs.
+
+       Between the 11.x and 12.x releases of BIG-IP, the REST endpoint for
+       WideIP changed from a Collection to an OrganizingCollection. The result
+       is that breaking changes occurred in the API.
+
+       This breakage led to a discussion on naming conventions because there
+       appeared to be a conflict now. For example, depending on your version,
+       only one of the following would work.
+
+       For 11.x,
+
+           tm.gtm.wideips.wideip.load(name='foo')
+
+       For 12.x,
+
+           tm.gtm.wideips.a_s.a.load(name='foo')
+
+       but not both. To stick with a consistent user experience, we decided
+       to override the __new__ method to support both examples above. The SDK
+       automatically detects which one to use based on the BIG-IP you are
+       communicating with.
+       """
+    def __new__(cls, container):
+        tmos_v = container._meta_data['bigip']._meta_data['tmos_version']
+        if LooseVersion(tmos_v) < LooseVersion('12.0.0'):
+            return WideipCollection(container)
+        else:
+            return WideipOrganizingCollection(container)
+
+
+class WideipOrganizingCollection(OrganizingCollection):
+    """v12.x GTM WideIP is an OC."""
+    def __init__(self, gtm):
+        self.__class__.__name__ = 'Wideip'
+        super(WideipOrganizingCollection, self).__init__(gtm)
+        self._meta_data['allowed_lazy_attributes'] = [
+            A_s,
+            Aaaas,
+            Cnames,
+            Mxs,
+            Naptrs,
+            Srvs,
+            ]
+
+
+class A_s(Collection):
+    """v12.x BIG-IP® A wideip collection.
+
+        Class name needed changing due to
+        'as' being reserved python keyword
+    """
+    def __init__(self, wideip):
+        super(A_s, self).__init__(wideip)
+        self._meta_data['allowed_lazy_attributes'] = [A]
+        self._meta_data['attribute_registry'] = \
+            {'tm:gtm:wideip:a:astate': A}
+
+
+class A(Resource):
+    """v12.x BIG-IP®A wideip resource"""
+    def __init__(self, _as):
+        super(A, self).__init__(_as)
+        self._meta_data['required_json_kind'] = \
+            'tm:gtm:wideip:a:astate'
+
+
+class Aaaas(Collection):
+    """v12.x BIG-IP® AAAA wideip collection"""
+    def __init__(self, wideip):
+        super(Aaaas, self).__init__(wideip)
+        self._meta_data['allowed_lazy_attributes'] = [Aaaa]
+        self._meta_data['attribute_registry'] = \
+            {'tm:gtm:wideip:aaaa:aaaastate': Aaaa}
+
+
+class Aaaa(Resource):
+    """v12.x BIG-IP® AAAA wideip resource"""
+    def __init__(self, aaaas):
+        super(Aaaa, self).__init__(aaaas)
+        self._meta_data['required_json_kind'] = \
+            'tm:gtm:wideip:aaaa:aaaastate'
+
+
+class Cnames(Collection):
+    """v12.x BIG-IP® CNAME wideip collection"""
+    def __init__(self, wideip):
+        super(Cnames, self).__init__(wideip)
+        self._meta_data['allowed_lazy_attributes'] = [Cname]
+        self._meta_data['attribute_registry'] = \
+            {'tm:gtm:wideip:cname:cnamestate': Cname}
+
+
+class Cname(Resource):
+    """v12.x BIG-IP® CNAME wideip resource"""
+    def __init__(self, cnames):
+        super(Cname, self).__init__(cnames)
+        self._meta_data['required_json_kind'] = \
+            'tm:gtm:wideip:cname:cnamestate'
+
+
+class Mxs(Collection):
+    """v12.x BIG-IP® MX wideip collection."""
+    def __init__(self, wideip):
+        super(Mxs, self).__init__(wideip)
+        self._meta_data['allowed_lazy_attributes'] = [Mx]
+        self._meta_data['attribute_registry'] = \
+            {'tm:gtm:wideip:mx:mxstate': Mx}
+
+
+class Mx(Resource):
+    """v12.x BIG-IP® MX wideip resource"""
+    def __init__(self, mxs):
+        super(Mx, self).__init__(mxs)
+        self._meta_data['required_json_kind'] = \
+            'tm:gtm:wideip:mx:mxstate'
+
+
+class Naptrs(Collection):
+    """v12.x BIG-IP® NAPTR wideip collection"""
+    def __init__(self, wideip):
+        super(Naptrs, self).__init__(wideip)
+        self._meta_data['allowed_lazy_attributes'] = [Naptr]
+        self._meta_data['attribute_registry'] = \
+            {'tm:gtm:wideip:naptr:naptrstate': Naptr}
+
+
+class Naptr(Resource):
+    """v12.x BIG-IP® NAPTR wideip resource"""
+    def __init__(self, naptrs):
+        super(Naptr, self).__init__(naptrs)
+        self._meta_data['required_json_kind'] = \
+            'tm:gtm:wideip:naptr:naptrstate'
+
+
+class Srvs(Collection):
+    """v12.x BIG-IP® SRV wideip collection"""
+    def __init__(self, wideip):
+        super(Srvs, self).__init__(wideip)
+        self._meta_data['allowed_lazy_attributes'] = [Srv]
+        self._meta_data['attribute_registry'] = \
+            {'tm:gtm:wideip:srv:srvstate': Srv}
+
+
+class Srv(Resource):
+    """v12.x BIG-IP® SRV wideip resource"""
+    def __init__(self, naptrs):
+        super(Srv, self).__init__(naptrs)
+        self._meta_data['required_json_kind'] = \
+            'tm:gtm:wideip:srv:srvstate'
+
+
+class WideipCollection(Collection):
+    """v11.x BIG-IP® GTM wideip collection"""
+    def __init__(self, gtm):
+        self.__class__.__name__ = 'Wideips'
+        super(WideipCollection, self).__init__(gtm)
+        self._meta_data['allowed_lazy_attributes'] = [Wideip]
+        self._meta_data['attribute_registry'] = \
+            {'tm:gtm:wideip:wideipstate': Wideip}
+
+
+class Wideip(Resource):
+    """v11.x BIG-IP® GTM pool resource"""
+    def __init__(self, wideips):
+        super(Wideip, self).__init__(wideips)
+        self._meta_data['required_json_kind'] = 'tm:gtm:wideip:wideipstate'

--- a/test/functional/tm/gtm/test_server.py
+++ b/test/functional/tm/gtm/test_server.py
@@ -1,0 +1,358 @@
+# Copyright 2015 F5 Networks Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import copy
+import pytest
+
+from distutils.version import LooseVersion
+from f5.bigip.tm.gtm.server import Server
+from f5.bigip.tm.gtm.server import Virtual_Servers
+from requests.exceptions import HTTPError
+
+
+def delete_server(mgmt_root, name):
+    try:
+        foo = mgmt_root.tm.gtm.servers.server.load(
+            name=name)
+    except HTTPError as err:
+        if err.response.status_code != 404:
+            raise
+        return
+    foo.delete()
+
+
+def delete_dc(mgmt_root, name, partition):
+    try:
+        delete_server(mgmt_root, 'fake_serv1')
+        foo = mgmt_root.tm.gtm.datacenters.datacenter.load(
+            name=name, partition=partition
+        )
+    except HTTPError as err:
+        if err.response.status_code != 404:
+            raise
+        return
+    foo.delete()
+
+
+def create_dc(request, mgmt_root, name, partition):
+    def teardown():
+        delete_dc(mgmt_root, name, partition)
+
+    # this line is to clean up any object that might have been left by
+    # previous test
+    delete_dc(mgmt_root, name, partition)
+
+    dc = mgmt_root.tm.gtm.datacenters.datacenter.create(
+        name=name, partition=partition)
+    request.addfinalizer(teardown)
+    return dc
+
+
+def setup_create_test(request, mgmt_root, name):
+    def teardown():
+        delete_server(mgmt_root, name)
+    request.addfinalizer(teardown)
+
+
+def setup_basic_test(request, mgmt_root, name, partition):
+    def teardown():
+        delete_server(mgmt_root, name)
+
+    # this line is to clean up any object that might have been left by
+    # previous test
+    delete_dc(mgmt_root, 'dc1', partition)
+
+    dc = create_dc(request, mgmt_root, 'dc1', partition)
+    serv1 = mgmt_root.tm.gtm.servers.server.create(
+        name=name, datacenter=dc.name,
+        addresses=[{'name': '1.1.1.1'}])
+    request.addfinalizer(teardown)
+    return serv1
+
+
+def delete_vs(mgmt_root, name):
+    s1 = mgmt_root.tm.gtm.servers.server.load(name='fake_serv1')
+    try:
+        foo = s1.virtual_servers_s.virtual_servers.load(
+            name=name)
+    except HTTPError as err:
+        if err.response.status_code != 404:
+            raise
+        return
+    foo.delete()
+
+
+def setup_vs_basic_test(request, mgmt_root, name, destination):
+    def teardown():
+        delete_vs(mgmt_root, name)
+
+    s1 = setup_basic_test(request, mgmt_root, 'fake_serv1', 'Common')
+    vs = s1.virtual_servers_s.virtual_servers.create(
+        name=name, destination=destination)
+    request.addfinalizer(teardown)
+    return vs
+
+
+def setup_create_vs_test(request, mgmt_root, name):
+    def teardown():
+        delete_server(mgmt_root, name)
+
+    request.addfinalizer(teardown)
+
+
+class TestCreate(object):
+    def test_create_req_arg(self, request, mgmt_root):
+        setup_create_test(request, mgmt_root, 'fake_serv1')
+        dc = create_dc(request, mgmt_root, 'dc1', 'Common')
+        serv1 = mgmt_root.tm.gtm.servers.server.create(
+            name='fake_serv1', datacenter=dc.name,
+            addresses=[{'name': '1.1.1.1'}])
+        assert serv1.name == 'fake_serv1'
+        assert serv1.generation and isinstance(serv1.generation, int)
+        assert serv1.kind == 'tm:gtm:server:serverstate'
+        assert serv1.selfLink.startswith(
+            'https://localhost/mgmt/tm/gtm/server/fake_serv1')
+
+    def test_create_optional_args(self, request, mgmt_root):
+        setup_create_test(request, mgmt_root, 'fake_serv1')
+        dc = create_dc(request, mgmt_root, 'dc1', 'Common')
+        serv1 = mgmt_root.tm.gtm.servers.server.create(
+            name='fake_serv1', datacenter=dc.name,
+            addresses=[{'name': '1.1.1.1'}],
+            iqAllowPath='no', enabled=False, disabled=True)
+        assert serv1.disabled is True
+        assert not hasattr(serv1, 'enabled')
+        assert serv1.iqAllowPath == 'no'
+
+    def test_create_duplicate(self, request, mgmt_root):
+        setup_basic_test(request, mgmt_root, 'fake_serv1', 'Common')
+        with pytest.raises(HTTPError) as err:
+            mgmt_root.tm.gtm.servers.server.create(
+                name='fake_serv1', datacenter='dc1',
+                addresses=[{'name': '1.1.1.1'}])
+            assert err.response.status_code == 400
+
+
+class TestRefresh(object):
+    def test_refresh(self, request, mgmt_root):
+        setup_basic_test(request, mgmt_root, 'fake_serv1', 'Common')
+        s1 = mgmt_root.tm.gtm.servers.server.load(name='fake_serv1')
+        s2 = mgmt_root.tm.gtm.servers.server.load(name='fake_serv1')
+
+        assert s1.iqAllowPath == 'yes'
+        assert s2.iqAllowPath == 'yes'
+
+        s2.update(iqAllowPath='no')
+        assert s1.iqAllowPath == 'yes'
+        assert s2.iqAllowPath == 'no'
+
+        s1.refresh()
+        assert s1.iqAllowPath == 'no'
+
+
+class TestLoad(object):
+    def test_load_no_object(self, mgmt_root):
+        with pytest.raises(HTTPError) as err:
+            mgmt_root.tm.gtm.servers.server.load(
+                name='fake_serv1')
+            assert err.response.status_code == 404
+
+    @pytest.mark.skipif(LooseVersion(pytest.config.getoption('--release')) ==
+                        '11.5.4',
+                        reason='Needs > v11.5.4 TMOS to pass')
+    def test_load(self, request, mgmt_root):
+        setup_basic_test(request, mgmt_root, 'fake_serv1', 'Common')
+        s1 = mgmt_root.tm.gtm.servers.server.load(name='fake_serv1')
+        assert s1.enabled is True
+        s1.enabled = False
+        s1.disabled = True
+        s1.update()
+        s2 = mgmt_root.tm.gtm.servers.server.load(name='fake_serv1')
+        assert not hasattr(s1, 'enabled')
+        assert hasattr(s2, 'disabled')
+        assert s2.disabled is True
+
+    @pytest.mark.skipif(
+        LooseVersion(pytest.config.getoption('--release')) >= LooseVersion(
+            '11.6.0'),
+        reason='This test is for 11.5.4 or less.')
+    def test_load_11_5_4_and_less(self, request, mgmt_root):
+        setup_basic_test(request, mgmt_root, 'fake_serv1', 'Common')
+        s1 = mgmt_root.tm.gtm.servers.server.load(name='fake_serv1')
+        assert s1.enabled is True
+        s1.enabled = False
+        s1.update()
+        s2 = mgmt_root.tm.gtm.servers.server.load(name='fake_serv1')
+        assert hasattr(s2, 'enabled')
+        assert s2.enabled is True
+
+
+class TestUpdateModify(object):
+    def test_update(self, request, mgmt_root):
+        s1 = setup_basic_test(request, mgmt_root, 'fake_serv1', 'Common')
+        assert s1.iqAllowPath == 'yes'
+        s1.update(iqAllowPath='no')
+        assert s1.iqAllowPath == 'no'
+
+    def test_modify(self, request, mgmt_root):
+        s1 = setup_basic_test(request, mgmt_root, 'fake_serv1', 'Common')
+        original_dict = copy.copy(s1.__dict__)
+        iqpath = 'iqAllowPath'
+        s1.modify(iqAllowPath='no')
+        for k, v in original_dict.items():
+            if k != iqpath:
+                original_dict[k] = s1.__dict__[k]
+            elif k == iqpath:
+                assert s1.__dict__[k] == 'no'
+
+
+class TestDelete(object):
+    def test_delete(self, request, mgmt_root):
+        s1 = setup_basic_test(request, mgmt_root, 'fake_serv1', 'Common')
+        s1.delete()
+        with pytest.raises(HTTPError) as err:
+            mgmt_root.tm.gtm.servers.server.load(name='fake_serv1')
+            assert err.response.status_code == 404
+
+
+class TestServerCollection(object):
+    def test_server_collection(self, request, mgmt_root):
+        s1 = setup_basic_test(request, mgmt_root, 'fake_serv1', 'Common')
+        assert s1.name == 'fake_serv1'
+        assert s1.generation and isinstance(s1.generation, int)
+        assert s1.fullPath == 'fake_serv1'
+        assert s1.kind == 'tm:gtm:server:serverstate'
+        assert s1.selfLink.startswith(
+            'https://localhost/mgmt/tm/gtm/server/fake_serv1')
+
+        sc = mgmt_root.tm.gtm.servers.get_collection()
+        assert isinstance(sc, list)
+        assert len(sc)
+        assert isinstance(sc[0], Server)
+
+
+class TestVirtualServerSubCollection(object):
+    def test_create_req_arg(self, request, mgmt_root):
+        setup_create_vs_test(request, mgmt_root, 'vs1')
+        s1 = setup_basic_test(request, mgmt_root, 'fake_serv1', 'Common')
+        vs = s1.virtual_servers_s
+        vs1 = vs.virtual_servers.create(name='vs1', destination='5.5.5.5:80')
+        assert vs1.name == 'vs1'
+        assert vs1.generation and isinstance(vs1.generation, int)
+        assert vs1.kind == 'tm:gtm:server:virtual-servers:virtual-serversstate'
+        assert vs1.selfLink.startswith('https://localhost/mgmt/tm/gtm/server/'
+                                       'fake_serv1/virtual-servers/vs1')
+
+    def test_create_optional_args(self, request, mgmt_root):
+        setup_create_vs_test(request, mgmt_root, 'vs1')
+        s1 = setup_basic_test(request, mgmt_root, 'fake_serv1', 'Common')
+        vs = s1.virtual_servers_s
+        vs1 = vs.virtual_servers.create(name='vs1',
+                                        destination='5.5.5.5:80',
+                                        description='FancyFakeVS',
+                                        limitMaxBpsStatus='enabled',
+                                        limitMaxBps=1337)
+        assert vs1.name == 'vs1'
+        assert vs1.description == 'FancyFakeVS'
+        assert vs1.limitMaxBpsStatus == 'enabled'
+        assert vs1.limitMaxBps == 1337
+
+    def test_create_duplicate(self, request, mgmt_root):
+        setup_vs_basic_test(request, mgmt_root, 'vs1', '5.5.5.5:80')
+        s1 = mgmt_root.tm.gtm.servers.server.load(name='fake_serv1')
+        try:
+            s1.virtual_servers_s.virtual_servers.create(
+                name='vs1', destination='5.5.5.5:80')
+        except HTTPError as err:
+            assert err.response.status_code == 409
+
+    def test_refresh(self, request, mgmt_root):
+        setup_vs_basic_test(request, mgmt_root, 'vs1', '5.5.5.5:80')
+        s1 = mgmt_root.tm.gtm.servers.server.load(name='fake_serv1')
+        vs1 = s1.virtual_servers_s.virtual_servers.load(name='vs1')
+        vs2 = s1.virtual_servers_s.virtual_servers.load(name='vs1')
+
+        assert vs1.limitMaxBpsStatus == 'disabled'
+        assert vs2.limitMaxBpsStatus == 'disabled'
+
+        vs2.update(limitMaxBpsStatus='enabled')
+        assert vs1.limitMaxBpsStatus == 'disabled'
+        assert vs2.limitMaxBpsStatus == 'enabled'
+
+        vs1.refresh()
+        assert vs2.limitMaxBpsStatus == 'enabled'
+
+    def test_load_no_object(self, request, mgmt_root):
+        s1 = setup_basic_test(request, mgmt_root, 'fake_serv1', 'Common')
+        try:
+            s1.virtual_servers_s.virtual_servers.load(name='vs1')
+        except HTTPError as err:
+            assert err.response.status_code == 404
+
+    def test_load(self, request, mgmt_root):
+        setup_vs_basic_test(request, mgmt_root, 'vs1', '5.5.5.5:80')
+        s1 = mgmt_root.tm.gtm.servers.server.load(name='fake_serv1')
+        vs1 = s1.virtual_servers_s.virtual_servers.load(name='vs1')
+        assert vs1.name == 'vs1'
+        assert vs1.limitMaxBpsStatus == 'disabled'
+
+        vs1.limitMaxBpsStatus = 'enabled'
+        vs1.update()
+        vs2 = s1.virtual_servers_s.virtual_servers.load(name='vs1')
+        assert vs2.name == 'vs1'
+        assert vs2.limitMaxBpsStatus == 'enabled'
+
+    def test_update(self, request, mgmt_root):
+        vs1 = setup_vs_basic_test(request, mgmt_root, 'vs1', '5.5.5.5:80')
+        assert vs1.limitMaxBpsStatus == 'disabled'
+        vs1.update(limitMaxBpsStatus='enabled')
+        assert vs1.limitMaxBpsStatus == 'enabled'
+
+    def test_modify(self, request, mgmt_root):
+        vs1 = setup_vs_basic_test(request, mgmt_root, 'vs1', '5.5.5.5:80')
+        original_dict = copy.copy(vs1.__dict__)
+        limit = 'limitMaxBpsStatus'
+        vs1.modify(limitMaxBpsStatus='enabled')
+        for k, v in original_dict.items():
+            if k != limit:
+                original_dict[k] = vs1.__dict__[k]
+            elif k == limit:
+                assert vs1.__dict__[k] == 'enabled'
+
+    @pytest.mark.skipif(pytest.config.getoption('--release') == '11.6.0',
+                        reason='Due to a bug in 11.6.0 Final this test '
+                               'fails')
+    def test_delete(self, request, mgmt_root):
+        vs1 = setup_vs_basic_test(request, mgmt_root, 'vs2', '5.5.5.5:80')
+        vs1.delete()
+        s1 = mgmt_root.tm.gtm.servers.server.load(name='fake_serv1')
+        try:
+            s1.virtual_servers_s.virtual_servers.load(name='vs2')
+        except HTTPError as err:
+            assert err.response.status_code == 404
+
+    def test_virtual_server_collection(self, request, mgmt_root):
+        vs1 = setup_vs_basic_test(request, mgmt_root, 'vs1', '5.5.5.5:80')
+        assert vs1.name == 'vs1'
+        assert vs1.generation and isinstance(vs1.generation, int)
+        assert vs1.kind == 'tm:gtm:server:virtual-servers:virtual-serversstate'
+        assert vs1.selfLink.startswith('https://localhost/mgmt/tm/gtm/server/'
+                                       'fake_serv1/virtual-servers/vs1')
+
+        s1 = mgmt_root.tm.gtm.servers.server.load(name='fake_serv1')
+        vsc = s1.virtual_servers_s.get_collection()
+        assert isinstance(vsc, list)
+        assert len(vsc)
+        assert isinstance(vsc[0], Virtual_Servers)

--- a/test/functional/tm/gtm/test_wideips.py
+++ b/test/functional/tm/gtm/test_wideips.py
@@ -1,0 +1,345 @@
+# Copyright 2015 F5 Networks Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import copy
+from distutils.version import LooseVersion
+from f5.bigip.tm.gtm.wideip import A
+from f5.bigip.tm.gtm.wideip import Aaaa
+from f5.bigip.tm.gtm.wideip import Cname
+from f5.bigip.tm.gtm.wideip import Mx
+from f5.bigip.tm.gtm.wideip import Naptr
+from f5.bigip.tm.gtm.wideip import Srv
+from f5.bigip.tm.gtm.wideip import Wideip
+from pprint import pprint as pp
+pp(__file__)
+import pytest
+from requests.exceptions import HTTPError
+
+
+TESTDESCRIPTION = "TESTDESCRIPTION"
+
+# Start of V12.x Tests here
+
+
+# Helper class to limit code repetition
+class HelperTest(object):
+    def __init__(self, collection_name):
+        self.partition = 'Common'
+        self.lowered = collection_name.lower()
+        self.test_name = 'fake.' + self.urielementname() + '.lab.local'
+        self.kinds = {'a': 'tm:gtm:wideip:a:astate',
+                      'aaaa': 'tm:gtm:wideip:aaaa:aaaastate',
+                      'cname': 'tm:gtm:wideip:cname:cnamestate',
+                      'mx': 'tm:gtm:wideip:mx:mxstate',
+                      'naptr': 'tm:gtm:wideip:naptr:naptrstate',
+                      'srv': 'tm:gtm:wideip:srv:srvstate'}
+
+    def urielementname(self):
+        if self.lowered[-2:] == '_s':
+            endind = 2
+        else:
+            endind = 1
+        return self.lowered[:-endind]
+
+    def delete_resource(self, resource):
+        try:
+            foo = resource.load(name=self.test_name, partition=self.partition)
+        except HTTPError as err:
+            if err.response.status_code != 404:
+                raise
+            return
+        foo.delete()
+
+    def setup_test(self, request, mgmt_root, **kwargs):
+        def teardown():
+            self.delete_resource(resource)
+
+        resourcecollection =\
+            getattr(getattr(getattr(mgmt_root, 'gtm'), 'wideips'),
+                    self.lowered)
+        resource = getattr(resourcecollection, self.urielementname())
+        self.delete_resource(resource)
+        created = resource.create(name=self.test_name,
+                                  partition=self.partition,
+                                  **kwargs)
+        request.addfinalizer(teardown)
+        return created, resourcecollection
+
+    def test_MCURDL(self, request, bigip, **kwargs):
+        # Testing create
+        wideip, rescollection = self.setup_test(request, bigip, **kwargs)
+        assert wideip.name == self.test_name
+        assert wideip.fullPath == '/Common/'+self.test_name
+        assert wideip.generation and isinstance(wideip.generation, int)
+        assert wideip.kind == self.kinds[self.urielementname()]
+
+        # Testing update
+        wideip.description = TESTDESCRIPTION
+        pp(wideip.raw)
+        wideip.update()
+        if hasattr(wideip, 'description'):
+            assert wideip.description == TESTDESCRIPTION
+
+        # Testing refresh
+        wideip.description = ''
+        wideip.refresh()
+        if hasattr(wideip, 'description'):
+            assert wideip.description == TESTDESCRIPTION
+
+        # Testing modify
+        meta_data = wideip.__dict__.pop('_meta_data')
+        start_dict = copy.deepcopy(wideip.__dict__)
+        wideip.__dict__['_meta_data'] = meta_data
+        wideip.modify(description='MODIFIED')
+        desc = 'description'
+        for k, v in wideip.__dict__.items():
+            if k != desc:
+                start_dict[k] = wideip.__dict__[k]
+                assert getattr(wideip, k) == start_dict[k]
+            elif k == desc:
+                assert getattr(wideip, desc) == 'MODIFIED'
+
+        # Testing load
+        p2 = getattr(rescollection, self.urielementname())
+        wideip2 = p2.load(partition=self.partition, name=self.test_name)
+        assert wideip.selfLink == wideip2.selfLink
+
+    def test_collection(self, request, bigip, **kwargs):
+        wideip, rescollection = self.setup_test(request, bigip, **kwargs)
+        assert wideip.name == self.test_name
+        assert wideip.fullPath == '/Common/'+self.test_name
+        assert wideip.generation and isinstance(wideip.generation, int)
+        assert wideip.kind == self.kinds[self.urielementname()]
+
+        coll = rescollection.get_collection()
+        assert isinstance(coll, list)
+        assert len(coll)
+        if self.lowered == 'a_s':
+            assert isinstance(coll[0], A)
+        elif self.lowered == 'aaaas':
+            assert isinstance(coll[0], Aaaa)
+        elif self.lowered == 'cnames':
+            assert isinstance(coll[0], Cname)
+        elif self.lowered == 'mxs':
+            assert isinstance(coll[0], Mx)
+        elif self.lowered == 'naptrs':
+            assert isinstance(coll[0], Naptr)
+        elif self.lowered == 'srvs':
+            assert isinstance(coll[0], Srv)
+
+
+@pytest.mark.skipif(
+    LooseVersion(pytest.config.getoption('--release')) < LooseVersion(
+        '12.0.0'),
+    reason='This collection exists on 12.0.0 or greater.'
+)
+class TestWideipAtype(object):
+    def test_MCURDL_and_collection(self, request, bigip):
+        wideip = HelperTest('A_s')
+        wideip.test_MCURDL(request, bigip)
+        wideip.test_collection(request, bigip)
+
+
+@pytest.mark.skipif(
+    LooseVersion(pytest.config.getoption('--release')) < LooseVersion(
+        '12.0.0'),
+    reason='This collection exists on 12.0.0 or greater.'
+)
+class TestWideipAaaaType(object):
+    def test_MCURDL_and_collection(self, request, bigip):
+        wideip = HelperTest('Aaaas')
+        wideip.test_MCURDL(request, bigip)
+        wideip.test_collection(request, bigip)
+
+
+@pytest.mark.skipif(
+    LooseVersion(pytest.config.getoption('--release')) < LooseVersion(
+        '12.0.0'),
+    reason='This collection exists on 12.0.0 or greater.'
+)
+class TestWideipCnameType(object):
+    def test_MCURDL_and_collection(self, request, bigip):
+        wideip = HelperTest('Cnames')
+        wideip.test_MCURDL(request, bigip)
+        wideip.test_collection(request, bigip)
+
+
+@pytest.mark.skipif(
+    LooseVersion(pytest.config.getoption('--release')) < LooseVersion(
+        '12.0.0'),
+    reason='This collection exists on 12.0.0 or greater.'
+)
+class TestWideipMxType(object):
+    def test_MCURDL_and_collection(self, request, bigip):
+        wideip = HelperTest('Mxs')
+        wideip.test_MCURDL(request, bigip)
+        wideip.test_collection(request, bigip)
+
+
+@pytest.mark.skipif(
+    LooseVersion(pytest.config.getoption('--release')) < LooseVersion(
+        '12.0.0'),
+    reason='This collection exists on 12.0.0 or greater.'
+)
+class TestWideipNaptrType(object):
+    def test_MCURDL_and_collection(self, request, bigip):
+        wideip = HelperTest('Naptrs')
+        wideip.test_MCURDL(request, bigip)
+        wideip.test_collection(request, bigip)
+
+
+@pytest.mark.skipif(
+    LooseVersion(pytest.config.getoption('--release')) < LooseVersion(
+        '12.0.0'),
+    reason='This collection exists on 12.0.0 or greater.'
+)
+class TestWideipSrvType(object):
+    def test_MCURDL_and_collection(self, request, bigip):
+        wideip = HelperTest('Srvs')
+        wideip.test_MCURDL(request, bigip)
+        wideip.test_collection(request, bigip)
+
+# End of v12.x Tests
+
+
+def delete_wideip_v11(mgmt_root, name):
+    try:
+        foo = mgmt_root.tm.gtm.wideips.wideip.load(
+            name=name)
+    except HTTPError as err:
+        if err.response.status_code != 404:
+            raise
+        return
+    foo.delete()
+
+
+def setup_create_test(request, mgmt_root, name):
+    def teardown():
+        delete_wideip_v11(mgmt_root, name)
+
+    request.addfinalizer(teardown)
+
+
+def setup_basic_test(request, mgmt_root, name, **kwargs):
+    def teardown():
+        delete_wideip_v11(mgmt_root, name)
+
+    wideip1 = mgmt_root.tm.gtm.wideips.wideip.create(
+        name=name, **kwargs)
+    request.addfinalizer(teardown)
+    return wideip1
+
+
+@pytest.mark.skipif(
+    LooseVersion(pytest.config.getoption('--release')) >= LooseVersion(
+        '12.0.0'),
+    reason='This collection exists on 11.x'
+)
+class TestWideips_v11(object):
+    def test_create_req_arg(self, request, mgmt_root):
+        setup_create_test(request, mgmt_root, 'fake.lab.local')
+        wideip1 = mgmt_root.tm.gtm.wideips.wideip.create(
+            name='fake.lab.local', partition='Common')
+        assert wideip1.name == 'fake.lab.local'
+        assert wideip1.generation and isinstance(wideip1.generation, int)
+        assert wideip1.kind == 'tm:gtm:wideip:wideipstate'
+        assert wideip1.selfLink.startswith(
+            'https://localhost/mgmt/tm/gtm/wideip/~Common~fake.lab.local')
+
+    def test_create_optional_args(self, request, mgmt_root):
+        setup_create_test(request, mgmt_root, 'fake.lab.local')
+        wideip1 = mgmt_root.tm.gtm.wideips.wideip.create(
+            name='fake.lab.local', description=TESTDESCRIPTION)
+        assert wideip1.description == TESTDESCRIPTION
+        assert wideip1.ipv6NoErrorResponse == 'disabled'
+
+    def test_create_duplicate(self, request, mgmt_root):
+        setup_create_test(request, mgmt_root, 'fake.lab.local')
+        try:
+            mgmt_root.tm.gtm.wideips.wideip.create(name='fake.lab.local')
+        except HTTPError as err:
+            assert err.response.status_code == 400
+
+    def test_refresh(self, request, mgmt_root):
+        setup_basic_test(request, mgmt_root, 'fake.lab.local')
+        s1 = mgmt_root.tm.gtm.wideips.wideip.load(name='fake.lab.local')
+        s2 = mgmt_root.tm.gtm.wideips.wideip.load(name='fake.lab.local')
+
+        assert s1.ipv6NoErrorResponse == 'disabled'
+        assert s2.ipv6NoErrorResponse == 'disabled'
+
+        s2.update(ipv6NoErrorResponse='enabled')
+        assert s1.ipv6NoErrorResponse == 'disabled'
+        assert s2.ipv6NoErrorResponse == 'enabled'
+
+        s1.refresh()
+        assert s1.ipv6NoErrorResponse == 'enabled'
+
+    def test_load_no_object(self, mgmt_root):
+        with pytest.raises(HTTPError) as err:
+            mgmt_root.tm.gtm.wideips.wideip.load(name='fake.lab.local')
+            assert err.response.status_code == 404
+
+    def test_load(self, request, mgmt_root):
+        setup_basic_test(request, mgmt_root, 'fake.lab.local')
+        s1 = mgmt_root.tm.gtm.wideips.wideip.load(name='fake.lab.local')
+        assert s1.ipv6NoErrorResponse == 'disabled'
+        s1.ipv6NoErrorResponse = 'enabled'
+        s1.update()
+        s2 = mgmt_root.tm.gtm.wideips.wideip.load(name='fake.lab.local')
+        assert s2.ipv6NoErrorResponse == 'enabled'
+
+    def test_update(self, request, mgmt_root):
+        s1 = setup_basic_test(request, mgmt_root, 'fake.lab.local')
+        assert s1.ipv6NoErrorResponse == 'disabled'
+        assert not hasattr(s1, 'description')
+        s1.update(ipv6NoErrorResponse='enabled', description=TESTDESCRIPTION)
+        assert s1.ipv6NoErrorResponse == 'enabled'
+        assert hasattr(s1, 'description')
+        assert s1.description == TESTDESCRIPTION
+
+    def test_modify(self, request, mgmt_root):
+        s1 = setup_basic_test(request, mgmt_root, 'fake.lab.local')
+        original_dict = copy.copy(s1.__dict__)
+        ipv6 = 'ipv6NoErrorResponse'
+        s1.modify(ipv6NoErrorResponse='enabled')
+        for k, v in original_dict.items():
+            if k != ipv6:
+                original_dict[k] = s1.__dict__[k]
+            elif k == ipv6:
+                assert s1.__dict__[k] == 'enabled'
+
+    def test_delete(self, request, mgmt_root):
+        s1 = setup_basic_test(request, mgmt_root, 'fake.lab.local')
+        s1.delete()
+        with pytest.raises(HTTPError) as err:
+            mgmt_root.tm.gtm.wideips.wideip.load(name='fake.lab.local')
+            assert err.response.status_code == 404
+
+    def test_wideips_collection(self, request, mgmt_root):
+        wideip1 = setup_basic_test(request, mgmt_root, 'fake.lab.local',
+                                   partition='Common')
+
+        assert wideip1.name == 'fake.lab.local'
+        assert wideip1.fullPath == '/Common/fake.lab.local'
+        assert wideip1.generation and isinstance(wideip1.generation, int)
+        assert wideip1.kind == 'tm:gtm:wideip:wideipstate'
+        assert wideip1.selfLink.startswith(
+            'https://localhost/mgmt/tm/gtm/wideip/~Common~fake.lab.local')
+
+        wideipc = mgmt_root.tm.gtm.wideips.get_collection()
+        assert isinstance(wideipc, list)
+        assert len(wideipc)
+        assert isinstance(wideipc[0], Wideip)


### PR DESCRIPTION
Fixes #633

Problem:
GTM WideIP  endpoint was missing from the SDK. This is a first of a series of PRs meant to introduce the GTM pools to the SDK

Analysis:
WideIP endpoint was added as it was a dependency for GTM pools

Tests:
Flake8
Functional Tests
Unit Tests

Files Added/Changed:

f5-common-python/f5/bigip/tm/gtm/init.py
f5-common-python/f5/bigip/tm/gtm/wideip.py
f5-common-python/f5/bigip/tm/gtm/test/test_wideip.py
f5-common-python/test/functional/tm/gtm/test_wideip.py
