### PR TITLE
LBaaSv2 adding a tagged vlan not functioning using v12.1 and 11.6.1

### DIFF
--- a/f5/bigip/tm/net/vlan.py
+++ b/f5/bigip/tm/net/vlan.py
@@ -96,10 +96,6 @@ class Interfaces(Resource, ExclusiveAttributesMixin):
         """
 
         self._check_tagmode_and_tmos_version(**kwargs)
-        if 'tagged' in kwargs and kwargs['tagged'] is True:
-            tup_par = ('tagMode', 'tagged')
-            self._meta_data['required_creation_parameters'].update(tup_par)
-
         return self._create(**kwargs)
 
     def _check_tagmode_and_tmos_version(self, **kwargs):

--- a/test/functional/tm/net/test_vlan.py
+++ b/test/functional/tm/net/test_vlan.py
@@ -97,6 +97,7 @@ class TestVLANInterfaces(object):
         ifc.update()
         assert ifc.untagged is True
         ifc.tagged = True
+        # Having tagmode in the update request will not raise an exception here
         ifc.tagMode = 'service'
         assert not hasattr(ifc, 'untagged')
         ifc.update()
@@ -123,6 +124,8 @@ class TestVLANInterfaces(object):
         ifc.tagged = True
         ifc.tagMode = 'service'
         assert not hasattr(ifc, 'untagged')
+        # tagmode in this request will fail because the test ensures we are
+        # making a request to 11.5.4
         with pytest.raises(TagModeDisallowedForTMOSVersion) as ex:
             ifc.update()
         assert "'tagMode', is not allowed against the following version of " \


### PR DESCRIPTION
@zancas 

Fixes #713
#### Any background context?

When making a request to create a vlan, we are adding tagMode as a
required creation parameter if the tagged kwarg was seen in the request.
#### What's this change do?

We removed the update of the required creation parameters. This will now fail with TagModeDisallowedForTMOSVersion exception if tagMode is in the request and we are querying against BIG-IP 11.5.4. The tests still pass, indicating we did not break backwards compatibility.
