### PR TITLE
Feature.policy drafts

### DIFF
--- a/f5/bigip/tm/ltm/policy.py
+++ b/f5/bigip/tm/ltm/policy.py
@@ -80,8 +80,7 @@ class Policy(Resource):
                 "to this method and both are set to True. A legacy ltm " \
                 "policy does not have the 'draft' or 'published' status."
             raise DraftPolicyNotSupportedInTMOSVersion(msg)
-
-        if legacy and LooseVersion(tmos_ver) >= LooseVersion('12.1.0'):
+        elif legacy and not publish:
             return super(Policy, self)._create(**kwargs)
         elif not legacy and LooseVersion(tmos_ver) < LooseVersion('12.1.0'):
             msg = "The version of TMOS on the device does not support " \

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ setup(
     author_email='f5_common_python@f5.com',
     url='https://github.com/F5Networks/f5-common-python',
     keywords=['F5', 'sdk', 'api', 'icontrol', 'bigip', 'api', 'ltm'],
-    install_requires=['f5-icontrol-rest == 1.0.9'],
+    install_requires=['f5-icontrol-rest == 1.1.0'],
     packages=find_packages(
         exclude=["*.test", "*.test.*", "test.*", "test_*", "test", "test*"]
     ),

--- a/test/functional/tm/ltm/test_policy.py
+++ b/test/functional/tm/ltm/test_policy.py
@@ -13,9 +13,14 @@
 # limitations under the License.
 #
 
+import copy
 from distutils.version import LooseVersion
+from icontrol.session import iControlUnexpectedHTTPError
 from pprint import pprint as pp
 import pytest
+
+from f5.bigip.tm.ltm.policy import DraftPolicyNotSupportedInTMOSVersion
+from f5.bigip.tm.ltm.policy import OperationNotSupportedOnPublishedPolicy
 
 pp('')
 TESTDESCRIPTION = "TESTDESCRIPTION"
@@ -28,9 +33,27 @@ def setup(request, setup_device_snapshot):
 
 def setup_policy_test(request, mgmt_root, partition, name,
                       strategy="first-match", **kwargs):
+    def teardown_policy():
+        kw = copy.deepcopy(kwargs)
+        kw.pop('legacy', None)
+        kw.pop('publish', None)
+        if mgmt_root.tm.ltm.policys.policy.exists(
+                name=name, partition=partition, **kw):
+            pol = mgmt_root.tm.ltm.policys.policy.load(
+                name=name, partition=partition, **kw)
+            pol.delete()
+        # Try to delete published draft if exists as well
+        kw.pop('subPath', None)
+        if mgmt_root.tm.ltm.policys.policy.exists(
+                name=name, partition=partition, **kw):
+            pol = mgmt_root.tlm.ltm.policys.policy.load(
+                name=name, partition=partition, **kw)
+            pol.delete()
+
     pc1 = mgmt_root.tm.ltm.policys
     policy1 = pc1.policy.create(
         name=name, partition=partition, strategy=strategy, **kwargs)
+    request.addfinalizer(teardown_policy)
     return policy1, pc1
 
 
@@ -80,6 +103,16 @@ class TestPolicy_legacy(object):
         assert r1conditions.kind == r1conditions._meta_data[
             'required_json_kind']
 
+    def test_create_policy_legacy_false(self, setup, request, mgmt_root):
+        with pytest.raises(DraftPolicyNotSupportedInTMOSVersion) as ex:
+            policy1, pc1 = setup_policy_test(request, mgmt_root, 'Common',
+                                             'poltest1', legacy=False)
+        msg = "The version of TMOS on the device does not support " \
+            "draft policies. The keyword argument 'legacy' was " \
+            "given to this method and it was set to 'False'. This " \
+            "is not allowed on the current device."
+        assert msg == ex.value.message
+
 
 @pytest.mark.skipif(
     LooseVersion(
@@ -91,17 +124,109 @@ class TestPolicy(object):
     def test_policy_create_refresh_update_delete_load(self, setup, request,
                                                       mgmt_root):
         policy1, pc1 = setup_policy_test(request, mgmt_root, 'Common',
-                                         'poltest1', legacy=True)
+                                         'poltest1', subPath='Drafts',
+                                         legacy=True)
         assert policy1.name == 'poltest1'
         policy1.strategy = '/Common/all-match'
-        policy1.update(legacy=True)
+        policy1.update()
         assert policy1.strategy == '/Common/all-match'
         policy1.strategy = '/Common/first-match'
         policy1.refresh()
         assert policy1.strategy == '/Common/all-match'
-        policy2 = pc1.policy.load(partition='Common', name='poltest1')
+        policy2 = pc1.policy.load(
+            partition='Common', name='poltest1', subPath='Drafts')
         assert policy2.selfLink == policy1.selfLink
         p2rc = policy2.rules_s
         p2rc.refresh()
         assert p2rc._meta_data['required_json_kind'] == p2rc.kind
         assert p2rc.get_collection() == []
+
+    def test_policy_create_no_subpath(self, setup, mgmt_root, request):
+        with pytest.raises(iControlUnexpectedHTTPError) as ex:
+            pol, pc1 = setup_policy_test(request, mgmt_root, 'Common',
+                                         'poltest1', legacy=False)
+        assert 'Cannot create/modify published policy' in ex.value.message
+
+    def test_policy_create_legacy_and_publish(
+            self, setup, mgmt_root, request):
+        with pytest.raises(DraftPolicyNotSupportedInTMOSVersion) as ex:
+            setup_policy_test(request, mgmt_root, 'Common',
+                              'poltest1', legacy=True, publish=True)
+        msg = "The keyword arguments 'legacy' and 'publish' were given " \
+            "to this method and both are set to True. A legacy ltm " \
+            "policy does not have the 'draft' or 'published' status."
+        assert msg == ex.value.message
+
+    def test_policy_create_draft(self, setup, mgmt_root, request):
+        pol1, pc1 = setup_policy_test(request, mgmt_root, 'Common',
+                                      'poltest1', legacy=False,
+                                      subPath='Drafts')
+        assert pol1.fullPath == '/Common/Drafts/poltest1'
+        pol1.strategy = '/Common/all-match'
+        pol1.update()
+        assert pol1.strategy == '/Common/all-match'
+        pol1a = pc1.policy.load(
+            name='poltest1', partition='Common', subPath='Drafts')
+        assert pol1a.strategy == pol1.strategy
+
+    def test_policy_publish_draft_on_create(self, setup, mgmt_root, request):
+        # Can publish a draft two ways, by providing publish=True to create
+        # for a policy, or call .publish() on an existing policy object
+        pol1, pc1 = setup_policy_test(request, mgmt_root, 'Common',
+                                      'poltest1', subPath='Drafts',
+                                      legacy=False, publish=True)
+        assert pol1.fullPath == '/Common/poltest1'
+        assert pol1.status == 'published'
+        pol2 = pc1.policy.load(name='poltest1', partition='Common')
+        assert pol1.status == 'published'
+        assert pol1.strategy == '/Common/first-match'
+        assert pol1.strategy == pol2.strategy
+        pol2.delete()
+
+    def test_policy_publish_draft(self, setup, mgmt_root, request):
+        # Can publish a draft two ways, by providing publish=True to create
+        # for a policy, or call .publish() on an existing policy object
+        pol1, pc1 = setup_policy_test(request, mgmt_root, 'Common',
+                                      'poltest1', subPath='Drafts',
+                                      legacy=False)
+        assert pol1.fullPath == '/Common/Drafts/poltest1'
+        assert pol1.status == 'draft'
+        pol1.publish()
+        assert pol1.fullPath == '/Common/poltest1'
+        assert pol1.status == 'published'
+        pol2 = pc1.policy.load(name='poltest1', partition='Common')
+        assert pol1.status == 'published'
+        pol2.delete()
+
+    def test_policy_publish_draft_update_exception(
+            self, setup, mgmt_root, request):
+        pol1, pc1 = setup_policy_test(request, mgmt_root, 'Common',
+                                      'poltest1', subPath='Drafts',
+                                      legacy=False)
+        assert pol1.fullPath == '/Common/Drafts/poltest1'
+        assert pol1.status == 'draft'
+        pol1.publish()
+        assert pol1.fullPath == '/Common/poltest1'
+        assert pol1.status == 'published'
+        pol2 = pc1.policy.load(name='poltest1', partition='Common')
+        assert pol1.status == 'published'
+        pol2.strategy = '/Common/all-match'
+        with pytest.raises(OperationNotSupportedOnPublishedPolicy) as ex:
+            pol2.update()
+        assert 'Update operation not allowed on a published policy.' == \
+            ex.value.message
+        pol1.delete()
+
+    def test_policy_publish_draft_modify_exception(
+            self, setup, mgmt_root, request):
+        pol1, pc1 = setup_policy_test(request, mgmt_root, 'Common',
+                                      'poltest1', subPath='Drafts',
+                                      legacy=False)
+        assert pol1.fullPath == '/Common/Drafts/poltest1'
+        assert pol1.status == 'draft'
+        pol1.publish()
+        with pytest.raises(OperationNotSupportedOnPublishedPolicy) as ex:
+            pol1.modify(strategy='/Common/all-match')
+        assert 'Modify operation not allowed on a published policy.' == \
+            ex.value.message
+        pol1.delete()

--- a/test/functional/tm/ltm/test_policy.py
+++ b/test/functional/tm/ltm/test_policy.py
@@ -105,8 +105,8 @@ class TestPolicy_legacy(object):
 
     def test_create_policy_legacy_false(self, setup, request, mgmt_root):
         with pytest.raises(DraftPolicyNotSupportedInTMOSVersion) as ex:
-            policy1, pc1 = setup_policy_test(request, mgmt_root, 'Common',
-                                             'poltest1', legacy=False)
+            setup_policy_test(request, mgmt_root, 'Common',
+                              'poltest1', legacy=False)
         msg = "The version of TMOS on the device does not support " \
             "draft policies. The keyword argument 'legacy' was " \
             "given to this method and it was set to 'False'. This " \

--- a/test/functional/tm/ltm/test_policy.py
+++ b/test/functional/tm/ltm/test_policy.py
@@ -203,6 +203,7 @@ class TestPolicy(object):
         pol1, pc1 = setup_policy_test(request, mgmt_root, 'Common',
                                       'poltest1', subPath='Drafts',
                                       legacy=False)
+        # Cannot update a published policy
         assert pol1.fullPath == '/Common/Drafts/poltest1'
         assert pol1.status == 'draft'
         pol1.publish()


### PR DESCRIPTION
@zancas 

This build will break until we release icontrol rest with subpath updates. Will do tomorrow.
#### What's this change do?

Fixes Issues #575 and #668. LTM policies have changed in TMOS 12.1.0, now allowing creation of a draft policy. We need to support this for L7 Content Switching in the agent.
#### Any background context?

This requires a change in icontrol rest as well. To allow subpath to be specified, which is where draft policies are created by default.
#### Where should the reviewer start?

Start at the functional tests.
