### PR TITLE
Addresses v12.1 changes and incompatibilities in GTM sub-module

### DIFF
--- a/f5/bigip/tm/gtm/pool.py
+++ b/f5/bigip/tm/gtm/pool.py
@@ -32,6 +32,8 @@ from distutils.version import LooseVersion
 from f5.bigip.resource import Collection
 from f5.bigip.resource import OrganizingCollection
 from f5.bigip.resource import Resource
+from f5.bigip.resource import URICreationCollision
+from requests.exceptions import HTTPError
 
 
 class Pools(object):
@@ -88,7 +90,7 @@ class Members_s(object):
             if isinstance(container, Aaaa):
                 return MembersCollectionAAAA(container)
             if isinstance(container, Cname):
-                return MembersCollectionCname
+                return MembersCollectionCname(container)
             if isinstance(container, Mx):
                 return MembersCollectionMx(container)
             if isinstance(container, Naptr):
@@ -102,11 +104,11 @@ class MembersCollection_v11(Collection):
     def __init__(self, pool):
         self.__class__.__name__ = 'Members_s'
         super(MembersCollection_v11, self).__init__(pool)
-        self._meta_data['allowed_lazy_attributes'] = [Members]
+        self._meta_data['allowed_lazy_attributes'] = [Member]
         self._meta_data['required_json_kind'] = \
             'tm:gtm:pool:members:memberscollectionstate'
         self._meta_data['attribute_registry'] = \
-            {'tm:gtm:pool:members:membersstate': Members}
+            {'tm:gtm:pool:members:membersstate': Member}
 
 
 class MembersCollectionA(Collection):
@@ -114,11 +116,11 @@ class MembersCollectionA(Collection):
     def __init__(self, pool):
         self.__class__.__name__ = 'Members_s'
         super(MembersCollectionA, self).__init__(pool)
-        self._meta_data['allowed_lazy_attributes'] = [Members]
+        self._meta_data['allowed_lazy_attributes'] = [Member]
         self._meta_data['required_json_kind'] = \
             'tm:gtm:pool:a:members:memberscollectionstate'
         self._meta_data['attribute_registry'] = \
-            {'tm:gtm:pool:a:members:membersstate': Members}
+            {'tm:gtm:pool:a:members:membersstate': Member}
 
 
 class MembersCollectionAAAA(Collection):
@@ -126,11 +128,11 @@ class MembersCollectionAAAA(Collection):
     def __init__(self, pool):
         self.__class__.__name__ = 'Members_s'
         super(MembersCollectionAAAA, self).__init__(pool)
-        self._meta_data['allowed_lazy_attributes'] = [Members]
+        self._meta_data['allowed_lazy_attributes'] = [Member]
         self._meta_data['required_json_kind'] = \
             'tm:gtm:pool:aaaa:members:memberscollectionstate'
         self._meta_data['attribute_registry'] = \
-            {'tm:gtm:pool:aaaa:members:membersstate': Members}
+            {'tm:gtm:pool:aaaa:members:membersstate': Member}
 
 
 class MembersCollectionCname(Collection):
@@ -138,11 +140,11 @@ class MembersCollectionCname(Collection):
     def __init__(self, pool):
         self.__class__.__name__ = 'Members_s'
         super(MembersCollectionCname, self).__init__(pool)
-        self._meta_data['allowed_lazy_attributes'] = [Members]
+        self._meta_data['allowed_lazy_attributes'] = [Member]
         self._meta_data['required_json_kind'] = \
             'tm:gtm:pool:cname:members:memberscollectionstate'
         self._meta_data['attribute_registry'] = \
-            {'tm:gtm:pool:cname:members:membersstate': Members}
+            {'tm:gtm:pool:cname:members:membersstate': Member}
 
 
 class MembersCollectionMx(Collection):
@@ -150,11 +152,11 @@ class MembersCollectionMx(Collection):
     def __init__(self, pool):
         self.__class__.__name__ = 'Members_s'
         super(MembersCollectionMx, self).__init__(pool)
