### PR TITLE
Make dockerfiles respect the requirements.txt pip files

### DIFF
--- a/devtools/dockerfiles/Dockerfile.python2
+++ b/devtools/dockerfiles/Dockerfile.python2
@@ -22,20 +22,14 @@
 FROM python:2
 MAINTAINER @f5networks
 
+COPY . /tmp/src/
+
 RUN mkdir -p /artifacts/coverage
+RUN apt-get update && apt-get -y install apt-utils vim
+
+WORKDIR /tmp/src
+RUN pip install -r /tmp/src/requirements.test.txt
+RUN rm -rf /tmp/src
+
 WORKDIR /artifacts
-
-RUN apt-get update && apt-get -y install vim
-
-RUN pip install hacking==0.10.2 \
-    mock==1.3.0 \
-    pytest==2.9.1 \
-    pytest-cov>=2.2.1 \
-    git+https://github.com/F5Networks/pytest-symbols.git \
-    f5-icontrol-rest==1.0.7 \
-    pyOpenSSL==16.0.0 \
-    python-coveralls==2.7.0 \
-    ordereddict \
-    requests-mock==1.1.0
-
 CMD /bin/bash

--- a/devtools/dockerfiles/Dockerfile.python3
+++ b/devtools/dockerfiles/Dockerfile.python3
@@ -22,19 +22,14 @@
 FROM python:3
 MAINTAINER @f5networks
 
+COPY . /tmp/src/
+
 RUN mkdir -p /artifacts/coverage
+RUN apt-get update && apt-get -y install apt-utils vim
+
+WORKDIR /tmp/src
+RUN pip install -r /tmp/src/requirements.test.txt
+RUN rm -rf /tmp/src
+
 WORKDIR /artifacts
-
-RUN apt-get update && apt-get -y install vim
-
-RUN pip install hacking==0.10.2 \
-    mock==1.3.0 \
-    pytest==2.9.1 \
-    pytest-cov>=2.2.1 \
-    git+https://github.com/F5Networks/pytest-symbols.git \
-    f5-icontrol-rest==1.0.7 \
-    pyOpenSSL==16.0.0 \
-    python-coveralls==2.7.0 \
-    requests-mock==1.1.0
-
 CMD /bin/bash

--- a/requirements.test.txt
+++ b/requirements.test.txt
@@ -2,13 +2,12 @@
 -e .
 
 # Test Requirements
-git+https://github.com/F5Networks/pytest-symbols.git
 hacking==0.10.2
 mock==1.3.0
 pytest==2.9.1
 pytest-cov>=2.2.1
 git+https://github.com/F5Networks/pytest-symbols.git
-python-coveralls
-pyopenssl
+python-coveralls==2.7.0
+pyOpenSSL==16.0.0
 ordereddict
 requests-mock==1.1.0


### PR DESCRIPTION
Issues:
Fixes #744

Problem:
The dockerfiles maintained a separate list of dependencies and this
would cause issues when those dependencies were updated because they
needed to be updated in two places at once

Analysis:
This patch makes the dockerfiles use the requirements file and behind
the scenes we also adjust the CI build to accomodate this.

Tests:
none
