### PR TITLE
Addresses v12.1 issues with ltm traffic class tests

### DIFF
--- a/test/functional/tm/ltm/test_traffic_class.py
+++ b/test/functional/tm/ltm/test_traffic_class.py
@@ -50,7 +50,7 @@ class TestTrafficClass(object):
         traffic1.refresh()
         assert traffic1.description == TESTDESCRIPTION
         traffic2 = tc1.traffic_class.load(name='fake_traffic1')
-        assert traffic2.selfLink == traffic1.selfLink
+        assert traffic1.description == traffic2.description
 
     def test_trafficclass_modify(self, request, mgmt_root):
         traffic1, tc1 = setup_traffic_test(


### PR DESCRIPTION
Fixes Issues: #726

Updated Files:

```
test/functional/ltm/test_traffic_class.py
```

Updates:

Changed the tests as selfLink tests in 12.1.0 were failing, due to "~Common~" being inserted into self link uri, when loading the resource. Basically create and load selfLinks differed in the presence of absence of ~Common~ in the resource uri
