### PR TITLE
Adding GTM pools - branched out ofr PR(#674), merge this last

### DIFF
--- a/f5/bigip/tm/gtm/__init__.py
+++ b/f5/bigip/tm/gtm/__init__.py
@@ -32,6 +32,7 @@ from f5.bigip.resource import OrganizingCollection
 from f5.bigip.tm.gtm.datacenter import Datacenters
 from f5.bigip.tm.gtm.rule import Rules
 from f5.bigip.tm.gtm.server import Servers
+from f5.bigip.tm.gtm.wideip import Wideips
 
 
 class Gtm(OrganizingCollection):
@@ -42,4 +43,5 @@ class Gtm(OrganizingCollection):
             Datacenters,
             Rules,
             Servers,
+            Wideips,
         ]

--- a/f5/bigip/tm/gtm/__init__.py
+++ b/f5/bigip/tm/gtm/__init__.py
@@ -31,6 +31,7 @@ REST Kind
 from f5.bigip.resource import OrganizingCollection
 from f5.bigip.tm.gtm.datacenter import Datacenters
 from f5.bigip.tm.gtm.rule import Rules
+from f5.bigip.tm.gtm.server import Servers
 
 
 class Gtm(OrganizingCollection):
@@ -39,5 +40,6 @@ class Gtm(OrganizingCollection):
         super(Gtm, self).__init__(tm)
         self._meta_data['allowed_lazy_attributes'] = [
             Datacenters,
-            Rules
+            Rules,
+            Servers,
         ]

--- a/f5/bigip/tm/gtm/__init__.py
+++ b/f5/bigip/tm/gtm/__init__.py
@@ -30,6 +30,7 @@ REST Kind
 
 from f5.bigip.resource import OrganizingCollection
 from f5.bigip.tm.gtm.datacenter import Datacenters
+from f5.bigip.tm.gtm.pool import Pools
 from f5.bigip.tm.gtm.rule import Rules
 from f5.bigip.tm.gtm.server import Servers
 from f5.bigip.tm.gtm.wideip import Wideips
