### PR TITLE
Addresses SNMP  issues in 12.1

### DIFF
--- a/f5/bigip/tm/sys/snmp.py
+++ b/f5/bigip/tm/sys/snmp.py
@@ -26,10 +26,11 @@ GUI Path
 REST Kind
     ``tm:snmp:*``
 """
-
+from distutils.version import LooseVersion
 from f5.bigip.resource import Collection
 from f5.bigip.resource import Resource
 from f5.bigip.resource import UnnamedResource
+from f5.bigip.resource import UnsupportedOperation
 
 
 class Snmp(UnnamedResource):
@@ -89,6 +90,20 @@ class Trap(Resource):
         self._meta_data['required_json_kind'] = \
             'tm:sys:snmp:traps:trapsstate'
 
+    def update(self, **kwargs):
+        """Due to a password decryption bug
+
+        we will disable update() method for 12.1.0 and up
+
+        """
+        tmos_version = self._meta_data['bigip'].tmos_version
+        if LooseVersion(tmos_version) > LooseVersion('12.0.0'):
+            msg = "Update() is unsupported for Trap on version %s. " \
+                  "Utilize Modify() method instead" % tmos_version
+            raise UnsupportedOperation(msg)
+        else:
+            self._update(**kwargs)
+
 
 class Users_s(Collection):
     """BIG-IP® SNMP Users collection."""
@@ -109,3 +124,17 @@ class User(Resource):
             'tm:sys:snmp:users:usersstate'
         self._meta_data['required_creation_parameters'] \
             .update(('authProtocol',))
+
+    def update(self, **kwargs):
+        """Due to a password decryption bug
+
+        we will disable update() method for 12.1.0 and up
+
+        """
+        tmos_version = self._meta_data['bigip'].tmos_version
+        if LooseVersion(tmos_version) > LooseVersion('12.0.0'):
+            msg = "Update() is unsupported for User on version %s. " \
+                  "Utilize Modify() method instead" % tmos_version
+            raise UnsupportedOperation(msg)
+        else:
+            self._update(**kwargs)

--- a/f5/bigip/tm/sys/test/test_snmp.py
+++ b/f5/bigip/tm/sys/test/test_snmp.py
@@ -17,13 +17,32 @@ import mock
 import pytest
 
 from f5.bigip.mixins import UnsupportedMethod
+from f5.bigip.resource import UnsupportedOperation
 from f5.bigip.tm.sys.snmp import Snmp
+from f5.bigip.tm.sys.snmp import Trap
+from f5.bigip.tm.sys.snmp import User
 
 
 @pytest.fixture
 def FakeSnmp():
     fake_sys = mock.MagicMock()
     return Snmp(fake_sys)
+
+
+@pytest.fixture
+def FakeSnmpUser():
+    fake_sys = mock.MagicMock()
+    fake_user = User(fake_sys)
+    fake_user._meta_data['bigip'].tmos_version = '12.1.0'
+    return fake_user
+
+
+@pytest.fixture
+def FakeTrapUser():
+    fake_sys = mock.MagicMock()
+    fake_trap = Trap(fake_sys)
+    fake_trap._meta_data['bigip'].tmos_version = '12.1.0'
+    return fake_trap
 
 
 def test_create_raises(FakeSnmp):
@@ -36,3 +55,19 @@ def test_delete_raises(FakeSnmp):
     with pytest.raises(UnsupportedMethod) as EIO:
         FakeSnmp.delete()
     assert EIO.value.message == "Snmp does not support the delete method"
+
+
+def test_update_user_raises(FakeSnmpUser):
+    with pytest.raises(UnsupportedOperation) as EIO:
+        FakeSnmpUser.update()
+    assert EIO.value.message == "Update() is unsupported for User on " \
+                                "version 12.1.0. " \
+                                "Utilize Modify() method instead"
+
+
+def test_update_trap_raises(FakeTrapUser):
+    with pytest.raises(UnsupportedOperation) as EIO:
+        FakeTrapUser.update()
+    assert EIO.value.message == "Update() is unsupported for Trap on " \
+                                "version 12.1.0. " \
+                                "Utilize Modify() method instead"


### PR DESCRIPTION
Fixes Issues: #735

Updated Files:

```
test/functional/net/test_snmp.py
f5/bigip/tm/sys/test/test_snmp.py
f5/bigip/tm/sys/snmp.py
```

Updates:

In 12.1.0 there are problems with decryption of the hashed password when using update() method. Given the number of ways this can break, the update() method has been disabled for Users and Traps. The error message returns advisory to use modify() method which functions correctly.

Tests:

Flake8
Functional Test
Unit Tests
