### PR TITLE
Fixes coverage to choose the right files

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,11 +1,17 @@
 [run]
 omit =
     # omit all functional tests
-    tests/*
-    # omit anything in a test directory anywhere
-    */test/*
+    */functional/*
+
+    # all unit tests
+    */unit/*
+
     # omit the devtools
     devtools/*
+
     # omit the conftest?
     conftest.py
     setup.py
+
+    # This file is only used in unit tests
+    f5/utils/iapp_parser.py


### PR DESCRIPTION
Problem:
coverage was testing files that were known to only be used in unit tests

Analysis:
This change updates the coveragerc file to add the correct files to coverage

Tests:
none