@@ -41,6 +42,7 @@ class Gtm(OrganizingCollection):
         super(Gtm, self).__init__(tm)
         self._meta_data['allowed_lazy_attributes'] = [
             Datacenters,
+            Pools,
             Rules,
             Servers,
             Wideips,

--- a/f5/bigip/tm/gtm/pool.py
+++ b/f5/bigip/tm/gtm/pool.py
@@ -1,0 +1,443 @@
+# coding=utf-8
+#
+#  Copyright 2014-2016 F5 Networks Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""BIG-IP® Global Traffic Manager™ (GTM®) pool module.
+
+REST URI
+    ``http://localhost/mgmt/tm/gtm/pool``
+
+GUI Path
+    ``DNS --> GSLB : Pools``
+
+REST Kind
+    ``tm:gtm:pools:*``
+"""
+
+from distutils.version import LooseVersion
+
+from f5.bigip.resource import Collection
+from f5.bigip.resource import OrganizingCollection
+from f5.bigip.resource import Resource
+
+
+class Pools(object):
+    """BIG-IP® GTM Pool factory
+
+       The GTM Pool factory object is used to provide a consistent user
+       experience across the SDK, while supporting the breaking changes in
+       the BIG-IP APIs.
+
+       Between the 11.x and 12.x releases of BIG-IP, the REST endpoint for
+       Pool changed from a Collection to an OrganizingCollection. The
+       result is that breaking changes occurred in the API.
+
+       This breakage led to a discussion on naming conventions because there
+       appeared to be a conflict now. For example, depending on your version,
+       only one of the following would work.
+
+       For 11.x,
+
+           tm.gtm.pools.pool.load(name='foo')
+
+       For 12.x,
+
+           tm.gtm.pools.a_s.a.load(name='foo')
+
+       but not both. To stick with a consistent user experience, we decided
+       to override the __new__ method to support both examples above. The SDK
+       automatically detects which one to use based on the BIG-IP you are
+       communicating with.
+       """
+    def __new__(cls, container):
+        tmos_v = container._meta_data['bigip']._meta_data['tmos_version']
+        if LooseVersion(tmos_v) < LooseVersion('12.0.0'):
+            return PoolCollection(container)
+        else:
+            return PoolOrganizingCollection(container)
+
+
+class Members_s(object):
+    """BIG-IP® GTM Members_s factory
+
+        The GTM Members_s factory is used here for code readability
+        and maintenance purposes, to allow us to stay in conventions already
+        set in this SDK, and at the same time accommodate changes between v11
+        and v12 versions of Members_s sub-collection
+        """
+    def __new__(cls, container):
+        tmos_v = container._meta_data['bigip']._meta_data['tmos_version']
+        if LooseVersion(tmos_v) < LooseVersion('12.0.0'):
+            return MembersCollection_v11(container)
+        else:
+            if isinstance(container, A):
+                return MembersCollectionA(container)
+            if isinstance(container, Aaaa):
+                return MembersCollectionAAAA(container)
+            if isinstance(container, Cname):
+                return MembersCollectionCname
+            if isinstance(container, Mx):
+                return MembersCollectionMx(container)
+            if isinstance(container, Naptr):
+                return MembersCollectionNaptr(container)
+            if isinstance(container, Srv):
+                return MembersCollectionSrv(container)
+
+
+class MembersCollection_v11(Collection):
+    """v11.x BIG-IP® GTM pool members sub-collection"""
+    def __init__(self, pool):
+        self.__class__.__name__ = 'Members_s'
+        super(MembersCollection_v11, self).__init__(pool)
+        self._meta_data['allowed_lazy_attributes'] = [Members]
+        self._meta_data['required_json_kind'] = \
+            'tm:gtm:pool:members:memberscollectionstate'
+        self._meta_data['attribute_registry'] = \
+            {'tm:gtm:pool:members:membersstate': Members}
+
+
+class MembersCollectionA(Collection):
+    """v12.x BIG-IP® GTM A pool members sub-collection"""
+    def __init__(self, pool):
+        self.__class__.__name__ = 'Members_s'
+        super(MembersCollectionA, self).__init__(pool)
+        self._meta_data['allowed_lazy_attributes'] = [Members]
+        self._meta_data['required_json_kind'] = \
+            'tm:gtm:pool:a:members:memberscollectionstate'
+        self._meta_data['attribute_registry'] = \
+            {'tm:gtm:pool:a:members:membersstate': Members}
+
+
+class MembersCollectionAAAA(Collection):
+    """v12.x BIG-IP® GTM AAAA pool members sub-collection"""
+    def __init__(self, pool):
+        self.__class__.__name__ = 'Members_s'
+        super(MembersCollectionAAAA, self).__init__(pool)
+        self._meta_data['allowed_lazy_attributes'] = [Members]
+        self._meta_data['required_json_kind'] = \
+            'tm:gtm:pool:aaaa:members:memberscollectionstate'
+        self._meta_data['attribute_registry'] = \
+            {'tm:gtm:pool:aaaa:members:membersstate': Members}
+
+
+class MembersCollectionCname(Collection):
+    """v12.x BIG-IP® GTM CNAME pool members sub-collection"""
+    def __init__(self, pool):
+        self.__class__.__name__ = 'Members_s'
+        super(MembersCollectionCname, self).__init__(pool)
+        self._meta_data['allowed_lazy_attributes'] = [Members]
+        self._meta_data['required_json_kind'] = \
+            'tm:gtm:pool:cname:members:memberscollectionstate'
+        self._meta_data['attribute_registry'] = \
+            {'tm:gtm:pool:cname:members:membersstate': Members}
+
+
+class MembersCollectionMx(Collection):
+    """v12.x BIG-IP® GTM MX pool members sub-collection"""
+    def __init__(self, pool):
+        self.__class__.__name__ = 'Members_s'
+        super(MembersCollectionMx, self).__init__(pool)
+        self._meta_data['allowed_lazy_attributes'] = [Members]
+        self._meta_data['required_json_kind'] = \
+            'tm:gtm:pool:mx:members:memberscollectionstate'
+        self._meta_data['attribute_registry'] = \
+            {'tm:gtm:pool:mx:members:membersstate': Members}
+
+
+class MembersCollectionNaptr(Collection):
+    """v12.x BIG-IP® GTM NAPTR pool members sub-collection"""
+    def __init__(self, pool):
+        self.__class__.__name__ = 'Members_s'
+        super(MembersCollectionNaptr, self).__init__(pool)
+        self._meta_data['allowed_lazy_attributes'] = [Members]
+        self._meta_data['required_json_kind'] = \
+            'tm:gtm:pool:naptr:members:memberscollectionstate'
+        self._meta_data['attribute_registry'] = \
+            {'tm:gtm:pool:naptr:members:membersstate': Members}
+
+
+class MembersCollectionSrv(Collection):
+    """v12.x BIG-IP® GTM SRV pool members sub-collection"""
+    def __init__(self, pool):
+        self.__class__.__name__ = 'Members_s'
+        super(MembersCollectionSrv, self).__init__(pool)
+        self._meta_data['allowed_lazy_attributes'] = [Members]
+        self._meta_data['required_json_kind'] = \
+            'tm:gtm:pool:srv:members:memberscollectionstate'
+        self._meta_data['attribute_registry'] = \
+            {'tm:gtm:pool:srv:members:membersstate': Members}
+
+
+class Members(object):
+    """BIG-IP® GTM Members factory
+
+        The GTM Members factory is used here for code readability
+        and maintenance purposes, to allow us to stay in conventions already
+        set in this SDK, and at the same time accommodate changes between v11
+        and v12 versions of Members resource
+        """
+
+    def __new__(cls, container):
+        if container._meta_data['required_json_kind'] == \
+                'tm:gtm:pool:members:memberscollectionstate':
+            return MembersResource_v11(container)
+        if container._meta_data['required_json_kind'] == \
+                'tm:gtm:pool:a:members:memberscollectionstate':
+            return MembersResourceA(container)
+        if container._meta_data['required_json_kind'] ==  \
+                'tm:gtm:pool:aaaa:members:memberscollectionstate':
+            return MembersResourceAAAA(container)
+        if container._meta_data['required_json_kind'] == \
+                'tm:gtm:pool:cname:members:memberscollectionstate':
+            return MembersResourceCname(container)
+        if container._meta_data['required_json_kind'] == \
+                'tm:gtm:pool:mx:members:memberscollectionstate':
+            return MembersResourceMx(container)
+        if container._meta_data['required_json_kind'] == \
+                'tm:gtm:pool:naptr:members:memberscollectionstate':
+            return MembersResourceNaptr(container)
+        if container._meta_data['required_json_kind'] == \
+                'tm:gtm:pool:srv:members:memberscollectionstate':
+            return MembersResourceSrv(container)
+
+
+class MembersResource_v11(Resource):
+    """v11.x BIG-IP® GTM members resource"""
+    def __init__(self, members_s):
+        self.__class__.__name__ = 'Members'
+        super(MembersResource_v11, self).__init__(members_s)
+        self._meta_data['required_creation_parameters'].update(('partition',))
+        self._meta_data['required_json_kind'] = \
+            'tm:gtm:pool:members:membersstate'
+
+
+class MembersResourceA(Resource):
+    """v12.x BIG-IP® GTM A pool members resource"""
+    def __init__(self, members_s):
+        self.__class__.__name__ = 'Members'
+        super(MembersResourceA, self).__init__(members_s)
+        self._meta_data['required_json_kind'] = \
+            'tm:gtm:pool:a:members:membersstate'
+        self._meta_data['required_creation_parameters'].update(('partition',))
+
+
+class MembersResourceAAAA(Resource):
+    """v12.x BIG-IP® GTM AAAA pool members resource"""
+    def __init__(self, members_s):
+        self.__class__.__name__ = 'Members'
+        super(MembersResourceAAAA, self).__init__(members_s)
+        self._meta_data['required_json_kind'] = \
+            'tm:gtm:pool:aaaa:members:membersstate'
+        self._meta_data['required_creation_parameters'].update(('partition',))
+
+
+class MembersResourceCname(Resource):
+    """v12.x BIG-IP® GTM CNAME pool members resource"""
+    def __init__(self, members_s):
+        self.__class__.__name__ = 'Members'
+        super(MembersResourceCname, self).__init__(members_s)
+        self._meta_data['required_json_kind'] = \
+            'tm:gtm:pool:cname:members:membersstate'
+
+
+class MembersResourceMx(Resource):
+    """v12.x BIG-IP® GTM MX pool members resource"""
+    def __init__(self, members_s):
+        self.__class__.__name__ = 'Members'
+        super(MembersResourceMx, self).__init__(members_s)
+        self._meta_data['required_json_kind'] = \
+            'tm:gtm:pool:mx:members:membersstate'
+
+
+class MembersResourceNaptr(Resource):
+    """v12.x BIG-IP® GTM NAPTR pool members resource"""
+    def __init__(self, members_s):
+        self.__class__.__name__ = 'Members'
+        super(MembersResourceNaptr, self).__init__(members_s)
+        self._meta_data['required_json_kind'] = \
+            'tm:gtm:pool:naptr:members:membersstate'
+        self._meta_data['required_creation_parameters'].update(
+            ('flags', 'service'))
+
+
+class MembersResourceSrv(Resource):
+    """v12.x BIG-IP® GTM SRV pool members resource"""
+    def __init__(self, members_s):
+        self.__class__.__name__ = 'Members'
+        super(MembersResourceSrv, self).__init__(members_s)
+        self._meta_data['required_json_kind'] = \
+            'tm:gtm:pool:srv:members:membersstate'
+        self._meta_data['required_creation_parameters'].update(
+            ('port',))
+
+
+class PoolCollection(Collection):
+    """v11.x BIG-IP® GTM pool collection"""
+    def __init__(self, gtm):
+        self.__class__.__name__ = 'Pools'
+        super(PoolCollection, self).__init__(gtm)
+        self._meta_data['allowed_lazy_attributes'] = [Pool]
+        self._meta_data['attribute_registry'] = \
+            {'tm:gtm:pool:poolstate': Pool}
+
+
+class Pool(Resource):
+    """v11.x BIG-IP® GTM pool resource"""
+    def __init__(self, pool_s):
+        super(Pool, self).__init__(pool_s)
+        self._meta_data['required_json_kind'] = 'tm:gtm:pool:poolstate'
+        self._meta_data['attribute_registry'] = {
+            'tm:gtm:pool:memberscollectionstate': Members_s
+        }
+
+
+class PoolOrganizingCollection(OrganizingCollection):
+    """v12.x GTM pool is an OC."""
+    def __init__(self, gtm):
+        self.__class__.__name__ = 'Pool'
+        super(PoolOrganizingCollection, self).__init__(gtm)
+        self._meta_data['allowed_lazy_attributes'] = [
+            A_s,
+            Aaaas,
+            Cnames,
+            Mxs,
+            Naptrs,
+            Srvs,
+            ]
+
+
+class A_s(Collection):
+    """v12.x BIG-IP® A pool collection.
+
+        Class name needed changing due to
+        'as' being reserved python keyword
+    """
+    def __init__(self, pool):
+        super(A_s, self).__init__(pool)
+        self._meta_data['allowed_lazy_attributes'] = [A]
+        self._meta_data['attribute_registry'] = \
+            {'tm:gtm:pool:a:astate': A}
+
+
+class A(Resource):
+    """v12.x BIG-IP®A pool resource"""
+    def __init__(self, _as):
+        super(A, self).__init__(_as)
+        self._meta_data['required_json_kind'] = \
+            'tm:gtm:pool:a:astate'
+        self._meta_data['attribute_registry'] = {
+            'tm:gtm:pool:a:members:memberscollectionstate': Members_s
+        }
+
+
+class Aaaas(Collection):
+    """v12.x BIG-IP® AAAA pool collection"""
+    def __init__(self, pool):
+        super(Aaaas, self).__init__(pool)
+        self._meta_data['allowed_lazy_attributes'] = [Aaaa]
+        self._meta_data['attribute_registry'] = \
+            {'tm:gtm:pool:aaaa:aaaastate': Aaaa}
+
+
+class Aaaa(Resource):
+    """v12.x BIG-IP® AAAA pool resource"""
+    def __init__(self, aaaas):
+        super(Aaaa, self).__init__(aaaas)
+        self._meta_data['required_json_kind'] = \
+            'tm:gtm:pool:aaaa:aaaastate'
+        self._meta_data['attribute_registry'] = {
+            'tm:gtm:pool:aaaa:members:memberscollectionstate': Members_s
+        }
+
+
+class Cnames(Collection):
+    """v12.x BIG-IP® CNAME pool collection"""
+    def __init__(self, pool):
+        super(Cnames, self).__init__(pool)
+        self._meta_data['allowed_lazy_attributes'] = [Cname]
+        self._meta_data['attribute_registry'] = \
+            {'tm:gtm:pool:cname:cnamestate': Cname}
+
+
+class Cname(Resource):
+    """v12.x BIG-IP® CNAME pool resource"""
+    def __init__(self, cnames):
+        super(Cname, self).__init__(cnames)
+        self._meta_data['required_json_kind'] = \
+            'tm:gtm:pool:cname:cnamestate'
+        self._meta_data['attribute_registry'] = {
+            'tm:gtm:pool:cname:members:memberscollectionstate': Members_s
+        }
+
+
+class Mxs(Collection):
+    """v12.x BIG-IP® MX pool collection."""
+    def __init__(self, pool):
+        super(Mxs, self).__init__(pool)
+        self._meta_data['allowed_lazy_attributes'] = [Mx]
+        self._meta_data['attribute_registry'] = \
+            {'tm:gtm:pool:mx:mxstate': Mx}
+
+
+class Mx(Resource):
+    """v12.x BIG-IP® MX pool resource"""
+    def __init__(self, mxs):
+        super(Mx, self).__init__(mxs)
+        self._meta_data['required_json_kind'] = \
+            'tm:gtm:pool:mx:mxstate'
+        self._meta_data['attribute_registry'] = {
+            'tm:gtm:pool:mx:members:memberscollectionstate': Members_s
+        }
+
+
+class Naptrs(Collection):
+    """v12.x BIG-IP® NAPTR pool collection"""
+    def __init__(self, pool):
+        super(Naptrs, self).__init__(pool)
+        self._meta_data['allowed_lazy_attributes'] = [Naptr]
+        self._meta_data['attribute_registry'] = \
+            {'tm:gtm:pool:naptr:naptrstate': Naptr}
+
+
+class Naptr(Resource):
+    """v12.x BIG-IP® NAPTR pool resource"""
+    def __init__(self, naptrs):
+        super(Naptr, self).__init__(naptrs)
+        self._meta_data['required_json_kind'] = \
+            'tm:gtm:pool:naptr:naptrstate'
+        self._meta_data['attribute_registry'] = {
+            'tm:gtm:pool:naptr:members:memberscollectionstate': Members_s
+        }
+
+
+class Srvs(Collection):
+    """v12.x BIG-IP® SRV pool collection"""
+    def __init__(self, pool):
+        super(Srvs, self).__init__(pool)
+        self._meta_data['allowed_lazy_attributes'] = [Srv]
+        self._meta_data['attribute_registry'] = \
+            {'tm:gtm:pool:srv:srvstate': Srv}
+
+
+class Srv(Resource):
+    """v12.x BIG-IP® SRV pool resource"""
+    def __init__(self, naptrs):
+        super(Srv, self).__init__(naptrs)
+        self._meta_data['required_json_kind'] = \
+            'tm:gtm:pool:srv:srvstate'
+        self._meta_data['attribute_registry'] = {
+            'tm:gtm:pool:srv:members:memberscollectionstate': Members_s
+        }

--- a/f5/bigip/tm/gtm/server.py
+++ b/f5/bigip/tm/gtm/server.py
@@ -1,0 +1,75 @@
+# coding=utf-8
+#
+#  Copyright 2014-2016 F5 Networks Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""BIG-IP® Global Traffic Manager™ (GTM®) pool module.
+
+REST URI
+    ``http://localhost/mgmt/tm/gtm/server``
+
+GUI Path
+    ``DNS --> GSLB : Servers``
+
+REST Kind
+    ``tm:gtm:server:*``
+"""
+
+from f5.bigip.resource import Collection
+from f5.bigip.resource import Resource
+
+
+class Servers(Collection):
+    """BIG-IP® GTM server collection"""
+    def __init__(self, gtm):
+        super(Servers, self).__init__(gtm)
+        self._meta_data['allowed_lazy_attributes'] = [Server]
+        self._meta_data['attribute_registry'] = \
+            {'tm:gtm:server:serverstate': Server}
+
+
+class Server(Resource):
+    """BIG-IP® GTM server resource"""
+    def __init__(self, servers):
+        super(Server, self).__init__(servers)
+        self._meta_data['required_json_kind'] = 'tm:gtm:server:serverstate'
+        self._meta_data['required_creation_parameters'].update(
+            ('datacenter', 'addresses'))
+        self._meta_data['attribute_registry'] = {
+            'tm:gtm:server:virtual-servers:virtual-serverscollectionstate':
+                Virtual_Servers_s
+        }
+
+
+class Virtual_Servers_s(Collection):
+    """BIG-IP® GTM virtual server sub-collection"""
+    def __init__(self, server):
+        super(Virtual_Servers_s, self).__init__(server)
+        self._meta_data['allowed_lazy_attributes'] = [Virtual_Servers]
+        self._meta_data['required_json_kind'] = \
+            'tm:gtm:server:virtual-servers:virtual-serverscollectionstate'
+        self._meta_data['attribute_registry'] = {
+            'tm:gtm:server:virtual-servers:virtual-serversstate':
+                Virtual_Servers}
+
+
+class Virtual_Servers(Resource):
+    """BIG-IP® GTM virtual server resource"""
+    def __init__(self, virtual_servers_s):
+        super(Virtual_Servers, self).__init__(virtual_servers_s)
+        self._meta_data['required_creation_parameters'].update((
+            'destination',))
+        self._meta_data['required_json_kind'] = \
+            'tm:gtm:server:virtual-servers:virtual-serversstate'

--- a/f5/bigip/tm/gtm/test/test_pool.py
+++ b/f5/bigip/tm/gtm/test/test_pool.py
@@ -1,0 +1,181 @@
+# Copyright 2015 F5 Networks Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import mock
+import pytest
+
+from f5.bigip import ManagementRoot
+from f5.bigip.resource import Collection
+from f5.bigip.resource import MissingRequiredCreationParameter
+from f5.bigip.resource import OrganizingCollection
+from f5.bigip.tm.gtm.pool import A
+from f5.bigip.tm.gtm.pool import Aaaa
+from f5.bigip.tm.gtm.pool import Cname
+from f5.bigip.tm.gtm.pool import Mx
+from f5.bigip.tm.gtm.pool import Naptr
+from f5.bigip.tm.gtm.pool import Pool
+from f5.bigip.tm.gtm.pool import PoolCollection
+from f5.bigip.tm.gtm.pool import Srv
+
+
+@pytest.fixture
+def FakePoolv11():
+    fake_gtm = mock.MagicMock()
+    fake_pool = PoolCollection(fake_gtm)
+    fake_pool._meta_data['bigip'].tmos_version = '11.6.0'
+    return fake_pool
+
+
+class TestPools(object):
+    def test_new_method_v11(self, fakeicontrolsession):
+        b = ManagementRoot('192.168.1.1', 'admin', 'admin')
+        p1 = b.tm.gtm.pools
+        assert isinstance(p1, Collection)
+        assert hasattr(p1, 'pool')
+        assert not hasattr(p1, 'a_s')
+        assert not hasattr(p1, 'aaaas')
+        assert not hasattr(p1, 'cnames')
+        assert not hasattr(p1, 'mxs')
+        assert not hasattr(p1, 'naptrs')
+        assert not hasattr(p1, 'srvs')
+
+    def test_new_method_v12(self, fakeicontrolsession_v12):
+        b = ManagementRoot('192.168.1.1', 'admin', 'admin')
+        p1 = b.tm.gtm.pools
+        assert isinstance(p1, OrganizingCollection)
+        assert not hasattr(p1, 'pool')
+        assert hasattr(p1, 'a_s')
+        assert hasattr(p1, 'aaaas')
+        assert hasattr(p1, 'cnames')
+        assert hasattr(p1, 'mxs')
+        assert hasattr(p1, 'naptrs')
+        assert hasattr(p1, 'srvs')
+
+
+class TestCreatev11(object):
+    def test_create_two_v11(self, fakeicontrolsession):
+        b = ManagementRoot('192.168.1.1', 'admin', 'admin')
+        p1 = b.tm.gtm.pools.pool
+        p2 = b.tm.gtm.pools.pool
+        assert p1 is not p2
+
+    def test_create_no_args_v11(self, FakePoolv11):
+        with pytest.raises(MissingRequiredCreationParameter):
+            FakePoolv11.pool.create()
+
+
+class TestCollectionv11(object):
+    def test_pool_attr_exists(self, fakeicontrolsession):
+        b = ManagementRoot('192.168.1.1', 'admin', 'admin')
+        p = b.tm.gtm.pools
+        test_meta = p._meta_data['attribute_registry']
+        test_meta2 = p._meta_data['allowed_lazy_attributes']
+        kind = 'tm:gtm:pool:poolstate'
+        assert kind in test_meta.keys()
+        assert Pool in test_meta2
+
+
+# Start v12.x Tests
+# Helper class to limit code repetition
+class HelperTest(object):
+    def __init__(self, collection_name):
+        self.partition = 'Common'
+        self.lowered = collection_name.lower()
+        self.test_name = 'fakepool_' + self.urielementname()
+        self.poolkinds = {'a': 'tm:gtm:pool:a:astate',
+                          'aaaa': 'tm:gtm:pool:aaaa:aaaastate',
+                          'cname': 'tm:gtm:pool:cname:cnamestate',
+                          'mx': 'tm:gtm:pool:mx:mxstate',
+                          'naptr': 'tm:gtm:pool:naptr:naptrstate',
+                          'srv': 'tm:gtm:pool:srv:srvstate'}
+
+    def urielementname(self):
+        if self.lowered[-2:] == '_s':
+            endind = 2
+        else:
+            endind = 1
+        return self.lowered[:-endind]
+
+    def set_resources(self, fakeicontrolsession_v12):
+        mr = ManagementRoot('192.168.1.1', 'admin', 'admin')
+        resourcecollection =\
+            getattr(getattr(getattr(mr.tm, 'gtm'), 'pools'),
+                    self.lowered)
+        resource1 = getattr(resourcecollection, self.urielementname())
+        resource2 = getattr(resourcecollection, self.urielementname())
+        return resource1, resource2
+
+    def set_collections(self, fakeicontrolsession_v12):
+        mr = ManagementRoot('192.168.1.1', 'admin', 'admin')
+        resourcecollection =\
+            getattr(getattr(getattr(mr.tm, 'gtm'), 'pools'),
+                    self.lowered)
+        return resourcecollection
+
+    def test_collections(self, fakeicontrolsession_v12, klass):
+        rc = self.set_collections(fakeicontrolsession_v12)
+        test_meta = rc._meta_data['attribute_registry']
+        test_meta2 = rc._meta_data['allowed_lazy_attributes']
+        kind = self.poolkinds[self.urielementname()]
+        assert kind in test_meta.keys()
+        assert klass in test_meta2
+
+    def test_create_two_v12(self, fakeicontrolsession_v12):
+        r1, r2, = self.set_resources(fakeicontrolsession_v12)
+        assert r1 is not r2
+
+    def test_create_no_args_v12(self, fakeicontrolsession_v12):
+        r1, r2, = self.set_resources(fakeicontrolsession_v12)
+        del r2
+        with pytest.raises(MissingRequiredCreationParameter):
+            r1.create()
+
+
+class Testv12(object):
+    def test_wideip_type_a(self, fakeicontrolsession_v12):
+        p = HelperTest('a_s')
+        p.test_collections(fakeicontrolsession_v12, A)
+        p.test_create_two_v12(fakeicontrolsession_v12)
+        p.test_create_no_args_v12(fakeicontrolsession_v12)
+
+    def test_wideip_type_aaaa(self, fakeicontrolsession_v12):
+        p = HelperTest('aaaas')
+        p.test_collections(fakeicontrolsession_v12, Aaaa)
+        p.test_create_two_v12(fakeicontrolsession_v12)
+        p.test_create_no_args_v12(fakeicontrolsession_v12)
+
+    def test_wideip_type_cname(self, fakeicontrolsession_v12):
+        p = HelperTest('cnames')
+        p.test_collections(fakeicontrolsession_v12, Cname)
+        p.test_create_two_v12(fakeicontrolsession_v12)
+        p.test_create_no_args_v12(fakeicontrolsession_v12)
+
+    def test_wideip_type_mx(self, fakeicontrolsession_v12):
+        p = HelperTest('Mxs')
+        p.test_collections(fakeicontrolsession_v12, Mx)
+        p.test_create_two_v12(fakeicontrolsession_v12)
+        p.test_create_no_args_v12(fakeicontrolsession_v12)
+
+    def test_wideip_type_naptr(self, fakeicontrolsession_v12):
+        p = HelperTest('Naptrs')
+        p.test_collections(fakeicontrolsession_v12, Naptr)
+        p.test_create_two_v12(fakeicontrolsession_v12)
+        p.test_create_no_args_v12(fakeicontrolsession_v12)
+
+    def test_wideip_type_srv(self, fakeicontrolsession_v12):
+        p = HelperTest('Srvs')
+        p.test_collections(fakeicontrolsession_v12, Srv)
+        p.test_create_two_v12(fakeicontrolsession_v12)
+        p.test_create_no_args_v12(fakeicontrolsession_v12)

--- a/f5/bigip/tm/gtm/test/test_server.py
+++ b/f5/bigip/tm/gtm/test/test_server.py
@@ -1,0 +1,70 @@
+# Copyright 2015 F5 Networks Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import mock
+import pytest
+
+from f5.bigip import ManagementRoot
+from f5.bigip.resource import MissingRequiredCreationParameter
+from f5.bigip.tm.gtm.server import Server
+from f5.bigip.tm.gtm.server import Virtual_Servers
+
+
+@pytest.fixture
+def FakeServer():
+    fake_servers = mock.MagicMock()
+    fake_server = Server(fake_servers)
+    return fake_server
+
+
+@pytest.fixture
+def FakeVS():
+    fake_server = mock.MagicMock()
+    fake_vs = Virtual_Servers(fake_server)
+    return fake_vs
+
+
+class TestCreate(object):
+    def test_create_two(self, fakeicontrolsession):
+        b = ManagementRoot('192.168.1.1', 'admin', 'admin')
+        s1 = b.tm.gtm.servers.server
+        s2 = b.tm.gtm.servers.server
+        assert s1 is not s2
+
+    def test_create_no_args(self, FakeServer):
+        with pytest.raises(MissingRequiredCreationParameter):
+            FakeServer.create()
+
+    def test_create_no_datacenter(self, FakeServer):
+        with pytest.raises(MissingRequiredCreationParameter):
+            FakeServer.create(name='fakeserver',
+                              addresses=[{'name': '1.1.1.1'}])
+
+    def test_create_no_address(self, FakeServer):
+        with pytest.raises(MissingRequiredCreationParameter):
+            FakeServer.create(name='fakeserver', datacenter='fakedc')
+
+
+class Test_VS_Subcoll(object):
+    def test_vs_attr_exists(self, fakeicontrolsession):
+        b = ManagementRoot('192.168.1.1', 'admin', 'admin')
+        s = b.tm.gtm.servers.server
+        test_meta = s._meta_data['attribute_registry']
+        kind = 'tm:gtm:server:virtual-servers:virtual-serverscollectionstate'
+        assert kind in test_meta.keys()
+
+    def test_create_no_args(self, FakeVS):
+        with pytest.raises(MissingRequiredCreationParameter):
+            FakeVS.create()

--- a/f5/bigip/tm/gtm/test/test_wideip.py
+++ b/f5/bigip/tm/gtm/test/test_wideip.py
@@ -1,0 +1,181 @@
+# Copyright 2015 F5 Networks Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import mock
+import pytest
+
+from f5.bigip import ManagementRoot
+from f5.bigip.resource import Collection
+from f5.bigip.resource import MissingRequiredCreationParameter
+from f5.bigip.resource import OrganizingCollection
+from f5.bigip.tm.gtm.wideip import A
+from f5.bigip.tm.gtm.wideip import Aaaa
+from f5.bigip.tm.gtm.wideip import Cname
+from f5.bigip.tm.gtm.wideip import Mx
+from f5.bigip.tm.gtm.wideip import Naptr
+from f5.bigip.tm.gtm.wideip import Srv
+from f5.bigip.tm.gtm.wideip import Wideip
+from f5.bigip.tm.gtm.wideip import WideipCollection
+
+
+@pytest.fixture
+def FakeWideipv11():
+    fake_gtm = mock.MagicMock()
+    fake_wideip = WideipCollection(fake_gtm)
+    fake_wideip._meta_data['bigip'].tmos_version = '11.6.0'
+    return fake_wideip
+
+
+class TestWideips(object):
+    def test_new_method_v11(self, fakeicontrolsession):
+        b = ManagementRoot('192.168.1.1', 'admin', 'admin')
+        w1 = b.tm.gtm.wideips
+        assert isinstance(w1, Collection)
+        assert hasattr(w1, 'wideip')
+        assert not hasattr(w1, 'a_s')
+        assert not hasattr(w1, 'aaaas')
+        assert not hasattr(w1, 'cnames')
+        assert not hasattr(w1, 'mxs')
+        assert not hasattr(w1, 'naptrs')
+        assert not hasattr(w1, 'srvs')
+
+    def test_new_method_v12(self, fakeicontrolsession_v12):
+        b = ManagementRoot('192.168.1.1', 'admin', 'admin')
+        w1 = b.tm.gtm.wideips
+        assert isinstance(w1, OrganizingCollection)
+        assert hasattr(w1, 'a_s')
+        assert hasattr(w1, 'aaaas')
+        assert hasattr(w1, 'cnames')
+        assert hasattr(w1, 'mxs')
+        assert hasattr(w1, 'naptrs')
+        assert hasattr(w1, 'srvs')
+        assert not hasattr(w1, 'wideip')
+
+
+class TestCreatev11(object):
+    def test_create_two_v11(self, fakeicontrolsession):
+        b = ManagementRoot('192.168.1.1', 'admin', 'admin')
+        w1 = b.tm.gtm.wideips.wideip
+        w2 = b.tm.gtm.wideips.wideip
+        assert w1 is not w2
+
+    def test_create_no_args_v11(self, FakeWideipv11):
+        with pytest.raises(MissingRequiredCreationParameter):
+            FakeWideipv11.wideip.create()
+
+
+class TestCollectionv11(object):
+    def test_wideip_attr_exists(self, fakeicontrolsession):
+        b = ManagementRoot('192.168.1.1', 'admin', 'admin')
+        w = b.tm.gtm.wideips
+        test_meta = w._meta_data['attribute_registry']
+        test_meta2 = w._meta_data['allowed_lazy_attributes']
+        kind = 'tm:gtm:wideip:wideipstate'
+        assert kind in test_meta.keys()
+        assert Wideip in test_meta2
+
+
+# Start v12.x Tests
+# Helper class to limit code repetition
+class HelperTest(object):
+    def __init__(self, collection_name):
+        self.lowered = collection_name.lower()
+        self.kinds = {'a': 'tm:gtm:wideip:a:astate',
+                      'aaaa': 'tm:gtm:wideip:aaaa:aaaastate',
+                      'cname': 'tm:gtm:wideip:cname:cnamestate',
+                      'mx': 'tm:gtm:wideip:mx:mxstate',
+                      'naptr': 'tm:gtm:wideip:naptr:naptrstate',
+                      'srv': 'tm:gtm:wideip:srv:srvstate'}
+
+    def urielementname(self):
+        if self.lowered[-2:] == '_s':
+            endind = 2
+        else:
+            endind = 1
+        return self.lowered[:-endind]
+
+    def set_resources(self, fakeicontrolsession_v12):
+        mr = ManagementRoot('192.168.1.1', 'admin', 'admin')
+        b = mr.tm
+        resourcecollection =\
+            getattr(getattr(getattr(b, 'gtm'), 'wideips'),
+                    self.lowered)
+        resource1 = getattr(resourcecollection, self.urielementname())
+        resource2 = getattr(resourcecollection, self.urielementname())
+        return resource1, resource2
+
+    def set_collections(self, fakeicontrolsession_v12):
+        mr = ManagementRoot('192.168.1.1', 'admin', 'admin')
+        b = mr.tm
+        resourcecollection =\
+            getattr(getattr(getattr(b, 'gtm'), 'wideips'),
+                    self.lowered)
+        return resourcecollection
+
+    def test_collections(self, fakeicontrolsession_v12, klass):
+        rc = self.set_collections(fakeicontrolsession_v12)
+        test_meta = rc._meta_data['attribute_registry']
+        test_meta2 = rc._meta_data['allowed_lazy_attributes']
+        kind = self.kinds[self.urielementname()]
+        assert kind in test_meta.keys()
+        assert klass in test_meta2
+
+    def test_create_two_v12(self, fakeicontrolsession_v12):
+        r1, r2, = self.set_resources(fakeicontrolsession_v12)
+        assert r1 is not r2
+
+    def test_create_no_args_v12(self, fakeicontrolsession_v12):
+        r1, r2, = self.set_resources(fakeicontrolsession_v12)
+        del r2
+        with pytest.raises(MissingRequiredCreationParameter):
+            r1.create()
+
+
+class Testv12(object):
+    def test_wideip_type_a(self, fakeicontrolsession_v12):
+        w = HelperTest('a_s')
+        w.test_collections(fakeicontrolsession_v12, A)
+        w.test_create_two_v12(fakeicontrolsession_v12)
+        w.test_create_no_args_v12(fakeicontrolsession_v12)
+
+    def test_wideip_type_aaaa(self, fakeicontrolsession_v12):
+        w = HelperTest('aaaas')
+        w.test_collections(fakeicontrolsession_v12, Aaaa)
+        w.test_create_two_v12(fakeicontrolsession_v12)
+        w.test_create_no_args_v12(fakeicontrolsession_v12)
+
+    def test_wideip_type_cname(self, fakeicontrolsession_v12):
+        w = HelperTest('cnames')
+        w.test_collections(fakeicontrolsession_v12, Cname)
+        w.test_create_two_v12(fakeicontrolsession_v12)
+        w.test_create_no_args_v12(fakeicontrolsession_v12)
+
+    def test_wideip_type_mx(self, fakeicontrolsession_v12):
+        w = HelperTest('Mxs')
+        w.test_collections(fakeicontrolsession_v12, Mx)
+        w.test_create_two_v12(fakeicontrolsession_v12)
+        w.test_create_no_args_v12(fakeicontrolsession_v12)
+
+    def test_wideip_type_naptr(self, fakeicontrolsession_v12):
+        w = HelperTest('Naptrs')
+        w.test_collections(fakeicontrolsession_v12, Naptr)
+        w.test_create_two_v12(fakeicontrolsession_v12)
+        w.test_create_no_args_v12(fakeicontrolsession_v12)
+
+    def test_wideip_type_srv(self, fakeicontrolsession_v12):
+        w = HelperTest('Srvs')
+        w.test_collections(fakeicontrolsession_v12, Srv)
+        w.test_create_two_v12(fakeicontrolsession_v12)
+        w.test_create_no_args_v12(fakeicontrolsession_v12)

--- a/f5/bigip/tm/gtm/wideip.py
+++ b/f5/bigip/tm/gtm/wideip.py
@@ -1,0 +1,208 @@
+# coding=utf-8
+#
+#  Copyright 2014-2016 F5 Networks Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""BIG-IP® Global Traffic Manager™ (GTM®) pool module.
+
+REST URI
+    ``http://localhost/mgmt/tm/gtm/wideip``
+
+GUI Path
+    ``DNS --> GSLB : Wide IPs``
+
+REST Kind
+    ``tm:gtm:pools:*``
+"""
+
+from distutils.version import LooseVersion
+
+from f5.bigip.resource import Collection
+from f5.bigip.resource import OrganizingCollection
+from f5.bigip.resource import Resource
+
+
+class Wideips(object):
+    """BIG-IP® GTM WideIP factory
+
+       The GTM WideIP factory object is used to provide a consistent user
+       experience across the SDK, while supporting the breaking changes in
+       the BIG-IP APIs.
+
+       Between the 11.x and 12.x releases of BIG-IP, the REST endpoint for
+       WideIP changed from a Collection to an OrganizingCollection. The result
+       is that breaking changes occurred in the API.
+
+       This breakage led to a discussion on naming conventions because there
+       appeared to be a conflict now. For example, depending on your version,
+       only one of the following would work.
+
+       For 11.x,
+
+           tm.gtm.wideips.wideip.load(name='foo')
+
+       For 12.x,
+
+           tm.gtm.wideips.a_s.a.load(name='foo')
+
+       but not both. To stick with a consistent user experience, we decided
+       to override the __new__ method to support both examples above. The SDK
+       automatically detects which one to use based on the BIG-IP you are
+       communicating with.
+       """
+    def __new__(cls, container):
+        tmos_v = container._meta_data['bigip']._meta_data['tmos_version']
+        if LooseVersion(tmos_v) < LooseVersion('12.0.0'):
+            return WideipCollection(container)
+        else:
+            return WideipOrganizingCollection(container)
+
+
+class WideipOrganizingCollection(OrganizingCollection):
+    """v12.x GTM WideIP is an OC."""
+    def __init__(self, gtm):
+        self.__class__.__name__ = 'Wideip'
+        super(WideipOrganizingCollection, self).__init__(gtm)
+        self._meta_data['allowed_lazy_attributes'] = [
+            A_s,
+            Aaaas,
+            Cnames,
+            Mxs,
+            Naptrs,
+            Srvs,
+            ]
+
+
+class A_s(Collection):
+    """v12.x BIG-IP® A wideip collection.
+
+        Class name needed changing due to
+        'as' being reserved python keyword
+    """
+    def __init__(self, wideip):
+        super(A_s, self).__init__(wideip)
+        self._meta_data['allowed_lazy_attributes'] = [A]
+        self._meta_data['attribute_registry'] = \
+            {'tm:gtm:wideip:a:astate': A}
+
+
+class A(Resource):
+    """v12.x BIG-IP®A wideip resource"""
+    def __init__(self, _as):
+        super(A, self).__init__(_as)
+        self._meta_data['required_json_kind'] = \
+            'tm:gtm:wideip:a:astate'
+
+
+class Aaaas(Collection):
+    """v12.x BIG-IP® AAAA wideip collection"""
+    def __init__(self, wideip):
+        super(Aaaas, self).__init__(wideip)
+        self._meta_data['allowed_lazy_attributes'] = [Aaaa]
+        self._meta_data['attribute_registry'] = \
+            {'tm:gtm:wideip:aaaa:aaaastate': Aaaa}
+
+
+class Aaaa(Resource):
+    """v12.x BIG-IP® AAAA wideip resource"""
+    def __init__(self, aaaas):
+        super(Aaaa, self).__init__(aaaas)
+        self._meta_data['required_json_kind'] = \
+            'tm:gtm:wideip:aaaa:aaaastate'
+
+
+class Cnames(Collection):
+    """v12.x BIG-IP® CNAME wideip collection"""
+    def __init__(self, wideip):
+        super(Cnames, self).__init__(wideip)
+        self._meta_data['allowed_lazy_attributes'] = [Cname]
+        self._meta_data['attribute_registry'] = \
+            {'tm:gtm:wideip:cname:cnamestate': Cname}
+
+
+class Cname(Resource):
+    """v12.x BIG-IP® CNAME wideip resource"""
+    def __init__(self, cnames):
+        super(Cname, self).__init__(cnames)
+        self._meta_data['required_json_kind'] = \
+            'tm:gtm:wideip:cname:cnamestate'
+
+
+class Mxs(Collection):
+    """v12.x BIG-IP® MX wideip collection."""
+    def __init__(self, wideip):
+        super(Mxs, self).__init__(wideip)
+        self._meta_data['allowed_lazy_attributes'] = [Mx]
+        self._meta_data['attribute_registry'] = \
+            {'tm:gtm:wideip:mx:mxstate': Mx}
+
+
+class Mx(Resource):
+    """v12.x BIG-IP® MX wideip resource"""
+    def __init__(self, mxs):
+        super(Mx, self).__init__(mxs)
+        self._meta_data['required_json_kind'] = \
+            'tm:gtm:wideip:mx:mxstate'
+
+
+class Naptrs(Collection):
+    """v12.x BIG-IP® NAPTR wideip collection"""
+    def __init__(self, wideip):
+        super(Naptrs, self).__init__(wideip)
+        self._meta_data['allowed_lazy_attributes'] = [Naptr]
+        self._meta_data['attribute_registry'] = \
+            {'tm:gtm:wideip:naptr:naptrstate': Naptr}
+
+
+class Naptr(Resource):
+    """v12.x BIG-IP® NAPTR wideip resource"""
+    def __init__(self, naptrs):
+        super(Naptr, self).__init__(naptrs)
+        self._meta_data['required_json_kind'] = \
+            'tm:gtm:wideip:naptr:naptrstate'
+
+
+class Srvs(Collection):
+    """v12.x BIG-IP® SRV wideip collection"""
+    def __init__(self, wideip):
+        super(Srvs, self).__init__(wideip)
+        self._meta_data['allowed_lazy_attributes'] = [Srv]
+        self._meta_data['attribute_registry'] = \
+            {'tm:gtm:wideip:srv:srvstate': Srv}
+
+
+class Srv(Resource):
+    """v12.x BIG-IP® SRV wideip resource"""
+    def __init__(self, naptrs):
+        super(Srv, self).__init__(naptrs)
+        self._meta_data['required_json_kind'] = \
+            'tm:gtm:wideip:srv:srvstate'
+
+
+class WideipCollection(Collection):
+    """v11.x BIG-IP® GTM wideip collection"""
+    def __init__(self, gtm):
+        self.__class__.__name__ = 'Wideips'
+        super(WideipCollection, self).__init__(gtm)
+        self._meta_data['allowed_lazy_attributes'] = [Wideip]
+        self._meta_data['attribute_registry'] = \
+            {'tm:gtm:wideip:wideipstate': Wideip}
+
+
+class Wideip(Resource):
+    """v11.x BIG-IP® GTM pool resource"""
+    def __init__(self, wideips):
+        super(Wideip, self).__init__(wideips)
+        self._meta_data['required_json_kind'] = 'tm:gtm:wideip:wideipstate'

--- a/test/functional/tm/gtm/test_pool.py
+++ b/test/functional/tm/gtm/test_pool.py
@@ -1,0 +1,814 @@
+# Copyright 2015 F5 Networks Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+import copy
+from distutils.version import LooseVersion
+from f5.bigip.tm.gtm.pool import A
+from f5.bigip.tm.gtm.pool import Aaaa
+from f5.bigip.tm.gtm.pool import Cname
+from f5.bigip.tm.gtm.pool import MembersResource_v11
+from f5.bigip.tm.gtm.pool import MembersResourceA
+from f5.bigip.tm.gtm.pool import MembersResourceAAAA
+from f5.bigip.tm.gtm.pool import MembersResourceCname
+from f5.bigip.tm.gtm.pool import MembersResourceMx
+from f5.bigip.tm.gtm.pool import MembersResourceNaptr
+from f5.bigip.tm.gtm.pool import MembersResourceSrv
+from f5.bigip.tm.gtm.pool import Mx
+from f5.bigip.tm.gtm.pool import Naptr
+from f5.bigip.tm.gtm.pool import Pool
+from f5.bigip.tm.gtm.pool import Srv
+from pprint import pprint as pp
+import pytest
+from requests.exceptions import HTTPError
+pp(__file__)
+
+
+GTM_SERVER = 'fake_serv1'
+GTM_VS = 'fakeVS'
+RES_NAME = GTM_SERVER + ':' + GTM_VS
+WIDEIPNAME = 'fake.wide.net'
+TESTDESCRIPTION = "TESTDESCRIPTION"
+
+# Dependencies setup to be shared between v11 and v12 tests
+
+
+def delete_gtm_server(mgmt_root, name):
+    try:
+        foo = mgmt_root.tm.gtm.servers.server.load(
+            name=name)
+    except HTTPError as err:
+        if err.response.status_code != 404:
+            raise
+        return
+    foo.delete()
+
+
+def delete_dc(mgmt_root, name, partition):
+    try:
+        delete_gtm_server(mgmt_root, GTM_SERVER)
+        foo = mgmt_root.tm.gtm.datacenters.datacenter.load(
+            name=name, partition=partition
+        )
+    except HTTPError as err:
+        if err.response.status_code != 404:
+            raise
+        return
+    foo.delete()
+
+
+def create_dc(request, mgmt_root, name, partition):
+    def teardown():
+        delete_dc(mgmt_root, name, partition)
+
+    dc = mgmt_root.tm.gtm.datacenters.datacenter.create(
+        name=name, partition=partition)
+    request.addfinalizer(teardown)
+    return dc
+
+
+def setup_gtm_server(request, mgmt_root, name, partition, **kwargs):
+    def teardown():
+        delete_gtm_server(mgmt_root, name)
+
+    dc = create_dc(request, mgmt_root, 'dc1', partition)
+    serv1 = mgmt_root.tm.gtm.servers.server.create(
+        name=name, datacenter=dc.name,
+        **kwargs)
+    request.addfinalizer(teardown)
+    return serv1
+
+
+def delete_gtm_vs(mgmt_root, name):
+    s1 = mgmt_root.tm.gtm.servers.server.load(name=GTM_SERVER)
+    try:
+        foo = s1.virtual_servers_s.virtual_servers.load(
+            name=name)
+    except HTTPError as err:
+        if err.response.status_code != 404:
+            raise
+        return
+    foo.delete()
+
+
+def setup_gtm_vs(request, mgmt_root, name, destination, **kwargs):
+    def teardown():
+        delete_gtm_vs(mgmt_root, name)
+
+    s1 = setup_gtm_server(request, mgmt_root, GTM_SERVER, 'Common', **kwargs)
+    vs = s1.virtual_servers_s.virtual_servers.create(
+        name=name, destination=destination)
+    request.addfinalizer(teardown)
+    return vs
+
+
+def delete_wideip_v12(mgmt_root, name):
+    try:
+        foo = mgmt_root.tm.gtm.wideips.a_s.a.load(
+            name=name)
+    except HTTPError as err:
+        if err.response.status_code != 404:
+            raise
+        return
+    foo.delete()
+
+
+def setup_wideip_v12(request, mgmt_root, name, **kwargs):
+    def teardown():
+        delete_wideip_v12(mgmt_root, name)
+
+    wideip1 = mgmt_root.tm.gtm.wideips.a_s.a.create(
+        name=name, **kwargs)
+    request.addfinalizer(teardown)
+    return wideip1
+
+
+# Start of V12.x Tests here
+
+
+# Helper class to limit code repetition
+class HelperTest(object):
+    def __init__(self, collection_name):
+        self.partition = 'Common'
+        self.lowered = collection_name.lower()
+        self.test_name = 'fakepool_' + self.urielementname()
+        self.poolkinds = {'a': 'tm:gtm:pool:a:astate',
+                          'aaaa': 'tm:gtm:pool:aaaa:aaaastate',
+                          'cname': 'tm:gtm:pool:cname:cnamestate',
+                          'mx': 'tm:gtm:pool:mx:mxstate',
+                          'naptr': 'tm:gtm:pool:naptr:naptrstate',
+                          'srv': 'tm:gtm:pool:srv:srvstate'}
+        self.memkinds = {'a': 'tm:gtm:pool:a:members:membersstate',
+                         'aaaa': 'tm:gtm:pool:aaaa:members:membersstate',
+                         'cname': 'tm:gtm:pool:cname:members:membersstate',
+                         'mx': 'tm:gtm:pool:mx:members:membersstate',
+                         'naptr': 'tm:gtm:pool:naptr:members:membersstate',
+                         'srv': 'tm:gtm:pool:srv:members:membersstate'}
+
+    def urielementname(self):
+        if self.lowered[-2:] == '_s':
+            endind = 2
+        else:
+            endind = 1
+        return self.lowered[:-endind]
+
+    def delete_resource(self, resource):
+        try:
+            foo = resource.load(name=self.test_name, partition=self.partition)
+        except HTTPError as err:
+            if err.response.status_code != 404:
+                raise
+            return
+        foo.delete()
+
+    def setup_test(self, request, mgmt_root, **kwargs):
+        def teardown():
+            self.delete_resource(resource)
+
+        resourcecollection =\
+            getattr(getattr(getattr(mgmt_root.tm, 'gtm'), 'pools'),
+                    self.lowered)
+        resource = getattr(resourcecollection, self.urielementname())
+        self.delete_resource(resource)
+        created = resource.create(name=self.test_name,
+                                  partition=self.partition,
+                                  **kwargs)
+        request.addfinalizer(teardown)
+        return created, resourcecollection
+
+    def test_MCURDL(self, request, mgmt_root, **kwargs):
+        # Testing create
+        pool, rescollection = self.setup_test(request, mgmt_root, **kwargs)
+        assert pool.name == self.test_name
+        assert pool.fullPath == '/Common/'+self.test_name
+        assert pool.generation and isinstance(pool.generation, int)
+        assert pool.kind == self.poolkinds[self.urielementname()]
+
+        # Testing update
+        pool.description = TESTDESCRIPTION
+        pp(pool.raw)
+        pool.update()
+        if hasattr(pool, 'description'):
+            assert pool.description == TESTDESCRIPTION
+
+        # Testing refresh
+        pool.description = ''
+        pool.refresh()
+        if hasattr(pool, 'description'):
+            assert pool.description == TESTDESCRIPTION
+
+        # Testing modify
+        meta_data = pool.__dict__.pop('_meta_data')
+        start_dict = copy.deepcopy(pool.__dict__)
+        pool.__dict__['_meta_data'] = meta_data
+        pool.modify(description='MODIFIED')
+        desc = 'description'
+        for k, v in pool.__dict__.items():
+            if k != desc:
+                start_dict[k] = pool.__dict__[k]
+                assert getattr(pool, k) == start_dict[k]
+            elif k == desc:
+                assert getattr(pool, desc) == 'MODIFIED'
+
+        # Testing load
+        p2 = getattr(rescollection, self.urielementname())
+        pool2 = p2.load(partition=self.partition, name=self.test_name)
+        assert pool.selfLink == pool2.selfLink
+
+    def test_collection(self, request, mgmt_root, **kwargs):
+        pool, rescollection = self.setup_test(request, mgmt_root, **kwargs)
+        assert pool.name == self.test_name
+        assert pool.fullPath == '/Common/'+self.test_name
+        assert pool.generation and isinstance(pool.generation, int)
+        assert pool.kind == self.poolkinds[self.urielementname()]
+
+        coll = rescollection.get_collection()
+        assert isinstance(coll, list)
+        assert len(coll)
+        if self.lowered == 'a_s':
+            assert isinstance(coll[0], A)
+        elif self.lowered == 'aaaas':
+            assert isinstance(coll[0], Aaaa)
+        elif self.lowered == 'cnames':
+            assert isinstance(coll[0], Cname)
+        elif self.lowered == 'mxs':
+            assert isinstance(coll[0], Mx)
+        elif self.lowered == 'naptrs':
+            assert isinstance(coll[0], Naptr)
+        elif self.lowered == 'srvs':
+            assert isinstance(coll[0], Srv)
+
+    def setup_members_test(self, request, mgmt_root, **kwargs):
+        pool, rescollection = self.setup_test(request, mgmt_root, **kwargs)
+        mem_coll = pool.members_s
+        if isinstance(pool, A):
+            setup_gtm_vs(request, mgmt_root, GTM_VS, '20.20.20.20:80',
+                         addresses=[{'name': '1.1.1.1'}])
+            member = mem_coll.members.create(name=RES_NAME,
+                                             partition=self.partition)
+        elif isinstance(pool, Aaaa):
+            setup_gtm_vs(request, mgmt_root, GTM_VS,
+                         'fd00:7967:71a5::.80',
+                         addresses=[{'name': 'fda8:e5d6:5ef6::'}])
+            member = mem_coll.members.create(name=RES_NAME,
+                                             partition=self.partition)
+        elif isinstance(pool, Cname) or isinstance(pool, Mx):
+            setup_wideip_v12(request, mgmt_root, WIDEIPNAME,
+                             partition=self.partition)
+            member = mem_coll.members.create(name=WIDEIPNAME)
+        elif isinstance(pool, Naptr):
+            setup_wideip_v12(request, mgmt_root, WIDEIPNAME,
+                             partition=self.partition)
+            member = mem_coll.members.create(name=WIDEIPNAME,
+                                             flags='a', service='http')
+        elif isinstance(pool, Srv):
+            setup_wideip_v12(request, mgmt_root, WIDEIPNAME,
+                             partition=self.partition)
+            member = mem_coll.members.create(name=WIDEIPNAME, port=80)
+
+        return member, mem_coll, member.name
+
+    def test_members_MCURDL(self, request, mgmt_root, **kwargs):
+        # Testing create
+        member, rescollection, name = self.setup_members_test(
+            request, mgmt_root, **kwargs)
+        assert member.name == name
+        assert member.generation and isinstance(member.generation, int)
+        assert member.kind == self.memkinds[self.urielementname()]
+
+        # Testing update
+        member.description = TESTDESCRIPTION
+        pp(member.raw)
+        member.update()
+        if hasattr(member, 'description'):
+            assert member.description == TESTDESCRIPTION
+
+        # Testing refresh
+        member.description = ''
+        member.refresh()
+        if hasattr(member, 'description'):
+            assert member.description == TESTDESCRIPTION
+
+        # Testing modify
+        meta_data = member.__dict__.pop('_meta_data')
+        start_dict = copy.deepcopy(member.__dict__)
+        member.__dict__['_meta_data'] = meta_data
+        member.modify(description='MODIFIED')
+        desc = 'description'
+        for k, v in member.__dict__.items():
+            if k != desc:
+                start_dict[k] = member.__dict__[k]
+                assert getattr(member, k) == start_dict[k]
+            elif k == desc:
+                assert getattr(member, desc) == 'MODIFIED'
+
+    def test_members_sucollection(self, request, mgmt_root, **kwargs):
+        member, rescollection, name = self.setup_members_test(
+            request, mgmt_root, **kwargs)
+        assert member.name == name
+        assert member.generation and isinstance(member.generation, int)
+        assert member.kind == self.memkinds[self.urielementname()]
+
+        coll = rescollection.get_collection()
+        assert isinstance(coll, list)
+        assert len(coll)
+        if self.lowered == 'a_s':
+            assert isinstance(coll[0], MembersResourceA)
+            assert rescollection.kind == \
+                'tm:gtm:pool:a:members:memberscollectionstate'
+        elif self.lowered == 'aaaas':
+            assert isinstance(coll[0], MembersResourceAAAA)
+            assert rescollection.kind == \
+                'tm:gtm:pool:aaaa:members:memberscollectionstate'
+        elif self.lowered == 'cnames':
+            assert isinstance(coll[0], MembersResourceCname)
+            assert rescollection.kind == \
+                'tm:gtm:pool:cname:members:memberscollectionstate'
+        elif self.lowered == 'mxs':
+            assert isinstance(coll[0], MembersResourceMx)
+            assert rescollection.kind == \
+                'tm:gtm:pool:mx:members:memberscollectionstate'
+        elif self.lowered == 'naptrs':
+            assert isinstance(coll[0], MembersResourceNaptr)
+            assert rescollection.kind == \
+                'tm:gtm:pool:naptr:members:memberscollectionstate'
+        elif self.lowered == 'srvs':
+            assert isinstance(coll[0], MembersResourceSrv)
+            assert rescollection.kind == \
+                'tm:gtm:pool:srv:members:memberscollectionstate'
+
+
+@pytest.mark.skipif(
+    LooseVersion(pytest.config.getoption('--release')) < LooseVersion(
+        '12.0.0'),
+    reason='This collection exists on 12.0.0 or greater.'
+)
+class TestPoolAtype(object):
+    def test_MCURDL(self, request, mgmt_root):
+        pool = HelperTest('A_s')
+        pool.test_MCURDL(request, mgmt_root)
+
+    def test_collection(self, request, mgmt_root):
+        pool = HelperTest('A_s')
+        pool.test_collection(request, mgmt_root)
+
+
+@pytest.mark.skipif(
+    LooseVersion(pytest.config.getoption('--release')) < LooseVersion(
+        '12.0.0'),
+    reason='This collection exists on 12.0.0 or greater.'
+)
+class TestPoolATypeSubcollMembers(object):
+    def test_MCURDL(self, request, mgmt_root):
+        pool = HelperTest('A_s')
+        pool.test_members_MCURDL(request, mgmt_root)
+
+    def test_collection(self, request, mgmt_root):
+        pool = HelperTest('A_s')
+        pool.test_members_sucollection(request, mgmt_root)
+
+
+@pytest.mark.skipif(
+    LooseVersion(pytest.config.getoption('--release')) < LooseVersion(
+        '12.0.0'),
+    reason='This collection exists on 12.0.0 or greater.'
+)
+class TestPoolAAAAtype(object):
+    def test_MCURDL(self, request, mgmt_root):
+        pool = HelperTest('Aaaas')
+        pool.test_MCURDL(request, mgmt_root)
+
+    def test_collection(self, request, mgmt_root):
+        pool = HelperTest('Aaaas')
+        pool.test_collection(request, mgmt_root)
+
+
+@pytest.mark.skipif(
+    LooseVersion(pytest.config.getoption('--release')) < LooseVersion(
+        '12.0.0'),
+    reason='This collection exists on 12.0.0 or greater.'
+)
+class TestPoolAAAATypeSubcollMembers(object):
+    def test_MCURDL(self, request, mgmt_root):
+        pool = HelperTest('Aaaas')
+        pool.test_members_MCURDL(request, mgmt_root)
+
+    def test_collection(self, request, mgmt_root):
+        pool = HelperTest('Aaaas')
+        pool.test_members_sucollection(request, mgmt_root)
+
+
+@pytest.mark.skipif(
+    LooseVersion(pytest.config.getoption('--release')) < LooseVersion(
+        '12.0.0'),
+    reason='This collection exists on 12.0.0 or greater.'
+)
+class TestPoolCnametype(object):
+    def test_MCURDL(self, request, mgmt_root):
+        pool = HelperTest('Cnames')
+        pool.test_MCURDL(request, mgmt_root)
+
+    def test_collection(self, request, mgmt_root):
+        pool = HelperTest('Cnames')
+        pool.test_collection(request, mgmt_root)
+
+
+@pytest.mark.skipif(
+    LooseVersion(pytest.config.getoption('--release')) < LooseVersion(
+        '12.0.0'),
+    reason='This collection exists on 12.0.0 or greater.'
+)
+class TestPoolCnameTypeSubcollMembers(object):
+    def test_MCURDL(self, request, mgmt_root):
+        pool = HelperTest('Cnames')
+        pool.test_members_MCURDL(request, mgmt_root)
+
+    def test_collection(self, request, mgmt_root):
+        pool = HelperTest('Cnames')
+        pool.test_members_sucollection(request, mgmt_root)
+
+
+@pytest.mark.skipif(
+    LooseVersion(pytest.config.getoption('--release')) < LooseVersion(
+        '12.0.0'),
+    reason='This collection exists on 12.0.0 or greater.'
+)
+class TestPoolMxstype(object):
+    def test_MCURDL(self, request, mgmt_root):
+        pool = HelperTest('Mxs')
+        pool.test_MCURDL(request, mgmt_root)
+
+    def test_collection(self, request, mgmt_root):
+        pool = HelperTest('Mxs')
+        pool.test_collection(request, mgmt_root)
+
+
+@pytest.mark.skipif(
+    LooseVersion(pytest.config.getoption('--release')) < LooseVersion(
+        '12.0.0'),
+    reason='This collection exists on 12.0.0 or greater.'
+)
+class TestPoolMxsTypeSubcollMembers(object):
+    def test_MCURDL(self, request, mgmt_root):
+        pool = HelperTest('Mxs')
+        pool.test_members_MCURDL(request, mgmt_root)
+
+    def test_collection(self, request, mgmt_root):
+        pool = HelperTest('Mxs')
+        pool.test_members_sucollection(request, mgmt_root)
+
+
+@pytest.mark.skipif(
+    LooseVersion(pytest.config.getoption('--release')) < LooseVersion(
+        '12.0.0'),
+    reason='This collection exists on 12.0.0 or greater.'
+)
+class TestPoolNaptrtype(object):
+    def test_MCURDL(self, request, mgmt_root):
+        pool = HelperTest('Naptrs')
+        pool.test_MCURDL(request, mgmt_root)
+
+    def test_collection(self, request, mgmt_root):
+        pool = HelperTest('Naptrs')
+        pool.test_collection(request, mgmt_root)
+
+
+@pytest.mark.skipif(
+    LooseVersion(pytest.config.getoption('--release')) < LooseVersion(
+        '12.0.0'),
+    reason='This collection exists on 12.0.0 or greater.'
+)
+class TestPoolNaptrTypeSubcollMembers(object):
+    def test_MCURDL(self, request, mgmt_root):
+        pool = HelperTest('Naptrs')
+        pool.test_members_MCURDL(request, mgmt_root)
+
+    def test_collection(self, request, mgmt_root):
+        pool = HelperTest('Naptrs')
+        pool.test_members_sucollection(request, mgmt_root)
+
+
+@pytest.mark.skipif(
+    LooseVersion(pytest.config.getoption('--release')) < LooseVersion(
+        '12.0.0'),
+    reason='This collection exists on 12.0.0 or greater.'
+)
+class TestPooSrvAtype(object):
+    def test_MCURDL(self, request, mgmt_root):
+        pool = HelperTest('Srvs')
+        pool.test_MCURDL(request, mgmt_root)
+
+    def test_collection(self, request, mgmt_root):
+        pool = HelperTest('Srvs')
+        pool.test_collection(request, mgmt_root)
+
+
+@pytest.mark.skipif(
+    LooseVersion(pytest.config.getoption('--release')) < LooseVersion(
+        '12.0.0'),
+    reason='This collection exists on 12.0.0 or greater.'
+)
+class TestPoolSrvTypeSubcollMembers(object):
+    def test_MCURDL(self, request, mgmt_root):
+        pool = HelperTest('Srvs')
+        pool.test_members_MCURDL(request, mgmt_root)
+
+    def test_collection(self, request, mgmt_root):
+        pool = HelperTest('Srvs')
+        pool.test_members_sucollection(request, mgmt_root)
+
+# End of v12.x Tests
+# Start of v11.x Tests
+
+
+def delete_pool(mgmt_root, name):
+    try:
+        foo = mgmt_root.tm.gtm.pools.pool.load(
+            name=name)
+    except HTTPError as err:
+        if err.response.status_code != 404:
+            raise
+        return
+    foo.delete()
+
+
+def setup_pool_basic_test(request, mgmt_root, name, partition):
+    def teardown():
+        delete_pool(mgmt_root, name)
+
+    poolc = mgmt_root.tm.gtm.pools
+    pool = poolc.pool.create(name=name, partition=partition)
+    request.addfinalizer(teardown)
+    return pool, poolc
+
+
+def setup_create_pool_test(request, mgmt_root, name):
+    def teardown():
+        delete_pool(mgmt_root, name)
+    request.addfinalizer(teardown)
+
+
+def setup_create_member_test(request, mgmt_root, name):
+    def teardown():
+        delete_pool(mgmt_root, name)
+    request.addfinalizer(teardown)
+
+
+def setup_member_basic_test(request, mgmt_root, name, partition, poolname):
+    def teardown():
+        delete_pool(mgmt_root, poolname)
+
+    setup_gtm_vs(request, mgmt_root, GTM_VS, '20.20.20.20:80',
+                 addresses=[{'name': '1.1.1.1'}])
+    pool, poolcoll = setup_pool_basic_test(request, mgmt_root, poolname,
+                                           partition)
+    memberc = pool.members_s
+    member = memberc.members.create(name=name, partition=partition)
+    request.addfinalizer(teardown)
+    return member, memberc
+
+
+@pytest.mark.skipif(
+    LooseVersion(pytest.config.getoption('--release')) >= LooseVersion(
+        '12.0.0'),
+    reason='This collection exists on 11.x'
+)
+class TestPools_v11(object):
+    def test_create_req_arg(self, request, mgmt_root):
+        setup_create_pool_test(request, mgmt_root, 'fake_pool')
+        pool1 = mgmt_root.tm.gtm.pools.pool.create(
+            name='fake_pool', partition='Common')
+        assert pool1.name == 'fake_pool'
+        assert pool1.generation and isinstance(pool1.generation, int)
+        assert pool1.kind == 'tm:gtm:pool:poolstate'
+        assert pool1.selfLink.startswith(
+            'https://localhost/mgmt/tm/gtm/pool/~Common~fake_pool')
+
+    def test_create_optional_args(self, request, mgmt_root):
+        setup_create_pool_test(request, mgmt_root, 'fake_pool')
+        pool1 = mgmt_root.tm.gtm.pools.pool.create(
+            name='fake_pool', partition='Common', description=TESTDESCRIPTION)
+        assert pool1.description == TESTDESCRIPTION
+        assert pool1.limitMaxBpsStatus == 'disabled'
+
+    def test_create_duplicate(self, request, mgmt_root):
+        setup_create_pool_test(request, mgmt_root, 'fake_pool')
+        try:
+            mgmt_root.tm.gtm.pools.pool.create(name='fake_pool',
+                                               partition='Common')
+        except HTTPError as err:
+            assert err.response.status_code == 400
+
+    def test_refresh(self, request, mgmt_root):
+        setup_pool_basic_test(request, mgmt_root, 'fake_pool', 'Common')
+        p1 = mgmt_root.tm.gtm.pools.pool.load(name='fake_pool')
+        p2 = mgmt_root.tm.gtm.pools.pool.load(name='fake_pool')
+
+        assert p1.limitMaxBpsStatus == 'disabled'
+        assert p2.limitMaxBpsStatus == 'disabled'
+
+        p2.update(limitMaxBpsStatus='enabled')
+        assert p1.limitMaxBpsStatus == 'disabled'
+        assert p2.limitMaxBpsStatus == 'enabled'
+
+        p1.refresh()
+        assert p1.limitMaxBpsStatus == 'enabled'
+
+    def test_load_no_object(self, mgmt_root):
+        with pytest.raises(HTTPError) as err:
+            mgmt_root.tm.gtm.pools.pool.load(name='fake_pool')
+            assert err.response.status_code == 404
+
+    def test_load(self, request, mgmt_root):
+        setup_pool_basic_test(request, mgmt_root, 'fake_pool', 'Common')
+        p1 = mgmt_root.tm.gtm.pools.pool.load(name='fake_pool')
+        assert p1.limitMaxBpsStatus == 'disabled'
+        p1.limitMaxBpsStatus = 'enabled'
+        p1.update()
+        p2 = mgmt_root.tm.gtm.pools.pool.load(name='fake_pool')
+        assert p2.limitMaxBpsStatus == 'enabled'
+
+    def test_update(self, request, mgmt_root):
+        p1, sc = setup_pool_basic_test(request, mgmt_root, 'fake_pool',
+                                       'Common')
+        assert p1.limitMaxBpsStatus == 'disabled'
+        assert not hasattr(p1, 'description')
+        p1.update(limitMaxBpsStatus='enabled', description=TESTDESCRIPTION)
+        assert p1.limitMaxBpsStatus == 'enabled'
+        assert hasattr(p1, 'description')
+        assert p1.description == TESTDESCRIPTION
+
+    def test_modify(self, request, mgmt_root):
+        p1, sc = setup_pool_basic_test(request, mgmt_root, 'fake_pool',
+                                       'Common')
+        original_dict = copy.copy(p1.__dict__)
+        limit = 'limitMaxBpsStatus'
+        p1.modify(limitMaxBpsStatus='enabled')
+        for k, v in original_dict.items():
+            if k != limit:
+                original_dict[k] = p1.__dict__[k]
+            elif k == limit:
+                assert p1.__dict__[k] == 'enabled'
+
+    def test_delete(self, request, mgmt_root):
+        p1, sc = setup_pool_basic_test(request, mgmt_root, 'fake_pool',
+                                       'Common')
+        p1.delete()
+        with pytest.raises(HTTPError) as err:
+            mgmt_root.tm.gtm.wideips.wideip.load(name='fake_pool')
+            assert err.response.status_code == 404
+
+    def test_pool_collection(self, request, mgmt_root):
+        pool1, pcoll = setup_pool_basic_test(request, mgmt_root,
+                                             'fake_pool', 'Common')
+
+        assert pool1.fullPath == '/Common/fake_pool'
+        assert pool1.name == 'fake_pool'
+        assert pool1.generation and isinstance(pool1.generation, int)
+        assert pool1.kind == 'tm:gtm:pool:poolstate'
+        assert pool1.selfLink.startswith(
+            'https://localhost/mgmt/tm/gtm/pool/~Common~fake_pool')
+
+        pc = pcoll.get_collection()
+        assert isinstance(pc, list)
+        assert len(pc)
+        assert isinstance(pc[0], Pool)
+
+
+@pytest.mark.skipif(
+    LooseVersion(pytest.config.getoption('--release')) >= LooseVersion(
+        '12.0.0'),
+    reason='This collection exists on 11.x'
+)
+class TestMembersSubCollection_v11(object):
+    def test_create_req_arg(self, request, mgmt_root):
+        setup_create_member_test(request, mgmt_root, 'fake_pool')
+        setup_gtm_vs(request, mgmt_root, GTM_VS, '20.20.20.20:80',
+                     addresses=[{'name': '1.1.1.1'}])
+        p1, pc = setup_pool_basic_test(request, mgmt_root, 'fake_pool',
+                                       'Common')
+        m1 = p1.members_s.members.create(name=RES_NAME, partition='Common')
+        uri = 'https://localhost/mgmt/tm/gtm/pool/~Common~fake_pool/' \
+              'members/~Common~fake_serv1:fakeVS'
+        assert m1.name == RES_NAME
+        assert m1.generation and isinstance(m1.generation, int)
+        assert m1.kind == 'tm:gtm:pool:members:membersstate'
+        assert m1.selfLink.startswith(uri)
+
+    def test_create_optional_args(self, request, mgmt_root):
+        setup_create_member_test(request, mgmt_root, 'fake_pool')
+        setup_gtm_vs(request, mgmt_root, GTM_VS, '20.20.20.20:80',
+                     addresses=[{'name': '1.1.1.1'}])
+        p1, pc = setup_pool_basic_test(request, mgmt_root, 'fake_pool',
+                                       'Common')
+        m1 = p1.members_s.members.create(name=RES_NAME, partition='Common',
+                                         description='FancyFakeMember',
+                                         limitMaxBpsStatus='enabled',
+                                         limitMaxBps=1337)
+        assert m1.name == RES_NAME
+        assert m1.description == 'FancyFakeMember'
+        assert m1.limitMaxBpsStatus == 'enabled'
+        assert m1.limitMaxBps == 1337
+
+    def test_create_duplicate(self, request, mgmt_root):
+        setup_member_basic_test(request, mgmt_root, RES_NAME, 'Common',
+                                'fake_pool')
+        p1 = mgmt_root.tm.gtm.pools.pool.load(name='fake_pool')
+        try:
+            p1.members_s.members.create(name=RES_NAME, partition='Common')
+        except HTTPError as err:
+            assert err.response.status_code == 409
+
+    def test_refresh(self, request, mgmt_root):
+        setup_member_basic_test(request, mgmt_root, RES_NAME, 'Common',
+                                'fake_pool')
+        p1 = mgmt_root.tm.gtm.pools.pool.load(name='fake_pool')
+        m1 = p1.members_s.members.load(name=RES_NAME, partition='Common')
+        m2 = p1.members_s.members.load(name=RES_NAME, partition='Common')
+
+        assert m1.limitMaxBpsStatus == 'disabled'
+        assert m1.limitMaxBpsStatus == 'disabled'
+
+        m2.update(limitMaxBpsStatus='enabled')
+        assert m1.limitMaxBpsStatus == 'disabled'
+        assert m2.limitMaxBpsStatus == 'enabled'
+
+        m1.refresh()
+        assert m2.limitMaxBpsStatus == 'enabled'
+
+    def test_load_no_object(self, request, mgmt_root):
+        p1, pc = setup_pool_basic_test(request, mgmt_root, 'fake_pool',
+                                       'Common')
+        try:
+            p1.members_s.members.load(name=RES_NAME)
+        except HTTPError as err:
+            assert err.response.status_code == 404
+
+    def test_load(self, request, mgmt_root):
+        m1, mc = setup_member_basic_test(request, mgmt_root, RES_NAME,
+                                         'Common', 'fake_pool')
+        assert m1.name == RES_NAME
+        assert m1.limitMaxBpsStatus == 'disabled'
+
+        m1.limitMaxBpsStatus = 'enabled'
+        m1.update()
+        m2 = mc.members.load(name=RES_NAME, partition='Common')
+        assert m2.name == RES_NAME
+        assert m2.limitMaxBpsStatus == 'enabled'
+
+    def test_update(self, request, mgmt_root):
+        m1, mc = setup_member_basic_test(request, mgmt_root, RES_NAME,
+                                         'Common', 'fake_pool')
+        assert m1.limitMaxBpsStatus == 'disabled'
+        m1.update(limitMaxBpsStatus='enabled')
+        assert m1.limitMaxBpsStatus == 'enabled'
+
+    def test_modify(self, request, mgmt_root):
+        m1, mc = setup_member_basic_test(request, mgmt_root, RES_NAME,
+                                         'Common', 'fake_pool')
+        original_dict = copy.copy(m1.__dict__)
+        limit = 'limitMaxBpsStatus'
+        m1.modify(limitMaxBpsStatus='enabled')
+        for k, v in original_dict.items():
+            if k != limit:
+                original_dict[k] = m1.__dict__[k]
+            elif k == limit:
+                assert m1.__dict__[k] == 'enabled'
+
+    @pytest.mark.skipif(pytest.config.getoption('--release') == '11.6.0',
+                        reason='Due to a bug in 11.6.0 Final this test '
+                               'fails')
+    def test_delete(self, request, mgmt_root):
+        m1, mc = setup_member_basic_test(request, mgmt_root, RES_NAME,
+                                         'Common', 'fake_pool')
+        m1.delete()
+        p1 = mgmt_root.tm.gtm.pools.pool.load(name='fake_pool')
+        try:
+            p1.members_s.members.load(name=RES_NAME)
+        except HTTPError as err:
+            assert err.response.status_code == 404
+
+    def test_member_collection(self, request, mgmt_root):
+        m1, mc = setup_member_basic_test(request, mgmt_root, RES_NAME,
+                                         'Common', 'fake_pool')
+        uri = 'https://localhost/mgmt/tm/gtm/pool/~Common~fake_pool/' \
+              'members/~Common~fake_serv1:fakeVS'
+        assert m1.name == RES_NAME
+        assert m1.generation and isinstance(m1.generation, int)
+        assert m1.kind == 'tm:gtm:pool:members:membersstate'
+        assert m1.selfLink.startswith(uri)
+
+        msc = mc.get_collection()
+        assert isinstance(msc, list)
+        assert len(msc)
+        assert isinstance(msc[0], MembersResource_v11)

--- a/test/functional/tm/gtm/test_server.py
+++ b/test/functional/tm/gtm/test_server.py
@@ -1,0 +1,358 @@
+# Copyright 2015 F5 Networks Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import copy
+import pytest
+
+from distutils.version import LooseVersion
+from f5.bigip.tm.gtm.server import Server
+from f5.bigip.tm.gtm.server import Virtual_Servers
+from requests.exceptions import HTTPError
+
+
+def delete_server(mgmt_root, name):
+    try:
+        foo = mgmt_root.tm.gtm.servers.server.load(
+            name=name)
+    except HTTPError as err:
+        if err.response.status_code != 404:
+            raise
+        return
+    foo.delete()
+
+
+def delete_dc(mgmt_root, name, partition):
+    try:
+        delete_server(mgmt_root, 'fake_serv1')
+        foo = mgmt_root.tm.gtm.datacenters.datacenter.load(
+            name=name, partition=partition
+        )
+    except HTTPError as err:
+        if err.response.status_code != 404:
+            raise
+        return
+    foo.delete()
+
+
+def create_dc(request, mgmt_root, name, partition):
+    def teardown():
+        delete_dc(mgmt_root, name, partition)
+
+    # this line is to clean up any object that might have been left by
+    # previous test
+    delete_dc(mgmt_root, name, partition)
+
+    dc = mgmt_root.tm.gtm.datacenters.datacenter.create(
+        name=name, partition=partition)
+    request.addfinalizer(teardown)
+    return dc
+
+
+def setup_create_test(request, mgmt_root, name):
+    def teardown():
+        delete_server(mgmt_root, name)
+    request.addfinalizer(teardown)
+
+
+def setup_basic_test(request, mgmt_root, name, partition):
+    def teardown():
+        delete_server(mgmt_root, name)
+
+    # this line is to clean up any object that might have been left by
+    # previous test
+    delete_dc(mgmt_root, 'dc1', partition)
+
+    dc = create_dc(request, mgmt_root, 'dc1', partition)
+    serv1 = mgmt_root.tm.gtm.servers.server.create(
+        name=name, datacenter=dc.name,
+        addresses=[{'name': '1.1.1.1'}])
+    request.addfinalizer(teardown)
+    return serv1
+
+
+def delete_vs(mgmt_root, name):
+    s1 = mgmt_root.tm.gtm.servers.server.load(name='fake_serv1')
+    try:
+        foo = s1.virtual_servers_s.virtual_servers.load(
+            name=name)
+    except HTTPError as err:
+        if err.response.status_code != 404:
+            raise
+        return
+    foo.delete()
+
+
+def setup_vs_basic_test(request, mgmt_root, name, destination):
+    def teardown():
+        delete_vs(mgmt_root, name)
+
+    s1 = setup_basic_test(request, mgmt_root, 'fake_serv1', 'Common')
+    vs = s1.virtual_servers_s.virtual_servers.create(
+        name=name, destination=destination)
+    request.addfinalizer(teardown)
+    return vs
+
+
+def setup_create_vs_test(request, mgmt_root, name):
+    def teardown():
+        delete_server(mgmt_root, name)
+
+    request.addfinalizer(teardown)
+
+
+class TestCreate(object):
+    def test_create_req_arg(self, request, mgmt_root):
+        setup_create_test(request, mgmt_root, 'fake_serv1')
+        dc = create_dc(request, mgmt_root, 'dc1', 'Common')
+        serv1 = mgmt_root.tm.gtm.servers.server.create(
+            name='fake_serv1', datacenter=dc.name,
+            addresses=[{'name': '1.1.1.1'}])
+        assert serv1.name == 'fake_serv1'
+        assert serv1.generation and isinstance(serv1.generation, int)
+        assert serv1.kind == 'tm:gtm:server:serverstate'
+        assert serv1.selfLink.startswith(
+            'https://localhost/mgmt/tm/gtm/server/fake_serv1')
+
+    def test_create_optional_args(self, request, mgmt_root):
+        setup_create_test(request, mgmt_root, 'fake_serv1')
+        dc = create_dc(request, mgmt_root, 'dc1', 'Common')
+        serv1 = mgmt_root.tm.gtm.servers.server.create(
+            name='fake_serv1', datacenter=dc.name,
+            addresses=[{'name': '1.1.1.1'}],
+            iqAllowPath='no', enabled=False, disabled=True)
+        assert serv1.disabled is True
+        assert not hasattr(serv1, 'enabled')
+        assert serv1.iqAllowPath == 'no'
+
+    def test_create_duplicate(self, request, mgmt_root):
+        setup_basic_test(request, mgmt_root, 'fake_serv1', 'Common')
+        with pytest.raises(HTTPError) as err:
+            mgmt_root.tm.gtm.servers.server.create(
+                name='fake_serv1', datacenter='dc1',
+                addresses=[{'name': '1.1.1.1'}])
+            assert err.response.status_code == 400
+
+
+class TestRefresh(object):
+    def test_refresh(self, request, mgmt_root):
+        setup_basic_test(request, mgmt_root, 'fake_serv1', 'Common')
+        s1 = mgmt_root.tm.gtm.servers.server.load(name='fake_serv1')
+        s2 = mgmt_root.tm.gtm.servers.server.load(name='fake_serv1')
+
+        assert s1.iqAllowPath == 'yes'
+        assert s2.iqAllowPath == 'yes'
+
+        s2.update(iqAllowPath='no')
+        assert s1.iqAllowPath == 'yes'
+        assert s2.iqAllowPath == 'no'
+
+        s1.refresh()
+        assert s1.iqAllowPath == 'no'
+
+
+class TestLoad(object):
+    def test_load_no_object(self, mgmt_root):
+        with pytest.raises(HTTPError) as err:
+            mgmt_root.tm.gtm.servers.server.load(
+                name='fake_serv1')
+            assert err.response.status_code == 404
+
+    @pytest.mark.skipif(LooseVersion(pytest.config.getoption('--release')) ==
+                        '11.5.4',
+                        reason='Needs > v11.5.4 TMOS to pass')
+    def test_load(self, request, mgmt_root):
+        setup_basic_test(request, mgmt_root, 'fake_serv1', 'Common')
+        s1 = mgmt_root.tm.gtm.servers.server.load(name='fake_serv1')
+        assert s1.enabled is True
+        s1.enabled = False
+        s1.disabled = True
+        s1.update()
+        s2 = mgmt_root.tm.gtm.servers.server.load(name='fake_serv1')
+        assert not hasattr(s1, 'enabled')
+        assert hasattr(s2, 'disabled')
+        assert s2.disabled is True
+
+    @pytest.mark.skipif(
+        LooseVersion(pytest.config.getoption('--release')) >= LooseVersion(
+            '11.6.0'),
+        reason='This test is for 11.5.4 or less.')
+    def test_load_11_5_4_and_less(self, request, mgmt_root):
+        setup_basic_test(request, mgmt_root, 'fake_serv1', 'Common')
+        s1 = mgmt_root.tm.gtm.servers.server.load(name='fake_serv1')
+        assert s1.enabled is True
+        s1.enabled = False
+        s1.update()
+        s2 = mgmt_root.tm.gtm.servers.server.load(name='fake_serv1')
+        assert hasattr(s2, 'enabled')
+        assert s2.enabled is True
+
+
+class TestUpdateModify(object):
+    def test_update(self, request, mgmt_root):
+        s1 = setup_basic_test(request, mgmt_root, 'fake_serv1', 'Common')
+        assert s1.iqAllowPath == 'yes'
+        s1.update(iqAllowPath='no')
+        assert s1.iqAllowPath == 'no'
+
+    def test_modify(self, request, mgmt_root):
+        s1 = setup_basic_test(request, mgmt_root, 'fake_serv1', 'Common')
+        original_dict = copy.copy(s1.__dict__)
+        iqpath = 'iqAllowPath'
+        s1.modify(iqAllowPath='no')
+        for k, v in original_dict.items():
+            if k != iqpath:
+                original_dict[k] = s1.__dict__[k]
+            elif k == iqpath:
+                assert s1.__dict__[k] == 'no'
+
+
+class TestDelete(object):
+    def test_delete(self, request, mgmt_root):
+        s1 = setup_basic_test(request, mgmt_root, 'fake_serv1', 'Common')
+        s1.delete()
+        with pytest.raises(HTTPError) as err:
+            mgmt_root.tm.gtm.servers.server.load(name='fake_serv1')
+            assert err.response.status_code == 404
+
+
+class TestServerCollection(object):
+    def test_server_collection(self, request, mgmt_root):
+        s1 = setup_basic_test(request, mgmt_root, 'fake_serv1', 'Common')
+        assert s1.name == 'fake_serv1'
+        assert s1.generation and isinstance(s1.generation, int)
+        assert s1.fullPath == 'fake_serv1'
+        assert s1.kind == 'tm:gtm:server:serverstate'
+        assert s1.selfLink.startswith(
+            'https://localhost/mgmt/tm/gtm/server/fake_serv1')
+
+        sc = mgmt_root.tm.gtm.servers.get_collection()
+        assert isinstance(sc, list)
+        assert len(sc)
+        assert isinstance(sc[0], Server)
+
+
+class TestVirtualServerSubCollection(object):
+    def test_create_req_arg(self, request, mgmt_root):
+        setup_create_vs_test(request, mgmt_root, 'vs1')
+        s1 = setup_basic_test(request, mgmt_root, 'fake_serv1', 'Common')
+        vs = s1.virtual_servers_s
+        vs1 = vs.virtual_servers.create(name='vs1', destination='5.5.5.5:80')
+        assert vs1.name == 'vs1'
+        assert vs1.generation and isinstance(vs1.generation, int)
+        assert vs1.kind == 'tm:gtm:server:virtual-servers:virtual-serversstate'
+        assert vs1.selfLink.startswith('https://localhost/mgmt/tm/gtm/server/'
+                                       'fake_serv1/virtual-servers/vs1')
+
+    def test_create_optional_args(self, request, mgmt_root):
+        setup_create_vs_test(request, mgmt_root, 'vs1')
+        s1 = setup_basic_test(request, mgmt_root, 'fake_serv1', 'Common')
+        vs = s1.virtual_servers_s
+        vs1 = vs.virtual_servers.create(name='vs1',
+                                        destination='5.5.5.5:80',
+                                        description='FancyFakeVS',
+                                        limitMaxBpsStatus='enabled',
+                                        limitMaxBps=1337)
+        assert vs1.name == 'vs1'
+        assert vs1.description == 'FancyFakeVS'
+        assert vs1.limitMaxBpsStatus == 'enabled'
+        assert vs1.limitMaxBps == 1337
+
+    def test_create_duplicate(self, request, mgmt_root):
+        setup_vs_basic_test(request, mgmt_root, 'vs1', '5.5.5.5:80')
+        s1 = mgmt_root.tm.gtm.servers.server.load(name='fake_serv1')
+        try:
+            s1.virtual_servers_s.virtual_servers.create(
+                name='vs1', destination='5.5.5.5:80')
+        except HTTPError as err:
+            assert err.response.status_code == 409
+
+    def test_refresh(self, request, mgmt_root):
+        setup_vs_basic_test(request, mgmt_root, 'vs1', '5.5.5.5:80')
+        s1 = mgmt_root.tm.gtm.servers.server.load(name='fake_serv1')
+        vs1 = s1.virtual_servers_s.virtual_servers.load(name='vs1')
+        vs2 = s1.virtual_servers_s.virtual_servers.load(name='vs1')
+
+        assert vs1.limitMaxBpsStatus == 'disabled'
+        assert vs2.limitMaxBpsStatus == 'disabled'
+
+        vs2.update(limitMaxBpsStatus='enabled')
+        assert vs1.limitMaxBpsStatus == 'disabled'
+        assert vs2.limitMaxBpsStatus == 'enabled'
+
+        vs1.refresh()
+        assert vs2.limitMaxBpsStatus == 'enabled'
+
+    def test_load_no_object(self, request, mgmt_root):
+        s1 = setup_basic_test(request, mgmt_root, 'fake_serv1', 'Common')
+        try:
+            s1.virtual_servers_s.virtual_servers.load(name='vs1')
+        except HTTPError as err:
+            assert err.response.status_code == 404
+
+    def test_load(self, request, mgmt_root):
+        setup_vs_basic_test(request, mgmt_root, 'vs1', '5.5.5.5:80')
+        s1 = mgmt_root.tm.gtm.servers.server.load(name='fake_serv1')
+        vs1 = s1.virtual_servers_s.virtual_servers.load(name='vs1')
+        assert vs1.name == 'vs1'
+        assert vs1.limitMaxBpsStatus == 'disabled'
+
+        vs1.limitMaxBpsStatus = 'enabled'
+        vs1.update()
+        vs2 = s1.virtual_servers_s.virtual_servers.load(name='vs1')
+        assert vs2.name == 'vs1'
+        assert vs2.limitMaxBpsStatus == 'enabled'
+
+    def test_update(self, request, mgmt_root):
+        vs1 = setup_vs_basic_test(request, mgmt_root, 'vs1', '5.5.5.5:80')
+        assert vs1.limitMaxBpsStatus == 'disabled'
+        vs1.update(limitMaxBpsStatus='enabled')
+        assert vs1.limitMaxBpsStatus == 'enabled'
+
+    def test_modify(self, request, mgmt_root):
+        vs1 = setup_vs_basic_test(request, mgmt_root, 'vs1', '5.5.5.5:80')
+        original_dict = copy.copy(vs1.__dict__)
+        limit = 'limitMaxBpsStatus'
+        vs1.modify(limitMaxBpsStatus='enabled')
+        for k, v in original_dict.items():
+            if k != limit:
+                original_dict[k] = vs1.__dict__[k]
+            elif k == limit:
+                assert vs1.__dict__[k] == 'enabled'
+
+    @pytest.mark.skipif(pytest.config.getoption('--release') == '11.6.0',
+                        reason='Due to a bug in 11.6.0 Final this test '
+                               'fails')
+    def test_delete(self, request, mgmt_root):
+        vs1 = setup_vs_basic_test(request, mgmt_root, 'vs2', '5.5.5.5:80')
+        vs1.delete()
+        s1 = mgmt_root.tm.gtm.servers.server.load(name='fake_serv1')
+        try:
+            s1.virtual_servers_s.virtual_servers.load(name='vs2')
+        except HTTPError as err:
+            assert err.response.status_code == 404
+
+    def test_virtual_server_collection(self, request, mgmt_root):
+        vs1 = setup_vs_basic_test(request, mgmt_root, 'vs1', '5.5.5.5:80')
+        assert vs1.name == 'vs1'
+        assert vs1.generation and isinstance(vs1.generation, int)
+        assert vs1.kind == 'tm:gtm:server:virtual-servers:virtual-serversstate'
+        assert vs1.selfLink.startswith('https://localhost/mgmt/tm/gtm/server/'
+                                       'fake_serv1/virtual-servers/vs1')
+
+        s1 = mgmt_root.tm.gtm.servers.server.load(name='fake_serv1')
+        vsc = s1.virtual_servers_s.get_collection()
+        assert isinstance(vsc, list)
+        assert len(vsc)
+        assert isinstance(vsc[0], Virtual_Servers)

--- a/test/functional/tm/gtm/test_wideips.py
+++ b/test/functional/tm/gtm/test_wideips.py
@@ -1,0 +1,345 @@
+# Copyright 2015 F5 Networks Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import copy
+from distutils.version import LooseVersion
+from f5.bigip.tm.gtm.wideip import A
+from f5.bigip.tm.gtm.wideip import Aaaa
+from f5.bigip.tm.gtm.wideip import Cname
+from f5.bigip.tm.gtm.wideip import Mx
+from f5.bigip.tm.gtm.wideip import Naptr
+from f5.bigip.tm.gtm.wideip import Srv
+from f5.bigip.tm.gtm.wideip import Wideip
+from pprint import pprint as pp
+pp(__file__)
+import pytest
+from requests.exceptions import HTTPError
+
+
+TESTDESCRIPTION = "TESTDESCRIPTION"
+
+# Start of V12.x Tests here
+
+
+# Helper class to limit code repetition
+class HelperTest(object):
+    def __init__(self, collection_name):
+        self.partition = 'Common'
+        self.lowered = collection_name.lower()
+        self.test_name = 'fake.' + self.urielementname() + '.lab.local'
+        self.kinds = {'a': 'tm:gtm:wideip:a:astate',
+                      'aaaa': 'tm:gtm:wideip:aaaa:aaaastate',
+                      'cname': 'tm:gtm:wideip:cname:cnamestate',
+                      'mx': 'tm:gtm:wideip:mx:mxstate',
+                      'naptr': 'tm:gtm:wideip:naptr:naptrstate',
+                      'srv': 'tm:gtm:wideip:srv:srvstate'}
+
+    def urielementname(self):
+        if self.lowered[-2:] == '_s':
+            endind = 2
+        else:
+            endind = 1
+        return self.lowered[:-endind]
+
+    def delete_resource(self, resource):
+        try:
+            foo = resource.load(name=self.test_name, partition=self.partition)
+        except HTTPError as err:
+            if err.response.status_code != 404:
+                raise
+            return
+        foo.delete()
+
+    def setup_test(self, request, mgmt_root, **kwargs):
+        def teardown():
+            self.delete_resource(resource)
+
+        resourcecollection =\
+            getattr(getattr(getattr(mgmt_root, 'gtm'), 'wideips'),
+                    self.lowered)
+        resource = getattr(resourcecollection, self.urielementname())
+        self.delete_resource(resource)
+        created = resource.create(name=self.test_name,
+                                  partition=self.partition,
+                                  **kwargs)
+        request.addfinalizer(teardown)
+        return created, resourcecollection
+
+    def test_MCURDL(self, request, bigip, **kwargs):
+        # Testing create
+        wideip, rescollection = self.setup_test(request, bigip, **kwargs)
+        assert wideip.name == self.test_name
+        assert wideip.fullPath == '/Common/'+self.test_name
+        assert wideip.generation and isinstance(wideip.generation, int)
+        assert wideip.kind == self.kinds[self.urielementname()]
+
+        # Testing update
+        wideip.description = TESTDESCRIPTION
+        pp(wideip.raw)
+        wideip.update()
+        if hasattr(wideip, 'description'):
+            assert wideip.description == TESTDESCRIPTION
+
+        # Testing refresh
+        wideip.description = ''
+        wideip.refresh()
+        if hasattr(wideip, 'description'):
+            assert wideip.description == TESTDESCRIPTION
+
+        # Testing modify
+        meta_data = wideip.__dict__.pop('_meta_data')
+        start_dict = copy.deepcopy(wideip.__dict__)
+        wideip.__dict__['_meta_data'] = meta_data
+        wideip.modify(description='MODIFIED')
+        desc = 'description'
+        for k, v in wideip.__dict__.items():
+            if k != desc:
+                start_dict[k] = wideip.__dict__[k]
+                assert getattr(wideip, k) == start_dict[k]
+            elif k == desc:
+                assert getattr(wideip, desc) == 'MODIFIED'
+
+        # Testing load
+        p2 = getattr(rescollection, self.urielementname())
+        wideip2 = p2.load(partition=self.partition, name=self.test_name)
+        assert wideip.selfLink == wideip2.selfLink
+
+    def test_collection(self, request, bigip, **kwargs):
+        wideip, rescollection = self.setup_test(request, bigip, **kwargs)
+        assert wideip.name == self.test_name
+        assert wideip.fullPath == '/Common/'+self.test_name
+        assert wideip.generation and isinstance(wideip.generation, int)
+        assert wideip.kind == self.kinds[self.urielementname()]
+
+        coll = rescollection.get_collection()
+        assert isinstance(coll, list)
+        assert len(coll)
+        if self.lowered == 'a_s':
+            assert isinstance(coll[0], A)
+        elif self.lowered == 'aaaas':
+            assert isinstance(coll[0], Aaaa)
+        elif self.lowered == 'cnames':
+            assert isinstance(coll[0], Cname)
+        elif self.lowered == 'mxs':
+            assert isinstance(coll[0], Mx)
+        elif self.lowered == 'naptrs':
+            assert isinstance(coll[0], Naptr)
+        elif self.lowered == 'srvs':
+            assert isinstance(coll[0], Srv)
+
+
+@pytest.mark.skipif(
+    LooseVersion(pytest.config.getoption('--release')) < LooseVersion(
+        '12.0.0'),
+    reason='This collection exists on 12.0.0 or greater.'
+)
+class TestWideipAtype(object):
+    def test_MCURDL_and_collection(self, request, bigip):
+        wideip = HelperTest('A_s')
+        wideip.test_MCURDL(request, bigip)
+        wideip.test_collection(request, bigip)
+
+
+@pytest.mark.skipif(
+    LooseVersion(pytest.config.getoption('--release')) < LooseVersion(
+        '12.0.0'),
+    reason='This collection exists on 12.0.0 or greater.'
+)
+class TestWideipAaaaType(object):
+    def test_MCURDL_and_collection(self, request, bigip):
+        wideip = HelperTest('Aaaas')
+        wideip.test_MCURDL(request, bigip)
+        wideip.test_collection(request, bigip)
+
+
+@pytest.mark.skipif(
+    LooseVersion(pytest.config.getoption('--release')) < LooseVersion(
+        '12.0.0'),
+    reason='This collection exists on 12.0.0 or greater.'
+)
+class TestWideipCnameType(object):
+    def test_MCURDL_and_collection(self, request, bigip):
+        wideip = HelperTest('Cnames')
+        wideip.test_MCURDL(request, bigip)
+        wideip.test_collection(request, bigip)
+
+
+@pytest.mark.skipif(
+    LooseVersion(pytest.config.getoption('--release')) < LooseVersion(
+        '12.0.0'),
+    reason='This collection exists on 12.0.0 or greater.'
+)
+class TestWideipMxType(object):
+    def test_MCURDL_and_collection(self, request, bigip):
+        wideip = HelperTest('Mxs')
+        wideip.test_MCURDL(request, bigip)
+        wideip.test_collection(request, bigip)
+
+
+@pytest.mark.skipif(
+    LooseVersion(pytest.config.getoption('--release')) < LooseVersion(
+        '12.0.0'),
+    reason='This collection exists on 12.0.0 or greater.'
+)
+class TestWideipNaptrType(object):
+    def test_MCURDL_and_collection(self, request, bigip):
+        wideip = HelperTest('Naptrs')
+        wideip.test_MCURDL(request, bigip)
+        wideip.test_collection(request, bigip)
+
+
+@pytest.mark.skipif(
+    LooseVersion(pytest.config.getoption('--release')) < LooseVersion(
+        '12.0.0'),
+    reason='This collection exists on 12.0.0 or greater.'
+)
+class TestWideipSrvType(object):
+    def test_MCURDL_and_collection(self, request, bigip):
+        wideip = HelperTest('Srvs')
+        wideip.test_MCURDL(request, bigip)
+        wideip.test_collection(request, bigip)
+
+# End of v12.x Tests
+
+
+def delete_wideip_v11(mgmt_root, name):
+    try:
+        foo = mgmt_root.tm.gtm.wideips.wideip.load(
+            name=name)
+    except HTTPError as err:
+        if err.response.status_code != 404:
+            raise
+        return
+    foo.delete()
+
+
+def setup_create_test(request, mgmt_root, name):
+    def teardown():
+        delete_wideip_v11(mgmt_root, name)
+
+    request.addfinalizer(teardown)
+
+
+def setup_basic_test(request, mgmt_root, name, **kwargs):
+    def teardown():
+        delete_wideip_v11(mgmt_root, name)
+
+    wideip1 = mgmt_root.tm.gtm.wideips.wideip.create(
+        name=name, **kwargs)
+    request.addfinalizer(teardown)
+    return wideip1
+
+
+@pytest.mark.skipif(
+    LooseVersion(pytest.config.getoption('--release')) >= LooseVersion(
+        '12.0.0'),
+    reason='This collection exists on 11.x'
+)
+class TestWideips_v11(object):
+    def test_create_req_arg(self, request, mgmt_root):
+        setup_create_test(request, mgmt_root, 'fake.lab.local')
+        wideip1 = mgmt_root.tm.gtm.wideips.wideip.create(
+            name='fake.lab.local', partition='Common')
+        assert wideip1.name == 'fake.lab.local'
+        assert wideip1.generation and isinstance(wideip1.generation, int)
+        assert wideip1.kind == 'tm:gtm:wideip:wideipstate'
+        assert wideip1.selfLink.startswith(
+            'https://localhost/mgmt/tm/gtm/wideip/~Common~fake.lab.local')
+
+    def test_create_optional_args(self, request, mgmt_root):
+        setup_create_test(request, mgmt_root, 'fake.lab.local')
+        wideip1 = mgmt_root.tm.gtm.wideips.wideip.create(
+            name='fake.lab.local', description=TESTDESCRIPTION)
+        assert wideip1.description == TESTDESCRIPTION
+        assert wideip1.ipv6NoErrorResponse == 'disabled'
+
+    def test_create_duplicate(self, request, mgmt_root):
+        setup_create_test(request, mgmt_root, 'fake.lab.local')
+        try:
+            mgmt_root.tm.gtm.wideips.wideip.create(name='fake.lab.local')
+        except HTTPError as err:
+            assert err.response.status_code == 400
+
+    def test_refresh(self, request, mgmt_root):
+        setup_basic_test(request, mgmt_root, 'fake.lab.local')
+        s1 = mgmt_root.tm.gtm.wideips.wideip.load(name='fake.lab.local')
+        s2 = mgmt_root.tm.gtm.wideips.wideip.load(name='fake.lab.local')
+
+        assert s1.ipv6NoErrorResponse == 'disabled'
+        assert s2.ipv6NoErrorResponse == 'disabled'
+
+        s2.update(ipv6NoErrorResponse='enabled')
+        assert s1.ipv6NoErrorResponse == 'disabled'
+        assert s2.ipv6NoErrorResponse == 'enabled'
+
+        s1.refresh()
+        assert s1.ipv6NoErrorResponse == 'enabled'
+
+    def test_load_no_object(self, mgmt_root):
+        with pytest.raises(HTTPError) as err:
+            mgmt_root.tm.gtm.wideips.wideip.load(name='fake.lab.local')
+            assert err.response.status_code == 404
+
+    def test_load(self, request, mgmt_root):
+        setup_basic_test(request, mgmt_root, 'fake.lab.local')
+        s1 = mgmt_root.tm.gtm.wideips.wideip.load(name='fake.lab.local')
+        assert s1.ipv6NoErrorResponse == 'disabled'
+        s1.ipv6NoErrorResponse = 'enabled'
+        s1.update()
+        s2 = mgmt_root.tm.gtm.wideips.wideip.load(name='fake.lab.local')
+        assert s2.ipv6NoErrorResponse == 'enabled'
+
+    def test_update(self, request, mgmt_root):
+        s1 = setup_basic_test(request, mgmt_root, 'fake.lab.local')
+        assert s1.ipv6NoErrorResponse == 'disabled'
+        assert not hasattr(s1, 'description')
+        s1.update(ipv6NoErrorResponse='enabled', description=TESTDESCRIPTION)
+        assert s1.ipv6NoErrorResponse == 'enabled'
+        assert hasattr(s1, 'description')
+        assert s1.description == TESTDESCRIPTION
+
+    def test_modify(self, request, mgmt_root):
+        s1 = setup_basic_test(request, mgmt_root, 'fake.lab.local')
+        original_dict = copy.copy(s1.__dict__)
+        ipv6 = 'ipv6NoErrorResponse'
+        s1.modify(ipv6NoErrorResponse='enabled')
+        for k, v in original_dict.items():
+            if k != ipv6:
+                original_dict[k] = s1.__dict__[k]
+            elif k == ipv6:
+                assert s1.__dict__[k] == 'enabled'
+
+    def test_delete(self, request, mgmt_root):
+        s1 = setup_basic_test(request, mgmt_root, 'fake.lab.local')
+        s1.delete()
+        with pytest.raises(HTTPError) as err:
+            mgmt_root.tm.gtm.wideips.wideip.load(name='fake.lab.local')
+            assert err.response.status_code == 404
+
+    def test_wideips_collection(self, request, mgmt_root):
+        wideip1 = setup_basic_test(request, mgmt_root, 'fake.lab.local',
+                                   partition='Common')
+
+        assert wideip1.name == 'fake.lab.local'
+        assert wideip1.fullPath == '/Common/fake.lab.local'
+        assert wideip1.generation and isinstance(wideip1.generation, int)
+        assert wideip1.kind == 'tm:gtm:wideip:wideipstate'
+        assert wideip1.selfLink.startswith(
+            'https://localhost/mgmt/tm/gtm/wideip/~Common~fake.lab.local')
+
+        wideipc = mgmt_root.tm.gtm.wideips.get_collection()
+        assert isinstance(wideipc, list)
+        assert len(wideipc)
+        assert isinstance(wideipc[0], Wideip)


### PR DESCRIPTION
Fixes #621

Problem:
GTM Pools  endpoint was missing from the SDK. This is the last of a series of PRs meant to introduce the GTM pools to the SDK

Analysis:
GTM pools were added with tests

Tests:
Flake8
Functional Tests
Unit Tests

Files Added/Changed:

f5-common-python/f5/bigip/tm/gtm/init.py
f5-common-python/f5/bigip/tm/gtm/pool.py
f5-common-python/f5/bigip/tm/gtm/test/test_pool.py
f5-common-python/test/functional/tm/gtm/test_pool.py
