### PR TITLE
ltm node sets 'state' as a read-only attribute

### DIFF
--- a/f5/bigip/tm/ltm/test/functional/test_node.py
+++ b/f5/bigip/tm/ltm/test/functional/test_node.py
@@ -16,33 +16,39 @@
 import pytest
 
 from f5.bigip.resource import MissingRequiredCreationParameter
+from f5.sdk_exception import NodeStateModifyUnsupported
 
 
 TESTDESCRIPTION = "TESTDESCRIPTION"
 
 
-def setup_node_test(request, bigip, partition, name, addr):
+def setup_node_test(request, mgmt_root, partition, name, addr):
     def teardown():
-        node1.delete()
+        if mgmt_root.tm.ltm.nodes.node.exists(name=name, partition=partition):
+            loaded_node = mgmt_root.tm.ltm.nodes.node.load(
+                name=name, partition=partition)
+            loaded_node.delete()
+    teardown()
     request.addfinalizer(teardown)
 
-    nodes = bigip.ltm.nodes
-    node1 = bigip.ltm.nodes.node.create(
+    nodes = mgmt_root.tm.ltm.nodes
+    node1 = mgmt_root.tm.ltm.nodes.node.create(
         name=name, partition=partition, address=addr)
     return node1, nodes
 
 
 class TestNode(object):
-    def test_create_missing_args(self, bigip):
-        n1 = bigip.ltm.nodes.node
+    def test_create_missing_args(self, mgmt_root):
+        n1 = mgmt_root.tm.ltm.nodes.node
         with pytest.raises(MissingRequiredCreationParameter):
             n1.create(name="n1", partition='Common')
 
-    def test_CURDLE(self, request, bigip):
+    def test_CURDLE(self, request, mgmt_root):
         # We will assume that the setup/teardown will test create/delete
         n1, nc1 = setup_node_test(
-            request, bigip, 'Common', 'node1', '192.168.100.1')
-        n2 = bigip.ltm.nodes.node.load(name=n1.name, partition=n1.partition)
+            request, mgmt_root, 'Common', 'node1', '192.168.100.1')
+        n2 = mgmt_root.tm.ltm.nodes.node.load(
+            name=n1.name, partition=n1.partition)
         assert n1.name == 'node1'
         assert n2.name == n1.name
         assert n1.generation == n2.generation
@@ -58,15 +64,55 @@ class TestNode(object):
         assert n2.description == n1.description
 
         # Exists
-        assert bigip.ltm.nodes.node.exists(name='node1', partition='Common')
-        assert not bigip.ltm.nodes.node.exists(name='node2',
-                                               partition='Common')
+        assert mgmt_root.tm.ltm.nodes.node.exists(
+            name='node1', partition='Common')
+        assert not mgmt_root.tm.ltm.nodes.node.exists(name='node2',
+                                                      partition='Common')
+
+    def test_state_update(self, request, mgmt_root):
+        n1, nc1 = setup_node_test(
+            request, mgmt_root, 'Common', 'node1', '192.168.100.1')
+        assert n1.state == 'unchecked'
+        n1.state = 'user-down'
+        n1.update()
+        n2 = mgmt_root.tm.ltm.nodes.node.load(
+            name='node1', partition='Common')
+        assert n2.state == 'user-down'
+        assert n2.state == n1.state
+
+    def test_state_update_with_kwargs(self, request, mgmt_root):
+        n1, nc1 = setup_node_test(
+            request, mgmt_root, 'Common', 'node1', '192.168.100.1')
+        assert n1.state == 'unchecked'
+        n1.update(state='unchecked')
+        n2 = mgmt_root.tm.ltm.nodes.node.load(
+            name='node1', partition='Common')
+        assert n2.state == 'unchecked'
+        assert n2.state == n1.state
+
+    def test_state_modify(self, request, mgmt_root):
+        n1, nc1 = setup_node_test(
+            request, mgmt_root, 'Common', 'node1', '10.10.10.1')
+        assert n1.state == 'unchecked'
+        n1.modify(state='user-down')
+        n2 = mgmt_root.tm.ltm.nodes.node.load(
+            name='node1', partition='Common')
+        assert n2.state == 'user-down'
+        assert n1.state == n2.state
+
+    def test_state_modify_error(self, request, mgmt_root):
+        n1, nc1 = setup_node_test(
+            request, mgmt_root, 'Common', 'node1', '10.10.10.1')
+        with pytest.raises(NodeStateModifyUnsupported) as ex:
+            n1.modify(state='unchecked')
+        assert "The node resource does not support a modify with the value " \
+            "of the 'state' attribute as 'unchecked'." == ex.value.message
 
 
 class TestNodes(object):
-    def test_get_collection(self, request, bigip):
-        setup_node_test(request, bigip, 'Common', 'node1', '192.168.100.1')
-        sc = bigip.ltm.nodes
+    def test_get_collection(self, request, mgmt_root):
+        setup_node_test(request, mgmt_root, 'Common', 'node1', '192.168.100.1')
+        sc = mgmt_root.tm.ltm.nodes
         nodes = sc.get_collection()
         assert len(nodes) >= 1
         assert [n for n in nodes if n.name == 'node1']

--- a/f5/sdk_exception.py
+++ b/f5/sdk_exception.py
@@ -24,3 +24,8 @@ class F5SDKError(Exception):
 class UnsupportedMethod(F5SDKError):
     """Raise this if a method supplied is unsupported."""
     pass
+
+
+class NodeStateModifyUnsupported(F5SDKError):
+    '''Modify of node with state=unchecked is unsupported.'''
+    pass


### PR DESCRIPTION
Issues:
Fixes #775

Problem:
The 'state' of a node can be modified through REST and is not strictly
read-only. We can remove this and test to ensure it works as expected.
The test will consist of a user creating a node with a specific state,
updating to a specific state, then modifying the state.

Analysis:
Remove 'state' as read-only attribute, then ensured a call to update or
modify does the right thing if state is present and it has a value of
unchecked.

Tests:
Wrote new functional tests to check this behavior
