### PR TITLE
Issue #614 - Cleaning up tests to use ManagementRoot instead of BigIP

### DIFF
--- a/f5/bigip/shared/test/functional/test___init__.py
+++ b/f5/bigip/shared/test/functional/test___init__.py
@@ -13,18 +13,16 @@
 # limitations under the License.
 from pprint import pprint as pp
 
-from f5.bigip import BigIP
 from f5.bigip.tm.shared import Shared
 
 
-def test_shared(request, bigip):
-    s = bigip.shared
+def test_shared(request, mgmt_root):
+    s = mgmt_root.tm.shared
     pp(s.raw)
-    assert isinstance(s._meta_data['container'], BigIP)
     assert s._meta_data['allowed_lazy_attributes'][0].__name__ == "Licensing"
     suri = s._meta_data['uri']
     assert suri.endswith('/mgmt/tm/shared/')
-    l = bigip.shared.licensing
+    l = mgmt_root.tm.shared.licensing
     pp(l.raw)
     assert isinstance(l._meta_data['container'], Shared)
     luri = l._meta_data['uri']

--- a/f5/bigip/test/unit/test___init__.py
+++ b/f5/bigip/test/unit/test___init__.py
@@ -19,48 +19,63 @@ try:
 except ImportError:
     from urllib import parse as urlparse
 
-from f5.bigip import BigIP
+from f5.bigip import ManagementRoot
 
+from f5.bigip.tm.asm import Asm
 from f5.bigip.tm.auth import Auth
+from f5.bigip.tm.cm import Cm
+from f5.bigip.tm.gtm import Gtm
 from f5.bigip.tm.ltm import Ltm
 from f5.bigip.tm.net import Net
 from f5.bigip.tm.shared import Shared
 from f5.bigip.tm.sys import Sys
+from f5.bigip.tm.util import Util
+from f5.bigip.tm.vcmp import Vcmp
 
 
 @pytest.fixture
 def FakeBigIP(fakeicontrolsession):
-    FBIP = BigIP('FakeHostName', 'admin', 'admin')
+    FBIP = ManagementRoot('FakeHostName', 'admin', 'admin')
     FBIP.icontrol = mock.MagicMock()
     return FBIP
 
 
 @pytest.fixture
 def FakeBigIPWithPort(fakeicontrolsession):
-    FBIP = BigIP('FakeHostName', 'admin', 'admin', port='10443')
+    FBIP = ManagementRoot('FakeHostName', 'admin', 'admin', port='10443')
     FBIP.icontrol = mock.MagicMock()
     return FBIP
 
 
 def test___get__attr(FakeBigIP):
-    bigip_dot_auth = FakeBigIP.auth
+    bigip_dot_asm = FakeBigIP.tm.asm
+    assert isinstance(bigip_dot_asm, Asm)
+    bigip_dot_auth = FakeBigIP.tm.auth
     assert isinstance(bigip_dot_auth, Auth)
-    bigip_dot_ltm = FakeBigIP.ltm
+    bigip_dot_cm = FakeBigIP.tm.cm
+    assert isinstance(bigip_dot_cm, Cm)
+    bigip_dot_gtm = FakeBigIP.tm.gtm
+    assert isinstance(bigip_dot_gtm, Gtm)
+    bigip_dot_ltm = FakeBigIP.tm.ltm
     assert isinstance(bigip_dot_ltm, Ltm)
-    bigip_dot_net = FakeBigIP.net
+    bigip_dot_net = FakeBigIP.tm.net
     assert isinstance(bigip_dot_net, Net)
-    bigip_dot_shared = FakeBigIP.shared
+    bigip_dot_shared = FakeBigIP.tm.shared
     assert isinstance(bigip_dot_shared, Shared)
-    bigip_dot_sys = FakeBigIP.sys
+    bigip_dot_sys = FakeBigIP.tm.sys
     assert isinstance(bigip_dot_sys, Sys)
+    bigip_dot_util = FakeBigIP.tm.util
+    assert isinstance(bigip_dot_util, Util)
+    bigip_dot_vcmp = FakeBigIP.tm.vcmp
+    assert isinstance(bigip_dot_vcmp, Vcmp)
     with pytest.raises(AttributeError):