-        self._meta_data['allowed_lazy_attributes'] = [Members]
+        self._meta_data['allowed_lazy_attributes'] = [Member]
         self._meta_data['required_json_kind'] = \
             'tm:gtm:pool:mx:members:memberscollectionstate'
         self._meta_data['attribute_registry'] = \
-            {'tm:gtm:pool:mx:members:membersstate': Members}
+            {'tm:gtm:pool:mx:members:membersstate': Member}
 
 
 class MembersCollectionNaptr(Collection):
@@ -162,11 +164,11 @@ class MembersCollectionNaptr(Collection):
     def __init__(self, pool):
         self.__class__.__name__ = 'Members_s'
         super(MembersCollectionNaptr, self).__init__(pool)
-        self._meta_data['allowed_lazy_attributes'] = [Members]
+        self._meta_data['allowed_lazy_attributes'] = [Member]
         self._meta_data['required_json_kind'] = \
             'tm:gtm:pool:naptr:members:memberscollectionstate'
         self._meta_data['attribute_registry'] = \
-            {'tm:gtm:pool:naptr:members:membersstate': Members}
+            {'tm:gtm:pool:naptr:members:membersstate': Member}
 
 
 class MembersCollectionSrv(Collection):
@@ -174,14 +176,14 @@ class MembersCollectionSrv(Collection):
     def __init__(self, pool):
         self.__class__.__name__ = 'Members_s'
         super(MembersCollectionSrv, self).__init__(pool)
-        self._meta_data['allowed_lazy_attributes'] = [Members]
+        self._meta_data['allowed_lazy_attributes'] = [Member]
         self._meta_data['required_json_kind'] = \
             'tm:gtm:pool:srv:members:memberscollectionstate'
         self._meta_data['attribute_registry'] = \
