### PR TITLE
Fix unordered dict bug in to_dict()

### DIFF
--- a/requirements.test.txt
+++ b/requirements.test.txt
@@ -10,3 +10,4 @@ pytest-cov>=2.2.1
 git+https://github.com/F5Networks/pytest-symbols.git
 python-coveralls
 pyopenssl
+ordereddict


### PR DESCRIPTION
Issues:
Fixes #687

Problem:
On python3 (and also I presume on python2) the test_two_refs test in
test_mixins.py will fail because the returned value is

```
{"x": [TraversalRecord, "z"], "z": [1, "a"]}
```

instead of the expected value

```
{"x": [1, "a"], "z": ["TraversalRecord", "x"]}
```

Analysis:
I tracked this down to the `_traverse_dict()` method where it iterates
over the values of the `instance_dict` variable. The problem is that
because dictionaries are unordered, the first value that is iterated
upon will sometimes return "z" first instead of "x".

This causes the result to become "turned around" and the test to fail.

I never saw this crop up on python 2, but it crops up regularly on
python 3. The fix I applied is to cast the unordered dict in `_traverse_dict`
into an OrderedDict. Doing this makes the values of that variable always
known, so-to-speak, because they have a defined order. Therefore the
tests will pass as expected.

Tests:
- f5/bigip/test/test_mixins.py::test_to_refs
