### PR TITLE
Issue #538 - Adding client/server ssl cipher list utility

### DIFF
--- a/f5/bigip/tm/util/Clientssl_Ciphers.py
+++ b/f5/bigip/tm/util/Clientssl_Ciphers.py
@@ -1,0 +1,48 @@
+# coding=utf-8
+#
+# Copyright 2016 F5 Networks Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+"""BIG-IP® utility module
+
+REST URI
+    ``http://localhost/mgmt/tm/util/clientssl-ciphers``
+
+GUI Path
+    N/A
+
+REST Kind
+    ``tm:util:clientssl-ciphers:*``
+"""
+
+from f5.bigip.mixins import CommandExecutionMixin
+from f5.bigip.resource import UnnamedResource
+
+
+class Clientssl_Ciphers(UnnamedResource, CommandExecutionMixin):
+    """BIG-IP® utility command
+
+    .. note::
+
+        This is an unnamed resource so it has no ~Partition~Name pattern
+        at the end of its URI.
+    """
+
+    def __init__(self, util):
+        super(Clientssl_Ciphers, self).__init__(util)
+        self._meta_data['required_command_parameters'].update(('utilCmdArgs',))
+        self._meta_data['required_json_kind'] =\
+            'tm:util:clientssl-ciphers:runstate'
+        self._meta_data['allowed_commands'].append('run')
+        self._meta_data['minimum_version'] = '12.1.0'

--- a/f5/bigip/tm/util/Serverssl_Ciphers.py
+++ b/f5/bigip/tm/util/Serverssl_Ciphers.py
@@ -1,0 +1,48 @@
+# coding=utf-8
+#
+# Copyright 2016 F5 Networks Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+"""BIG-IP® utility module
+
+REST URI
+    ``http://localhost/mgmt/tm/util/serverssl-ciphers``
+
+GUI Path
+    N/A
+
+REST Kind
+    ``tm:util:serverssl-ciphers:*``
+"""
+
+from f5.bigip.mixins import CommandExecutionMixin
+from f5.bigip.resource import UnnamedResource
+
+
+class Serverssl_Ciphers(UnnamedResource, CommandExecutionMixin):
+    """BIG-IP® utility command
+
+    .. note::
+
+        This is an unnamed resource so it has no ~Partition~Name pattern
+        at the end of its URI.
+    """
+
+    def __init__(self, util):
+        super(Serverssl_Ciphers, self).__init__(util)
+        self._meta_data['required_command_parameters'].update(('utilCmdArgs',))
+        self._meta_data['required_json_kind'] =\
+            'tm:util:serverssl-ciphers:runstate'
+        self._meta_data['allowed_commands'].append('run')
+        self._meta_data['minimum_version'] = '12.1.0'

--- a/f5/bigip/tm/util/__init__.py
+++ b/f5/bigip/tm/util/__init__.py
@@ -29,8 +29,10 @@ REST Kind
 
 from f5.bigip.resource import PathElement
 from f5.bigip.tm.util.Bash import Bash
+from f5.bigip.tm.util.Clientssl_Ciphers import Clientssl_Ciphers
 from f5.bigip.tm.util.Dig import Dig
 from f5.bigip.tm.util.Qkview import Qkview
+from f5.bigip.tm.util.Serverssl_Ciphers import Serverssl_Ciphers
 from f5.bigip.tm.util.Unix_Ls import Unix_Ls
 from f5.bigip.tm.util.Unix_Mv import Unix_Mv
 from f5.bigip.tm.util.Unix_Rm import Unix_Rm
@@ -41,8 +43,10 @@ class Util(PathElement):
         super(Util, self).__init__(bigip)
         self._meta_data['allowed_lazy_attributes'] = [
             Bash,
+            Clientssl_Ciphers,
             Dig,
             Qkview,
+            Serverssl_Ciphers,
             Unix_Ls,
             Unix_Mv,
             Unix_Rm

--- a/f5/bigip/tm/util/test/functional/test_clientssl_ciphers.py
+++ b/f5/bigip/tm/util/test/functional/test_clientssl_ciphers.py
@@ -1,0 +1,54 @@
+
+# Copyright 2016 F5 Networks Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import pytest
+
+from distutils.version import LooseVersion
+from f5.bigip.resource import MissingRequiredCommandParameter
+from icontrol.session import iControlUnexpectedHTTPError
+
+
+@pytest.mark.skipif(
+    LooseVersion(
+        pytest.config.getoption('--release')
+    ) < LooseVersion('12.1.0'),
+    reason='util/clientssl-ciphers is only supported in 12.1.0 or greater.'
+)
+def test_E_clientssl_ciphers(mgmt_root):
+
+    with pytest.raises(MissingRequiredCommandParameter) as err:
+        mgmt_root.tm.util.clientssl_ciphers.exec_cmd('run')
+        assert "Missing required params: ['utilCmdArgs']" in err.response.text
+
+    cssl_cipher1 = mgmt_root.tm.util.clientssl_ciphers.exec_cmd('run',
+                                                                utilCmdArgs='')
+
+    # syntax message should be present
+    assert 'Syntax: clientssl-ciphers \'<cipher-string>\'' in \
+           cssl_cipher1.commandResult
+
+    cssl_cipher2 = mgmt_root.tm.util.clientssl_ciphers.exec_cmd(
+        'run', utilCmdArgs='DEFAULT')
+
+    # cipher list should be returned, match the header row
+    assert 'DHE-RSA-AES128-GCM-SHA256' in \
+           cssl_cipher2.commandResult
+
+    # iControlUnexpectedHTTPError should be raised if quotes don't match
+    with pytest.raises(iControlUnexpectedHTTPError) as err:
+        mgmt_root.tm.util.clientssl_ciphers.exec_cmd('run', utilCmdArgs='"')
+        assert err.response.status_code == 400
+        assert 'quotes are not balanced' in err.response.text

--- a/f5/bigip/tm/util/test/functional/test_serverssl_ciphers.py
+++ b/f5/bigip/tm/util/test/functional/test_serverssl_ciphers.py
@@ -1,0 +1,54 @@
+
+# Copyright 2016 F5 Networks Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import pytest
+
+from distutils.version import LooseVersion
+from f5.bigip.resource import MissingRequiredCommandParameter
+from icontrol.session import iControlUnexpectedHTTPError
+
+
+@pytest.mark.skipif(
+    LooseVersion(
+        pytest.config.getoption('--release')
+    ) < LooseVersion('12.1.0'),
+    reason='util/serverssl-ciphers is only supported in 12.1.0 or greater.'
+)
+def test_E_serverssl_ciphers(mgmt_root):
+
+    with pytest.raises(MissingRequiredCommandParameter) as err:
+        mgmt_root.tm.util.serverssl_ciphers.exec_cmd('run')
+        assert "Missing required params: ['utilCmdArgs']" in err.response.text
+
+    sssl_cipher1 = mgmt_root.tm.util.serverssl_ciphers.exec_cmd('run',
+                                                                utilCmdArgs='')
+
+    # syntax message should be present
+    assert 'Syntax: serverssl-ciphers \'<cipher-string>\'' in \
+           sssl_cipher1.commandResult
+
+    sssl_cipher2 = mgmt_root.tm.util.serverssl_ciphers.exec_cmd(
+        'run', utilCmdArgs='DEFAULT')
+
+    # cipher list should be returned, match the header row
+    assert 'DHE-RSA-AES128-GCM-SHA256' in \
+           sssl_cipher2.commandResult
+
+    # iControlUnexpectedHTTPError should be raised if quotes don't match
+    with pytest.raises(iControlUnexpectedHTTPError) as err:
+        mgmt_root.tm.util.serverssl_ciphers.exec_cmd('run', utilCmdArgs='"')
+        assert err.response.status_code == 400
+        assert 'quotes are not balanced' in err.response.text

--- a/f5/bigip/tm/util/test/unit/test_clientssl_ciphers.py
+++ b/f5/bigip/tm/util/test/unit/test_clientssl_ciphers.py
@@ -1,0 +1,52 @@
+# Copyright 2016 F5 Networks Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import mock
+import pytest
+
+from f5.bigip import ManagementRoot
+from f5.bigip.resource import MissingRequiredCommandParameter
+from f5.bigip.tm.util.Clientssl_Ciphers import Clientssl_Ciphers
+
+
+@pytest.fixture
+def FakeClientsslCiphers():
+    fake_sys = mock.MagicMock()
+    fake_clientssl_ciphers = Clientssl_Ciphers(fake_sys)
+    fake_clientssl_ciphers._meta_data['bigip'].tmos_version = '12.1.0'
+    return fake_clientssl_ciphers
+
+
+@pytest.fixture
+def FakeiControl(fakeicontrolsession_v12):
+    mr = ManagementRoot('host', 'fake_admin', 'fake_admin')
+    mock_session = mock.MagicMock()
+    mock_session.post.return_value.json.return_value = {}
+    mr._meta_data['icr_session'] = mock_session
+    return mr.tm.util.clientssl_ciphers
+
+
+def test_clientssl_exec_missing_args(FakeClientsslCiphers):
+    with pytest.raises(MissingRequiredCommandParameter):
+        FakeClientsslCiphers.exec_cmd('run')
+
+
+def test_command_clientssl_ciphers(FakeiControl):
+    FakeiControl.exec_cmd('run', utilCmdArgs='DEFAULT')
+    session = FakeiControl._meta_data['bigip']._meta_data['icr_session']
+    assert session.post.call_args == mock.call(
+        'https://host:443/mgmt/tm/util/clientssl-ciphers/',
+        json={'utilCmdArgs': 'DEFAULT', 'command': 'run'}
+    )

--- a/f5/bigip/tm/util/test/unit/test_serverssl_ciphers.py
+++ b/f5/bigip/tm/util/test/unit/test_serverssl_ciphers.py
@@ -1,0 +1,52 @@
+# Copyright 2016 F5 Networks Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import mock
+import pytest
+
+from f5.bigip import ManagementRoot
+from f5.bigip.resource import MissingRequiredCommandParameter
+from f5.bigip.tm.util.Serverssl_Ciphers import Serverssl_Ciphers
+
+
+@pytest.fixture
+def FakeServersslCiphers():
+    fake_sys = mock.MagicMock()
+    fake_serverssl_ciphers = Serverssl_Ciphers(fake_sys)
+    fake_serverssl_ciphers._meta_data['bigip'].tmos_version = '12.1.0'
+    return fake_serverssl_ciphers
+
+
+@pytest.fixture
+def FakeiControl(fakeicontrolsession_v12):
+    mr = ManagementRoot('host', 'fake_admin', 'fake_admin')
+    mock_session = mock.MagicMock()
+    mock_session.post.return_value.json.return_value = {}
+    mr._meta_data['icr_session'] = mock_session
+    return mr.tm.util.serverssl_ciphers
+
+
+def test_serverssl_exec_missing_args(FakeServersslCiphers):
+    with pytest.raises(MissingRequiredCommandParameter):
+        FakeServersslCiphers.exec_cmd('run')
+
+
+def test_command_serverssl_ciphers(FakeiControl):
+    FakeiControl.exec_cmd('run', utilCmdArgs='DEFAULT')
+    session = FakeiControl._meta_data['bigip']._meta_data['icr_session']
+    assert session.post.call_args == mock.call(
+        'https://host:443/mgmt/tm/util/serverssl-ciphers/',
+        json={'utilCmdArgs': 'DEFAULT', 'command': 'run'}
+    )


### PR DESCRIPTION
Updated File
- f5/bigip/tm/util/**init**.py
  
  Added Files
- f5/bigip/tm/util/Clientssl_Ciphers.py
- f5/bigip/tm/util/Serverssl_Ciphers.py
- f5/bigip/tm/util/test/functional/test_clientssl_ciphers.py
- f5/bigip/tm/util/test/functional/test_serverssl_ciphers.py
- f5/bigip/tm/util/test/unit/test_clientssl_ciphers.py
- f5/bigip/tm/util/test/unit/test_serverssl_ciphers.py