-        FakeBigIP.this_is_not_a_real_attribute
+        FakeBigIP.tm.this_is_not_a_real_attribute
     assert FakeBigIP.hostname == 'FakeHostName'
 
 
 def test_invalid_args():
     with pytest.raises(TypeError) as err:
-        BigIP('FakeHostName', 'admin', 'admin', badArgs='foobar')
+        ManagementRoot('FakeHostName', 'admin', 'admin', badArgs='foobar')
     assert 'Unexpected **kwargs' in str(err.value)
 
 

--- a/f5/bigip/tm/auth/test/unit/test_user.py
+++ b/f5/bigip/tm/auth/test/unit/test_user.py
@@ -16,7 +16,7 @@
 import mock
 import pytest
 
-from f5.bigip import BigIP
+from f5.bigip import ManagementRoot
 from f5.bigip.resource import MissingRequiredCreationParameter
 from f5.bigip.tm.auth.user import User
 
@@ -30,9 +30,9 @@ def FakeUser():
 
 class TestCreate(object):
     def test_create_two(self, fakeicontrolsession):
-        b = BigIP('localhost', 'admin', 'admin')
-        n1 = b.auth.users.user
-        n2 = b.auth.users.user
+        b = ManagementRoot('localhost', 'admin', 'admin')
+        n1 = b.tm.auth.users.user
+        n2 = b.tm.auth.users.user
         assert n1 is not n2
 
     def test_create_no_args(self, FakeUser):

--- a/f5/bigip/tm/cm/test/unit/test_sync_group.py
+++ b/f5/bigip/tm/cm/test/unit/test_sync_group.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 #
 
-from f5.bigip import BigIP
+from f5.bigip import ManagementRoot
 
 import mock
 import pytest
@@ -21,11 +21,11 @@ import pytest
 
 @pytest.fixture
 def FakeiControl(fakeicontrolsession):
-    bigip = BigIP('host', 'fake_admin', 'fake_admin')
+    bigip = ManagementRoot('host', 'fake_admin', 'fake_admin')
     mock_session = mock.MagicMock()
     mock_session.post.return_value.json.return_value = {}
     bigip._meta_data['icr_session'] = mock_session
-    return bigip.cm
+    return bigip.tm.cm
 
 
 class TestCMSync(object):

--- a/f5/bigip/tm/ltm/test/unit/test_nat.py
+++ b/f5/bigip/tm/ltm/test/unit/test_nat.py
@@ -16,7 +16,7 @@
 import mock
 import pytest
 
-from f5.bigip import BigIP
+from f5.bigip import ManagementRoot
 from f5.bigip.resource import MissingRequiredCreationParameter
 from f5.bigip.tm.ltm.nat import Nat
 
@@ -30,9 +30,9 @@ def FakeNat():
 
 class TestCreate(object):
     def test_create_two(self, fakeicontrolsession):
-        b = BigIP('192.168.1.1', 'admin', 'admin')
-        n1 = b.ltm.nats.nat
-        n2 = b.ltm.nats.nat
+        b = ManagementRoot('192.168.1.1', 'admin', 'admin')
+        n1 = b.tm.ltm.nats.nat
+        n2 = b.tm.ltm.nats.nat
         assert n1 is not n2
 
     def test_create_no_args(self, FakeNat):

--- a/f5/bigip/tm/ltm/test/unit/test_rule.py
+++ b/f5/bigip/tm/ltm/test/unit/test_rule.py
@@ -16,7 +16,7 @@
 import mock
 import pytest
 
-from f5.bigip import BigIP
+from f5.bigip import ManagementRoot
 from f5.bigip.resource import MissingRequiredCreationParameter
 from f5.bigip.tm.ltm.nat import Nat
 
@@ -30,9 +30,9 @@ def FakeRule():
 
 class TestCreate(object):
     def test_create_two(self, fakeicontrolsession):
-        b = BigIP('192.168.1.1', 'admin', 'admin')
-        r1 = b.ltm.rules.rule
-        r2 = b.ltm.rules.rule
+        b = ManagementRoot('192.168.1.1', 'admin', 'admin')
+        r1 = b.tm.ltm.rules.rule
+        r2 = b.tm.ltm.rules.rule
         assert r1 is not r2
 
     def test_create_no_args(self, FakeRule):

