### PR TITLE
Adds requests-mock package for testing

### DIFF
--- a/devtools/dockerfiles/Dockerfile.python2
+++ b/devtools/dockerfiles/Dockerfile.python2
@@ -35,6 +35,7 @@ RUN pip install hacking==0.10.2 \
     f5-icontrol-rest==1.0.7 \
     pyOpenSSL==16.0.0 \
     python-coveralls==2.7.0 \
-    ordereddict
+    ordereddict \
+    requests-mock==1.1.0
 
 CMD /bin/bash

--- a/devtools/dockerfiles/Dockerfile.python3
+++ b/devtools/dockerfiles/Dockerfile.python3
@@ -34,6 +34,7 @@ RUN pip install hacking==0.10.2 \
     git+https://github.com/F5Networks/pytest-symbols.git \
     f5-icontrol-rest==1.0.7 \
     pyOpenSSL==16.0.0 \
-    python-coveralls==2.7.0
+    python-coveralls==2.7.0 \
+    requests-mock==1.1.0
 
 CMD /bin/bash

--- a/requirements.test.txt
+++ b/requirements.test.txt
@@ -11,3 +11,4 @@ git+https://github.com/F5Networks/pytest-symbols.git
 python-coveralls
 pyopenssl
 ordereddict
+requests-mock==1.1.0


### PR DESCRIPTION
Issues:
Fixes #738

Problem:
This change supplies the python requests-mock package in the
test pip and docker files so that it can be used in tests

Analysis:
Contributors asked that this package be included for writing
unit and functional tests. The change updates the dockerfiles
and the pip requirements file to support version 1.1.0 of
the requests-mock package

Tests:
none
