### PR TITLE
Issue #730 - Fixes snat functional test for 12.1

### DIFF
--- a/test/functional/tm/ltm/test_snat.py
+++ b/test/functional/tm/ltm/test_snat.py
@@ -26,9 +26,9 @@ EXPECTED_ORIGINS_DELETION_MESSAGE = 'one of the following must be ',\
     'specified:\\\\nadd, delete, modify, replace-all-with","errorStack":[]}\''
 
 
-def delete_snat(bigip, name, partition):
+def delete_snat(mgmt_root, name, partition):
     try:
-        s = bigip.ltm.snats.snat.load(name=name, partition=partition)
+        s = mgmt_root.tm.ltm.snats.snat.load(name=name, partition=partition)
     except HTTPError as err:
         if err.response.status_code != 404:
             raise
@@ -36,33 +36,33 @@ def delete_snat(bigip, name, partition):
     s.delete()
 
 
-def setup_create_test(request, bigip, name, partition):
+def setup_create_test(request, mgmt_root, name, partition):
     def teardown():
-        delete_snat(bigip, name, partition)
+        delete_snat(mgmt_root, name, partition)
     request.addfinalizer(teardown)
-    snat1 = bigip.ltm.snats.snat
+    snat1 = mgmt_root.tm.ltm.snats.snat
     return snat1
 
 
-def setup_basic_test(request, bigip, name, partition, orig='1.1.1.1'):
+def setup_basic_test(request, mgmt_root, name, partition, orig='1.1.1.1'):
     def teardown():
-        delete_snat(bigip, name, partition)
+        delete_snat(mgmt_root, name, partition)
 
-    snat_s1 = bigip.ltm.snats
-    snat1 = bigip.ltm.snats.snat.create(
+    snat_s1 = mgmt_root.tm.ltm.snats
+    snat1 = mgmt_root.tm.ltm.snats.snat.create(
         name=name, partition=partition, origins=orig, automap=True)
     request.addfinalizer(teardown)
     return snat1, snat_s1
 
 
 class TestSNAT(object):
-    def test_create_no_args(self, request, bigip):
-        snat1 = setup_create_test(request, bigip, 'TESTNAME', 'Common')
+    def test_create_no_args(self, request, mgmt_root):
+        snat1 = setup_create_test(request, mgmt_root, 'TESTNAME', 'Common')
         with pytest.raises(RequireOneOf):
             snat1.create()
 
-    def test_create(self, request, bigip):
-        snat = setup_create_test(request, bigip, 'snat1', 'Common')
+    def test_create(self, request, mgmt_root):
+        snat = setup_create_test(request, mgmt_root, 'snat1', 'Common')
         snat1 = snat.create(
             name='snat1', partition='Common', origins='1.1.1.1', automap=True)
         assert snat1.name == 'snat1'
@@ -72,8 +72,8 @@ class TestSNAT(object):
         assert snat1.selfLink.startswith(
             'https://localhost/mgmt/tm/ltm/snat/~Common~snat1')
 
-    def test_update_and_refresh(self, request, bigip):
-        snat1, sc1 = setup_basic_test(request, bigip, 'snat1', 'Common')
+    def test_update_and_refresh(self, request, mgmt_root):
+        snat1, sc1 = setup_basic_test(request, mgmt_root, 'snat1', 'Common')
         snat1.description = TESTDESCRIPTION
         snat1.update()
         assert snat1.description == TESTDESCRIPTION
@@ -84,13 +84,13 @@ class TestSNAT(object):
         snat1.update()
         assert snat1.description == "NEWDESCRIPTION"
 
-    def test_load_and_delete(self, request, bigip):
-        snat1, sc1 = setup_basic_test(request, bigip, 'snat1', 'Common')
+    def test_load_and_delete(self, request, mgmt_root):
+        snat1, sc1 = setup_basic_test(request, mgmt_root, 'snat1', 'Common')
         snat1.delete()
         assert snat1.__dict__ == {'deleted': True}
 
-    def test_add_one_origin(self, request, bigip):
-        snat1, sc1 = setup_basic_test(request, bigip, 'snat1', 'Common')
+    def test_add_one_origin(self, request, mgmt_root):
+        snat1, sc1 = setup_basic_test(request, mgmt_root, 'snat1', 'Common')
         assert snat1.origins == [{u'name': u'1.1.1.1/32'}]
         origin2 = {u'name': u'2.2.2.2/32'}
         snat1.origins.append(origin2)
@@ -102,6 +102,6 @@ class TestSNAT(object):
         assert snat1.origins == [{u'name': u'2.2.2.2/32'},
                                  {u'name': u'3.3.3.3/32'}]
         snat1.origins = []
-        with pytest.raises(iControlUnexpectedHTTPError) as UHEIO:
+        with pytest.raises(iControlUnexpectedHTTPError) as err:
             snat1.update()
-        assert UHEIO.value.message.endswith(EXPECTED_ORIGINS_DELETION_MESSAGE)
+            assert EXPECTED_ORIGINS_DELETION_MESSAGE in err.response.text


### PR DESCRIPTION
Updated Files
- test/functional/tm/ltm/test_snat.py
  
  Updates
- Updated bigip fixture to mgmt_root fixture in all test cases
- Changed test assertion from exact match to make sure string was present as the response text has changed slightly in 12.1
