### PR TITLE
Adding Token Auth to SDK

### DIFF
--- a/f5/bigip/__init__.py
+++ b/f5/bigip/__init__.py
@@ -43,10 +43,12 @@ class ManagementRoot(PathElement):
         timeout = kwargs.pop('timeout', 30)
         port = kwargs.pop('port', 443)
         icontrol_version = kwargs.pop('icontrol_version', '')
+        token = kwargs.pop('token', False)
         if kwargs:
             raise TypeError('Unexpected **kwargs: %r' % kwargs)
         # _meta_data variable values
-        iCRS = iControlRESTSession(username, password, timeout=timeout)
+        iCRS = iControlRESTSession(username, password, timeout=timeout,
+                                   token=token)
         # define _meta_data
         self._meta_data = {
             'allowed_lazy_attributes': [Tm, Cm, Shared],


### PR DESCRIPTION
Issues:
Fixes #487

Problem:
SDK does not support token auth, so it will not be usable with situations where remote auth is required. The underlying iControlRest library has this functionality already.

Analysis:
Added a kwarg 'token' option, with the default set to False.

Tests:
Flake 8
