### PR TITLE
Addresses NTP and FDB test issues in 12.1

### DIFF
--- a/test/functional/tm/net/test_fdb.py
+++ b/test/functional/tm/net/test_fdb.py
@@ -12,8 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+from distutils.version import LooseVersion
+import pytest
 
 TEST_MAC = '02:00:00:00:00:01'
+
+V12PAYLOAD = [{'name': '02:00:00:00:00:01', 'endpoint': '10.1.1.1'}]
 
 
 def test_tunnels_get_collection(mgmt_root):
@@ -22,6 +26,9 @@ def test_tunnels_get_collection(mgmt_root):
         assert tunnel.name == 'http-tunnel' or tunnel.name == 'socks-tunnel'
 
 
+@pytest.mark.skipif(
+    LooseVersion(pytest.config.getoption('--release')) >= LooseVersion(
+        '12.1.0'), reason='This test is for 12.0.0 or less.')
 def test_tunnel_exists_load_update_refresh(mgmt_root):
     t_fact = mgmt_root.tm.net.fdb.tunnels.tunnel
     assert t_fact.exists(partition='Common', name='http-tunnel')
@@ -31,5 +38,22 @@ def test_tunnel_exists_load_update_refresh(mgmt_root):
     http_tunnel.update(records=TEST_MAC)
     http2_tunnel.refresh()
     assert http2_tunnel.records == [{u'name': u'02:00:00:00:00:01'}]
+    http_tunnel.update(records=None)
+    assert 'records' not in http_tunnel.__dict__
+
+
+@pytest.mark.skipif(
+    LooseVersion(pytest.config.getoption('--release')) < LooseVersion(
+        '12.1.0'), reason='This test is for 12.1.0 or greater.')
+def test_tunnel_exists_load_update_refresh_v12_1(mgmt_root):
+    t_fact = mgmt_root.tm.net.fdb.tunnels.tunnel
+    assert t_fact.exists(partition='Common', name='http-tunnel')
+    assert t_fact.exists(partition='Common', name='socks-tunnel')
+    http_tunnel = t_fact.load(partition='Common', name='http-tunnel')
+    http2_tunnel = t_fact.load(partition='Common', name='http-tunnel')
+    http_tunnel.update(records=V12PAYLOAD)
+    http2_tunnel.refresh()
+    assert http2_tunnel.records == [{u'name': u'02:00:00:00:00:01',
+                                     u'endpoint': u'10.1.1.1'}]
     http_tunnel.update(records=None)
     assert 'records' not in http_tunnel.__dict__

--- a/test/functional/tm/sys/test_ntp.py
+++ b/test/functional/tm/sys/test_ntp.py
@@ -76,9 +76,18 @@ class TestNtpRestrictions(object):
         if pytest.config.getoption('--release') < LooseVersion('11.6.1'):
             assert ntp1.name == 'r1'
             assert ntp1.partition == 'Common'
+        elif pytest.config.getoption('--release') >= LooseVersion('12.1.0'):
+            assert ntp1.name == 'r1'
+            assert not hasattr(ntp1, 'partition')
         else:
             assert ntp1.name == '/Common/r1'
             # The 'partition' attribute was removed in 11.6.1?
+            assert not hasattr(ntp1, 'partition')
+
+        if pytest.config.getoption('--release') >= LooseVersion('12.1.0'):
+            link = 'https://localhost/mgmt/tm/sys/ntp/restrict/r1'
+        else:
+            link = 'https://localhost/mgmt/tm/sys/ntp/restrict/~Common~r1'
 
         assert ntp1.defaultEntry == "disabled"
         assert ntp1.ignore == "disabled"
@@ -95,8 +104,7 @@ class TestNtpRestrictions(object):
         assert ntp1.ntpPort == "disabled"
         assert ntp1.version == "disabled"
         assert ntp1.kind == 'tm:sys:ntp:restrict:restrictstate'
-        assert ntp1.selfLink.startswith(
-            'https://localhost/mgmt/tm/sys/ntp/restrict/~Common~r1')
+        assert ntp1.selfLink.startswith(link)
 
     def test_create_full(self, request, mgmt_root):
         ntp = setup_restrict_test(request, mgmt_root,
@@ -130,9 +138,18 @@ class TestNtpRestrictions(object):
         if pytest.config.getoption('--release') < LooseVersion('11.6.1'):
             assert ntp1.name == 'r2'
             assert ntp1.partition == 'Common'
+        elif pytest.config.getoption('--release') >= LooseVersion('12.1.0'):
+            assert ntp1.name == 'r2'
+            assert not hasattr(ntp1, 'partition')
         else:
             assert ntp1.name == '/Common/r2'
+            assert not hasattr(ntp1, 'partition')
             # The 'partition' attribute was removed in 11.6.1?
+
+        if pytest.config.getoption('--release') >= LooseVersion('12.1.0'):
+            link = 'https://localhost/mgmt/tm/sys/ntp/restrict/r2'
+        else:
+            link = 'https://localhost/mgmt/tm/sys/ntp/restrict/~Common~r2'
 
         assert ntp1.address == "192.168.1.0"
         assert ntp1.defaultEntry == "enabled"
@@ -151,5 +168,4 @@ class TestNtpRestrictions(object):
         assert ntp1.ntpPort == "enabled"
         assert ntp1.version == "enabled"
         assert ntp1.kind == 'tm:sys:ntp:restrict:restrictstate'
-        assert ntp1.selfLink.startswith(
-            'https://localhost/mgmt/tm/sys/ntp/restrict/~Common~r2')
+        assert ntp1.selfLink.startswith(link)


### PR DESCRIPTION
Fixes Issues: #733, #734

Updated Files:

```
test/functional/net/test_fdb.py
 test/functional/sys/test_ntp.py
```

Updates:

There are some changes again in some resource names not prepended by /Common/, so some conditionals required to be added to ntp tests. FDB tests were failing due to a change in required parameters inside 'records', in 12.1 apart from name, also endpoint parameter was required for the record to be created. This corresponds to TMSH command changes.

Tests:

Flake8
Functional Test
