### PR TITLE
Add LTM Traffic Class Endpoint

### DIFF
--- a/f5/bigip/tm/ltm/__init__.py
+++ b/f5/bigip/tm/ltm/__init__.py
@@ -42,6 +42,7 @@ from f5.bigip.tm.ltm.rule import Rules
 from f5.bigip.tm.ltm.snat import Snats
 from f5.bigip.tm.ltm.snat_translation import Snat_Translations
 from f5.bigip.tm.ltm.snatpool import Snatpools
+from f5.bigip.tm.ltm.traffic_class import Traffic_Class_s
 from f5.bigip.tm.ltm.virtual import Virtuals
 from f5.bigip.tm.ltm.virtual_address import Virtual_Address_s
 
@@ -64,6 +65,7 @@ class Ltm(OrganizingCollection):
             Snats,
             Snatpools,
             Snat_Translations,
+            Traffic_Class_s,
             Virtuals,
             Virtual_Address_s,
         ]

--- a/f5/bigip/tm/ltm/test/test_traffic_class.py
+++ b/f5/bigip/tm/ltm/test/test_traffic_class.py
@@ -1,0 +1,44 @@
+# Copyright 2015 F5 Networks Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import mock
+import pytest
+
+from f5.bigip import ManagementRoot
+from f5.bigip.resource import MissingRequiredCreationParameter
+from f5.bigip.tm.ltm.traffic_class import Traffic_Class
+
+
+@pytest.fixture
+def FakeTraffic():
+    fake_traffic_class_s = mock.MagicMock()
+    fake_traffic = Traffic_Class(fake_traffic_class_s)
+    return fake_traffic
+
+
+class TestCreate(object):
+    def test_create_two(self, fakeicontrolsession):
+        mr = ManagementRoot('192.168.1.1', 'admin', 'admin')
+        t1 = mr.tm.ltm.traffic_class_s.traffic_class
+        t2 = mr.tm.ltm.traffic_class_s.traffic_class
+        assert t1 is not t2
+
+    def test_create_no_args(self, FakeTraffic):
+        with pytest.raises(MissingRequiredCreationParameter):
+            FakeTraffic.create()
+
+    def test_create_name(self, FakeTraffic):
+        with pytest.raises(MissingRequiredCreationParameter):
+            FakeTraffic.create(name='myname')

--- a/f5/bigip/tm/ltm/traffic_class.py
+++ b/f5/bigip/tm/ltm/traffic_class.py
@@ -1,0 +1,50 @@
+# coding=utf-8
+#
+#  Copyright 2014-2016 F5 Networks Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""BIG-IP Local Traffic Manager (LTM) Traffic Class module.
+
+REST URI
+    ``https://localhost/mgmt/tm/ltm/traffic-class``
+
+GUI Path
+    ``Local Traffic --> Traffic Class``
+
+REST Kind
+    ``tm:ltm:traffic-class:*``
+"""
+
+from f5.bigip.resource import Collection
+from f5.bigip.resource import Resource
+
+
+class Traffic_Class_s(Collection):
+    """BIG-IP® LTM Traffic Class collection"""
+    def __init__(self, ltm):
+        super(Traffic_Class_s, self).__init__(ltm)
+        self._meta_data['allowed_lazy_attributes'] = [Traffic_Class]
+        self._meta_data['attribute_registry'] =\
+            {'tm:ltm:traffic-class:traffic-classstate': Traffic_Class}
+
+
+class Traffic_Class(Resource):
+    """BIG-IP® LTM Traffic Class Resource"""
+    def __init__(self, traffic_class_s):
+        super(Traffic_Class, self).__init__(traffic_class_s)
+        self._meta_data['required_json_kind'] = \
+            'tm:ltm:traffic-class:traffic-classstate'
+        self._meta_data['required_creation_parameters'].update((
+            'classification',))

--- a/test/functional/tm/ltm/test_traffic_class.py
+++ b/test/functional/tm/ltm/test_traffic_class.py
@@ -1,0 +1,64 @@
+# Copyright 2015-2016 F5 Networks Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import copy
+from pprint import pprint as pp
+
+
+TESTDESCRIPTION = "TESTDESCRIPTION"
+
+
+def delete_resource(resources):
+    for resource in resources.get_collection():
+        resource.delete()
+
+
+def setup_traffic_test(request, mgmt_root, name, classification):
+    def teardown():
+        delete_resource(tc1)
+    request.addfinalizer(teardown)
+    tc1 = mgmt_root.tm.ltm.traffic_class_s
+    pp('****')
+    traffic1 = tc1.traffic_class.create(name=name,
+                                        classification=classification)
+    return traffic1, tc1
+
+
+class TestTrafficClass(object):
+    def test_trafficclass_create_refresh_update_delete_load(
+            self, request, mgmt_root):
+        traffic1, tc1 = setup_traffic_test(
+            request, mgmt_root, 'fake_traffic1', 'fakeclasstag')
+        assert traffic1.name == 'fake_traffic1'
+        traffic1.description = TESTDESCRIPTION
+        traffic1.update()
+        assert traffic1.description == TESTDESCRIPTION
+        traffic1.description = ''
+        traffic1.refresh()
+        assert traffic1.description == TESTDESCRIPTION
+        traffic2 = tc1.traffic_class.load(name='fake_traffic1')
+        assert traffic2.selfLink == traffic1.selfLink
+
+    def test_trafficclass_modify(self, request, mgmt_root):
+        traffic1, tc1 = setup_traffic_test(
+            request, mgmt_root, 'fake_traffic1', 'fakeclasstag')
+        original_dict = copy.copy(traffic1.__dict__)
+        desc = 'description'
+        traffic1.modify(description='Cool mod test')
+        for k, v in original_dict.items():
+            if k != desc:
+                original_dict[k] = traffic1.__dict__[k]
+            elif k == desc:
+                assert traffic1.__dict__[k] == 'Cool mod test'

--- a/test/functional/tm/ltm/test_traffic_class.py
+++ b/test/functional/tm/ltm/test_traffic_class.py
@@ -15,6 +15,7 @@
 
 import copy
 from pprint import pprint as pp
+from six import iteritems
 
 
 TESTDESCRIPTION = "TESTDESCRIPTION"
@@ -57,7 +58,7 @@ class TestTrafficClass(object):
         original_dict = copy.copy(traffic1.__dict__)
         desc = 'description'
         traffic1.modify(description='Cool mod test')
-        for k, v in original_dict.items():
+        for k, v in iteritems(traffic1.__dict__):
             if k != desc:
                 original_dict[k] = traffic1.__dict__[k]
             elif k == desc:


### PR DESCRIPTION
Problem:
LTM traffic-class endpoint was missing from the SDK

Analysis:
Added LTM traffic-class endpoint to SDK

Tests:
Flake8
Functional Tests
Unit Tests

Files Added/Changed:

f5-common-python/f5/bigip/tm/ltm/init.py
f5-common-python/f5/bigip/tm/ltm/traffic_class.py
f5-common-python/f5/bigip/tm/ltm/test/test_traffic_class.py
f5-common-python/test/functional/tm/ltm/test_traffic_class.py