--- a/f5/bigip/tm/sys/test/unit/test_sys_application.py
+++ b/f5/bigip/tm/sys/test/unit/test_sys_application.py
@@ -17,7 +17,7 @@ import mock
 import pytest
 from requests import HTTPError
 
-from f5.bigip import BigIP
+from f5.bigip import ManagementRoot
 from f5.bigip.resource import KindTypeMismatch
 from f5.bigip.resource import MissingRequiredCreationParameter
 from f5.bigip.resource import MissingRequiredReadParameter
@@ -189,9 +189,9 @@ class MockHTTPErrorResponse400(HTTPError):
 
 class TestServiceCreate(object):
     def test_create_two(self, fakeicontrolsession):
-        b = BigIP('192.168.1.1', 'admin', 'admin')
-        serv1 = b.sys.application.services.service
-        serv2 = b.sys.application.services.service
+        b = ManagementRoot('192.168.1.1', 'admin', 'admin')
+        serv1 = b.tm.sys.application.services.service
+        serv2 = b.tm.sys.application.services.service
         assert serv1 is not serv2
 
     def test_create_no_args(self, FakeService):
@@ -341,9 +341,9 @@ class TestServiceUpdate(object):
 
 class TestTemplateCreate(object):
     def test_create_two(self, fakeicontrolsession):
-        b = BigIP('192.168.1.1', 'admin', 'admin')
-        templ1 = b.sys.application.templates.template
-        templ2 = b.sys.application.templates.template
+        b = ManagementRoot('192.168.1.1', 'admin', 'admin')
+        templ1 = b.tm.sys.application.templates.template
+        templ2 = b.tm.sys.application.templates.template
         assert templ1 is not templ2
 
     def test_create_no_args(self, FakeTemplate):
@@ -355,9 +355,9 @@ class TestTemplateCreate(object):
 
 class TestAplscript(object):
     def test_create_two(self, fakeicontrolsession):
-        b = BigIP('192.168.1.1', 'admin', 'admin')
-        templ1 = b.sys.application.aplscripts.aplscript
-        templ2 = b.sys.application.aplscripts.aplscript
+        b = ManagementRoot('192.168.1.1', 'admin', 'admin')
+        templ1 = b.tm.sys.application.aplscripts.aplscript
+        templ2 = b.tm.sys.application.aplscripts.aplscript
         assert templ1 is not templ2
 
     def test_create_no_args(self, FakeAplscript):
@@ -368,9 +368,9 @@ class TestAplscript(object):
 
 class TestCustomstat(object):
     def test_create_two(self, fakeicontrolsession):
-        b = BigIP('192.168.1.1', 'admin', 'admin')
-        templ1 = b.sys.application.customstats.customstat
-        templ2 = b.sys.application.customstats.customstat
+        b = ManagementRoot('192.168.1.1', 'admin', 'admin')
+        templ1 = b.tm.sys.application.customstats.customstat
+        templ2 = b.tm.sys.application.customstats.customstat
         assert templ1 is not templ2
 
     def test_create_no_args(self, FakeCustomstat):

--- a/f5/multi_device/cluster/test/functional/teardown_exist.py
+++ b/f5/multi_device/cluster/test/functional/teardown_exist.py
@@ -1,9 +1,9 @@
-from f5.bigip import BigIP
+from f5.bigip import ManagementRoot
 from f5.cluster.cluster_manager import ClusterManager
 
-a = BigIP('10.190.20.202', 'admin', 'admin')
-b = BigIP('10.190.20.203', 'admin', 'admin')
-c = BigIP('10.190.20.204', 'admin', 'admin')
+a = ManagementRoot('10.190.20.202', 'admin', 'admin')
+b = ManagementRoot('10.190.20.203', 'admin', 'admin')
+c = ManagementRoot('10.190.20.204', 'admin', 'admin')
 
 cm = ClusterManager([a, b], 'testing_cluster', 'Common', 'sync-failover')
 


### PR DESCRIPTION
- Cleaned up all tests to use ManagementRoot instead of BigIP as part of the larger effort to remove BigIP altogether.
- Added remaining tm branches to f5/bigip/test/unit/test__init__.py
