### PR TITLE
Python six module required in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ setup(
     author_email='f5_common_python@f5.com',
     url='https://github.com/F5Networks/f5-common-python',
     keywords=['F5', 'sdk', 'api', 'icontrol', 'bigip', 'api', 'ltm'],
-    install_requires=['f5-icontrol-rest == 1.1.0'],
+    install_requires=['f5-icontrol-rest == 1.1.0', 'six'],
     packages=find_packages(
         exclude=["*.test", "*.test.*", "test.*", "test_*", "test", "test*"]
     ),


### PR DESCRIPTION
Issues:
@zancas 

Fixes #758

Problem:
Recently, we began using the 'six' module in the sdk, but we did not
update setup.py with six as a required module. This is a critical
install failure.

Analysis:
Added six in setup.py

Tests:
Pip installed and ensured latest six version was installed. Based six version on openstack's last few releases.
