### PR TITLE
Adding tm/util/unix-rm

### DIFF
--- a/f5/bigip/tm/__init__.py
+++ b/f5/bigip/tm/__init__.py
@@ -26,6 +26,7 @@ from f5.bigip.tm.net import Net
 from f5.bigip.tm.shared import Shared
 from f5.bigip.tm.sys import Sys
 from f5.bigip.tm.transaction import Transactions
+from f5.bigip.tm.util import Util
 from f5.bigip.tm.vcmp import Vcmp
 
 
@@ -42,5 +43,6 @@ class Tm(OrganizingCollection):
             Shared,
             Sys,
             Transactions,
+            Util,
             Vcmp
         ]

--- a/f5/bigip/tm/util/Unix_Rm.py
+++ b/f5/bigip/tm/util/Unix_Rm.py
@@ -1,0 +1,58 @@
+# coding=utf-8
+#
+# Copyright 2016 F5 Networks Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+"""BIG-IP® utility module
+
+REST URI
+    ``http://localhost/mgmt/tm/util/unix-rm``
+
+GUI Path
+    N/A
+
+REST Kind
+    ``tm:util:unix-rm:*``
+"""
+
+from f5.bigip.mixins import CommandExecutionMixin
+from f5.bigip.resource import UnnamedResource
+from f5.utils.util_exceptions import UtilError
+
+
+class Unix_Rm(UnnamedResource, CommandExecutionMixin):
+
+    def __init__(self, util):
+        super(Unix_Rm, self).__init__(util)
+        self._meta_data['required_command_parameters'].update(('utilCmdArgs',))
+        self._meta_data['required_json_kind'] = 'tm:util:unix-rm:runstate'
+        self._meta_data['allowed_commands'].append('run')
+
+    def _exec_cmd(self, command, **kwargs):
+        kwargs['command'] = command
+        self._check_exclusive_parameters(**kwargs)
+        requests_params = self._handle_requests_params(kwargs)
+        self._check_command_parameters(**kwargs)
+        session = self._meta_data['bigip']._meta_data['icr_session']
+        response = session.post(
+            self._meta_data['uri'], json=kwargs, **requests_params)
+        self._local_update(response.json())
+
+        if 'commandResult' in self.__dict__:
+            if self.commandResult.startswith('/bin/rm'):
+                raise UtilError('%s' % self.commandResult.split(' ', 1)[1])
+            else:
+                return self
+        else:
+            return self

--- a/f5/bigip/tm/util/Unix_Rm.py
+++ b/f5/bigip/tm/util/Unix_Rm.py
@@ -52,7 +52,5 @@ class Unix_Rm(UnnamedResource, CommandExecutionMixin):
         if 'commandResult' in self.__dict__:
             if self.commandResult.startswith('/bin/rm'):
                 raise UtilError('%s' % self.commandResult.split(' ', 1)[1])
-            else:
-                return self
         else:
             return self

--- a/f5/bigip/tm/util/__init__.py
+++ b/f5/bigip/tm/util/__init__.py
@@ -1,0 +1,39 @@
+# coding=utf-8
+#
+# Copyright 2016 F5 Networks Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""BIG-IP® Utility (util) module
+
+REST URI
+    ``http://localhost/mgmt/tm/util/``
+
+GUI Path
+    ``System``
+
+REST Kind
+    N/A -- HTTP GET returns an error
+"""
+
+from f5.bigip.resource import PathElement
+from f5.bigip.tm.util.Unix_Rm import Unix_Rm
+
+
+class Util(PathElement):
+    def __init__(self, bigip):
+        super(Util, self).__init__(bigip)
+        self._meta_data['allowed_lazy_attributes'] = [
+            Unix_Rm
+        ]