-            {'tm:gtm:pool:srv:members:membersstate': Members}
+            {'tm:gtm:pool:srv:members:membersstate': Member}
 
 
-class Members(object):
+class Member(object):
     """BIG-IP® GTM Members factory
 
         The GTM Members factory is used here for code readability
@@ -217,7 +219,7 @@ class Members(object):
 class MembersResource_v11(Resource):
     """v11.x BIG-IP® GTM members resource"""
     def __init__(self, members_s):
-        self.__class__.__name__ = 'Members'
+        self.__class__.__name__ = 'Member'
         super(MembersResource_v11, self).__init__(members_s)
         self._meta_data['required_creation_parameters'].update(('partition',))
         self._meta_data['required_json_kind'] = \
@@ -227,27 +229,141 @@ class MembersResource_v11(Resource):
 class MembersResourceA(Resource):
     """v12.x BIG-IP® GTM A pool members resource"""
     def __init__(self, members_s):
-        self.__class__.__name__ = 'Members'
+        self.__class__.__name__ = 'Member'
         super(MembersResourceA, self).__init__(members_s)
         self._meta_data['required_json_kind'] = \
             'tm:gtm:pool:a:members:membersstate'
         self._meta_data['required_creation_parameters'].update(('partition',))
 
+    def create(self, **kwargs):
+        """This method needs to be created due to a bug in 12.x
+
+        The issue arises when you attempt to create a members sub-collection
+        resource and while the operation succeeds BIGIP responds with 404.
+
+        By requiring partition as argument we have shielded ourselves from
+        this issue in 12.0.0, however in v12.1.x the problem occurs, even when
+        the partition parameter is submitted. Custom create method is required
+        to catch and deal with iControlUnexpectedHTTPError exception.
+
+        Issue is tracked under: ID610441.
+
+        note:: If version is 12.x then we use this method, otherwise we use
+               _create method from Resource class as usual.
+        """
+        tmos_v = self._meta_data['bigip']._meta_data['tmos_version']
+        if LooseVersion(tmos_v) >= LooseVersion('12.1.0'):
+            if 'uri' in self._meta_data:
+                error = "There was an attempt to assign a new uri to this " \
+                        "resource, the _meta_data['uri'] is %s and it should" \
+                        " not be changed." % (self._meta_data['uri'])
+                raise URICreationCollision(error)
+            self._check_exclusive_parameters(**kwargs)
+            requests_params = self._handle_requests_params(kwargs)
+            self._check_create_parameters(**kwargs)
+
+            # Reduce boolean pairs as specified by the meta_data entry below
+            for key1, key2 in self._meta_data['reduction_forcing_pairs']:
+                kwargs = self._reduce_boolean_pair(kwargs, key1, key2)
+
+            # Make convenience variable with short names for this method.
+            _create_uri = self._meta_data['container']._meta_data['uri']
+            session = self._meta_data['bigip']._meta_data['icr_session']
+            # This is a bit hacky but we need to do this so we are able to
+            # create a resource inside SDK properly. We also include the
+            # scenario where 20x range response occurs just in case this gets
+            # fixed in later 12.x release.
+
+            try:
+                response = session.post(
+                    _create_uri, json=kwargs, **requests_params)
+
+            except HTTPError as err:
+                if err.response.status_code != 404:
+                    raise
+                if err.response.status_code == 404:
+                    kwargs['uri_as_parts'] = True
+                    response = session.get(_create_uri, **kwargs)
+                    return self._produce_instance(response)
+
+            # Make new instance of self
+            return self._produce_instance(response)
+
+        else:
+            return self._create(**kwargs)
+
 
 class MembersResourceAAAA(Resource):
     """v12.x BIG-IP® GTM AAAA pool members resource"""
     def __init__(self, members_s):
-        self.__class__.__name__ = 'Members'
+        self.__class__.__name__ = 'Member'
         super(MembersResourceAAAA, self).__init__(members_s)
         self._meta_data['required_json_kind'] = \
             'tm:gtm:pool:aaaa:members:membersstate'
         self._meta_data['required_creation_parameters'].update(('partition',))
 
+    def create(self, **kwargs):
+        """This method needs to be created due to a bug in 12.x
+
+        The issue arises when you attempt to create a members sub-collection
+        resource and while the operation succeeds BIGIP responds with 404.
+
+        By requiring partition as argument we have shielded ourselves from
+        this issue in 12.0.0, however in v12.1.x the problem occurs, even when
+        the partition parameter is submitted. Custom create method is required
+        to catch and deal with iControlUnexpectedHTTPError exception.
+
+        Issue is tracked under: ID610441.
+
+        note:: If version is 12.x then we use this method, otherwise we use
+               _create method from Resource class as usual.
+        """
+        tmos_v = self._meta_data['bigip']._meta_data['tmos_version']
+        if LooseVersion(tmos_v) >= LooseVersion('12.1.0'):
+            if 'uri' in self._meta_data:
+                error = "There was an attempt to assign a new uri to this " \
+                        "resource, the _meta_data['uri'] is %s and it should" \
+                        " not be changed." % (self._meta_data['uri'])
+                raise URICreationCollision(error)
+            self._check_exclusive_parameters(**kwargs)
+            requests_params = self._handle_requests_params(kwargs)
+            self._check_create_parameters(**kwargs)
+
+            # Reduce boolean pairs as specified by the meta_data entry below
+            for key1, key2 in self._meta_data['reduction_forcing_pairs']:
+                kwargs = self._reduce_boolean_pair(kwargs, key1, key2)
+
+            # Make convenience variable with short names for this method.
+            _create_uri = self._meta_data['container']._meta_data['uri']
+            session = self._meta_data['bigip']._meta_data['icr_session']
+            # This is a bit hacky but we need to do this so we are able to
+            # create a resource inside SDK properly. We also include the
+            # scenario where 20x range response occurs just in case this gets
+            # fixed in later 12.x release.
+
+            try:
+                response = session.post(
+                    _create_uri, json=kwargs, **requests_params)
+
+            except HTTPError as err:
+                if err.response.status_code != 404:
+                    raise
+                if err.response.status_code == 404:
+                    kwargs['uri_as_parts'] = True
+                    response = session.get(_create_uri, **kwargs)
+                    return self._produce_instance(response)
+
+            # Make new instance of self
+            return self._produce_instance(response)
+
+        else:
+            return self._create(**kwargs)
+
 
 class MembersResourceCname(Resource):
     """v12.x BIG-IP® GTM CNAME pool members resource"""
     def __init__(self, members_s):
-        self.__class__.__name__ = 'Members'
+        self.__class__.__name__ = 'Member'
         super(MembersResourceCname, self).__init__(members_s)
         self._meta_data['required_json_kind'] = \
             'tm:gtm:pool:cname:members:membersstate'
@@ -256,7 +372,7 @@ class MembersResourceCname(Resource):
 class MembersResourceMx(Resource):
     """v12.x BIG-IP® GTM MX pool members resource"""
     def __init__(self, members_s):
-        self.__class__.__name__ = 'Members'
+        self.__class__.__name__ = 'Member'
         super(MembersResourceMx, self).__init__(members_s)
         self._meta_data['required_json_kind'] = \
             'tm:gtm:pool:mx:members:membersstate'
@@ -265,7 +381,7 @@ class MembersResourceMx(Resource):
 class MembersResourceNaptr(Resource):
     """v12.x BIG-IP® GTM NAPTR pool members resource"""
     def __init__(self, members_s):
-        self.__class__.__name__ = 'Members'
+        self.__class__.__name__ = 'Member'
         super(MembersResourceNaptr, self).__init__(members_s)
         self._meta_data['required_json_kind'] = \
             'tm:gtm:pool:naptr:members:membersstate'
@@ -276,7 +392,7 @@ class MembersResourceNaptr(Resource):
 class MembersResourceSrv(Resource):
     """v12.x BIG-IP® GTM SRV pool members resource"""
     def __init__(self, members_s):
-        self.__class__.__name__ = 'Members'
+        self.__class__.__name__ = 'Member'
         super(MembersResourceSrv, self).__init__(members_s)
         self._meta_data['required_json_kind'] = \
             'tm:gtm:pool:srv:members:membersstate'

--- a/f5/bigip/tm/gtm/server.py
+++ b/f5/bigip/tm/gtm/server.py
@@ -57,18 +57,18 @@ class Virtual_Servers_s(Collection):
     """BIG-IP® GTM virtual server sub-collection"""
     def __init__(self, server):
         super(Virtual_Servers_s, self).__init__(server)
-        self._meta_data['allowed_lazy_attributes'] = [Virtual_Servers]
+        self._meta_data['allowed_lazy_attributes'] = [Virtual_Server]
         self._meta_data['required_json_kind'] = \
             'tm:gtm:server:virtual-servers:virtual-serverscollectionstate'
         self._meta_data['attribute_registry'] = {
             'tm:gtm:server:virtual-servers:virtual-serversstate':
-                Virtual_Servers}
+                Virtual_Server}
 
 
-class Virtual_Servers(Resource):
+class Virtual_Server(Resource):
     """BIG-IP® GTM virtual server resource"""
     def __init__(self, virtual_servers_s):
-        super(Virtual_Servers, self).__init__(virtual_servers_s)
+        super(Virtual_Server, self).__init__(virtual_servers_s)
         self._meta_data['required_creation_parameters'].update((
             'destination',))
         self._meta_data['required_json_kind'] = \

--- a/f5/bigip/tm/gtm/test/test_server.py
+++ b/f5/bigip/tm/gtm/test/test_server.py
@@ -19,7 +19,7 @@ import pytest
 from f5.bigip import ManagementRoot
 from f5.bigip.resource import MissingRequiredCreationParameter
 from f5.bigip.tm.gtm.server import Server
-from f5.bigip.tm.gtm.server import Virtual_Servers
+from f5.bigip.tm.gtm.server import Virtual_Server
 
 from six import iterkeys
 
@@ -34,7 +34,7 @@ def FakeServer():
 @pytest.fixture
 def FakeVS():
     fake_server = mock.MagicMock()
-    fake_vs = Virtual_Servers(fake_server)
+    fake_vs = Virtual_Server(fake_server)
     return fake_vs
 
 

--- a/test/functional/tm/gtm/test_pool.py
+++ b/test/functional/tm/gtm/test_pool.py
@@ -95,7 +95,7 @@ def setup_gtm_server(request, mgmt_root, name, partition, **kwargs):
 def delete_gtm_vs(mgmt_root, name):
     s1 = mgmt_root.tm.gtm.servers.server.load(name=GTM_SERVER)
     try:
-        foo = s1.virtual_servers_s.virtual_servers.load(
+        foo = s1.virtual_servers_s.virtual_server.load(
             name=name)
     except HTTPError as err:
         if err.response.status_code != 404:
@@ -109,7 +109,7 @@ def setup_gtm_vs(request, mgmt_root, name, destination, **kwargs):
         delete_gtm_vs(mgmt_root, name)
 
     s1 = setup_gtm_server(request, mgmt_root, GTM_SERVER, 'Common', **kwargs)
-    vs = s1.virtual_servers_s.virtual_servers.create(
+    vs = s1.virtual_servers_s.virtual_server.create(
         name=name, destination=destination)
     request.addfinalizer(teardown)
     return vs
@@ -257,27 +257,27 @@ class HelperTest(object):
         if isinstance(pool, A):
             setup_gtm_vs(request, mgmt_root, GTM_VS, '20.20.20.20:80',
                          addresses=[{'name': '1.1.1.1'}])
-            member = mem_coll.members.create(name=RES_NAME,
-                                             partition=self.partition)
+            member = mem_coll.member.create(name=RES_NAME,
+                                            partition=self.partition)
         elif isinstance(pool, Aaaa):
             setup_gtm_vs(request, mgmt_root, GTM_VS,
                          'fd00:7967:71a5::.80',
                          addresses=[{'name': 'fda8:e5d6:5ef6::'}])
-            member = mem_coll.members.create(name=RES_NAME,
-                                             partition=self.partition)
+            member = mem_coll.member.create(name=RES_NAME,
+                                            partition=self.partition)
         elif isinstance(pool, Cname) or isinstance(pool, Mx):
             setup_wideip_v12(request, mgmt_root, WIDEIPNAME,
                              partition=self.partition)
-            member = mem_coll.members.create(name=WIDEIPNAME)
+            member = mem_coll.member.create(name=WIDEIPNAME)
         elif isinstance(pool, Naptr):
             setup_wideip_v12(request, mgmt_root, WIDEIPNAME,
                              partition=self.partition)
-            member = mem_coll.members.create(name=WIDEIPNAME,
-                                             flags='a', service='http')
+            member = mem_coll.member.create(name=WIDEIPNAME,
+                                            flags='a', service='http')
         elif isinstance(pool, Srv):
             setup_wideip_v12(request, mgmt_root, WIDEIPNAME,
                              partition=self.partition)
-            member = mem_coll.members.create(name=WIDEIPNAME, port=80)
+            member = mem_coll.member.create(name=WIDEIPNAME, port=80)
 
         return member, mem_coll, member.name
 
@@ -576,7 +576,7 @@ def setup_member_basic_test(request, mgmt_root, name, partition, poolname):
     pool, poolcoll = setup_pool_basic_test(request, mgmt_root, poolname,
                                            partition)
     memberc = pool.members_s
-    member = memberc.members.create(name=name, partition=partition)
+    member = memberc.member.create(name=name, partition=partition)
     request.addfinalizer(teardown)
     return member, memberc
 
@@ -700,7 +700,7 @@ class TestMembersSubCollection_v11(object):
                      addresses=[{'name': '1.1.1.1'}])
         p1, pc = setup_pool_basic_test(request, mgmt_root, 'fake_pool',
                                        'Common')
-        m1 = p1.members_s.members.create(name=RES_NAME, partition='Common')
+        m1 = p1.members_s.member.create(name=RES_NAME, partition='Common')
         uri = 'https://localhost/mgmt/tm/gtm/pool/~Common~fake_pool/' \
               'members/~Common~fake_serv1:fakeVS'
         assert m1.name == RES_NAME
@@ -714,10 +714,10 @@ class TestMembersSubCollection_v11(object):
                      addresses=[{'name': '1.1.1.1'}])
         p1, pc = setup_pool_basic_test(request, mgmt_root, 'fake_pool',
                                        'Common')
-        m1 = p1.members_s.members.create(name=RES_NAME, partition='Common',
-                                         description='FancyFakeMember',
-                                         limitMaxBpsStatus='enabled',
-                                         limitMaxBps=1337)
+        m1 = p1.members_s.member.create(name=RES_NAME, partition='Common',
+                                        description='FancyFakeMember',
+                                        limitMaxBpsStatus='enabled',
+                                        limitMaxBps=1337)
         assert m1.name == RES_NAME
         assert m1.description == 'FancyFakeMember'
         assert m1.limitMaxBpsStatus == 'enabled'
@@ -728,7 +728,7 @@ class TestMembersSubCollection_v11(object):
                                 'fake_pool')
         p1 = mgmt_root.tm.gtm.pools.pool.load(name='fake_pool')
         try:
-            p1.members_s.members.create(name=RES_NAME, partition='Common')
+            p1.members_s.member.create(name=RES_NAME, partition='Common')
         except HTTPError as err:
             assert err.response.status_code == 409
 
@@ -736,8 +736,8 @@ class TestMembersSubCollection_v11(object):
         setup_member_basic_test(request, mgmt_root, RES_NAME, 'Common',
                                 'fake_pool')
         p1 = mgmt_root.tm.gtm.pools.pool.load(name='fake_pool')
-        m1 = p1.members_s.members.load(name=RES_NAME, partition='Common')
-        m2 = p1.members_s.members.load(name=RES_NAME, partition='Common')
+        m1 = p1.members_s.member.load(name=RES_NAME, partition='Common')
+        m2 = p1.members_s.member.load(name=RES_NAME, partition='Common')
 
         assert m1.limitMaxBpsStatus == 'disabled'
         assert m1.limitMaxBpsStatus == 'disabled'
@@ -753,7 +753,7 @@ class TestMembersSubCollection_v11(object):
         p1, pc = setup_pool_basic_test(request, mgmt_root, 'fake_pool',
                                        'Common')
         try:
-            p1.members_s.members.load(name=RES_NAME)
+            p1.members_s.member.load(name=RES_NAME)
         except HTTPError as err:
             assert err.response.status_code == 404
 
@@ -765,7 +765,7 @@ class TestMembersSubCollection_v11(object):
 
         m1.limitMaxBpsStatus = 'enabled'
         m1.update()
-        m2 = mc.members.load(name=RES_NAME, partition='Common')
+        m2 = mc.member.load(name=RES_NAME, partition='Common')
         assert m2.name == RES_NAME
         assert m2.limitMaxBpsStatus == 'enabled'
 
@@ -797,7 +797,7 @@ class TestMembersSubCollection_v11(object):
         m1.delete()
         p1 = mgmt_root.tm.gtm.pools.pool.load(name='fake_pool')
         try:
-            p1.members_s.members.load(name=RES_NAME)
+            p1.members_s.member.load(name=RES_NAME)
         except HTTPError as err:
             assert err.response.status_code == 404
 


### PR DESCRIPTION
Fixes Issues: #719,  #679

Updated Files:

```
test/functional/gtm/test_pool.py
test/functional/test_server.py
f5/bigip/tm/gtm/pool.py
f5/bigip/tm/gtm/server.py
```

Updates:

As we started adding Partition to the selflinks in 12.1.0, some tests needed to be amended. There is a serious bug in 12.x branch with members, as described in #719, I have had to create custom create methods for 2 member classes in pools.py.
Corrected subcollection resource names to be singular not plural as per discussion with Tim, amended tests accordingly