--- a/f5/bigip/tm/util/test/test_unix_rm.py
+++ b/f5/bigip/tm/util/test/test_unix_rm.py
@@ -1,0 +1,46 @@
+# Copyright 2016 F5 Networks Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import mock
+import pytest
+
+from f5.bigip import ManagementRoot
+from f5.bigip.tm.util.Unix_Rm import Unix_Rm
+
+
+@pytest.fixture
+def FakeUnixRm():
+    fake_sys = mock.MagicMock()
+    fake_rm = Unix_Rm(fake_sys)
+    return fake_rm
+
+
+@pytest.fixture
+def FakeiControl(fakeicontrolsession):
+    mr = ManagementRoot('host', 'fake_admin', 'fake_admin')
+    mock_session = mock.MagicMock()
+    mock_session.post.return_value.json.return_value = {}
+    mr._meta_data['icr_session'] = mock_session
+    return mr.tm.util.unix_rm
+
+
+class TestUnixRmCommand(object):
+    def test_command_unix_rm(self, FakeiControl):
+        FakeiControl.exec_cmd('run', utilCmdArgs='/var/tmp/testfile.txt')
+        session = FakeiControl._meta_data['bigip']._meta_data['icr_session']
+        assert session.post.call_args == mock.call(
+            'https://host:443/mgmt/tm/util/unix-rm/',
+            json={'utilCmdArgs': '/var/tmp/testfile.txt', 'command': 'run'}
+        )

--- a/test/functional/tm/util/test_unix_rm.py
+++ b/test/functional/tm/util/test_unix_rm.py
@@ -14,6 +14,9 @@
 # limitations under the License.
 #
 
+import pytest
+
+from f5.utils.util_exceptions import UtilError
 import os
 from tempfile import NamedTemporaryFile
 
@@ -28,7 +31,13 @@ def test_E_unix_rm(mgmt_root):
 
     fr1 = mgmt_root.tm.util.unix_rm.exec_cmd('run', utilCmdArgs=tpath_name)
 
+    # validate object was created
     assert fr1.utilCmdArgs == '/var/config/rest/downloads/{0}'.format(
         ntf_basename)
 
+    # if command was successful, commandResult should not be present
     assert 'commandResult' not in fr1.__dict__
+
+    # UtilError should be raised when non-existent file is mentioned
+    with pytest.raises(UtilError):
+        mgmt_root.tm.util.unix_rm.exec_cmd('run', utilCmdArgs='testfile.txt')

--- a/test/functional/tm/util/test_unix_rm.py
+++ b/test/functional/tm/util/test_unix_rm.py
@@ -31,7 +31,4 @@ def test_E_unix_rm(mgmt_root):
     assert fr1.utilCmdArgs == '/var/config/rest/downloads/{0}'.format(
         ntf_basename)
 
-    try:
-        fr1.__dict__['commandResult']
-    except KeyError:
-        pass
+    assert 'commandResult' not in fr1.__dict__

--- a/test/functional/tm/util/test_unix_rm.py
+++ b/test/functional/tm/util/test_unix_rm.py
@@ -1,0 +1,37 @@
+
+# Copyright 2016 F5 Networks Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import os
+from tempfile import NamedTemporaryFile
+
+
+def test_E_unix_rm(mgmt_root):
+    ntf = NamedTemporaryFile(delete=False)
+    ntf_basename = os.path.basename(ntf.name)
+    ntf.write('text for test file')
+    ntf.seek(0)
+    mgmt_root.shared.file_transfer.uploads.upload_file(ntf.name)
+    tpath_name = '/var/config/rest/downloads/{0}'.format(ntf_basename)
+
+    fr1 = mgmt_root.tm.util.unix_rm.exec_cmd('run', utilCmdArgs=tpath_name)
+
+    assert fr1.utilCmdArgs == '/var/config/rest/downloads/{0}'.format(
+        ntf_basename)
+
+    try:
+        fr1.__dict__['commandResult']
+    except KeyError:
+        pass


### PR DESCRIPTION
Issue #538 - Feature introduction for utility commands; unix-rm up first.

Updated Files:
f5/bigip/tm/**init**.py

Added Files:
f5/bigip/tm/util/**init**.py
f5/bigip/tm/util/Unix_Rm.py
f5/bigip/tm/test/test_unix_rm.py
test/functional/tm/util/**init**.py (empty file)
test/functional/tm/util/test_unix_rm.py
