### PR TITLE
Add functional tests for LTM policy deployments

### DIFF
--- a/f5/bigip/tm/ltm/test/functional/full_policy.json
+++ b/f5/bigip/tm/ltm/test/functional/full_policy.json
@@ -1,0 +1,119 @@
+{
+    "subPath": "Drafts",
+    "requires": [
+      "http"
+    ],
+    "rules": [
+        {
+            "name": "test_rule",
+            "ordinal": 0,
+            "actions": [
+                {
+                    "name": "0",
+                    "code": 0,
+                    "httpHeader": true,
+                    "insert": true,
+                    "tmName": "Z-HEADER",
+                    "port": 0,
+                    "request": true,
+                    "status": 0,
+                    "value": "this is just a test of the rule",
+                    "vlanId": 0
+                },
+                {
+                    "name": "1",
+                    "code": 0,
+                    "httpHeader": true,
+                    "tmName": "Z-HEADER",
+                    "port": 0,
+                    "remove": true,
+                    "request": true,
+                    "status": 0,
+                    "vlanId": 0
+                }
+            ],
+            "conditions": [
+                {
+                    "name": "0",
+                    "all": true,
+                    "caseInsensitive": true,
+                    "equals": true,
+                    "external": true,
+                    "httpHeader": true,
+                    "index": 0,
+                    "tmName": "X-HEADER",
+                    "present": true,
+                    "remote": true,
+                    "request": true,
+                    "values": [
+                        "yes"
+                    ]
+                },
+                {
+                    "name": "1",
+                    "all": true,
+                    "caseInsensitive": true,
+                    "equals": true,
+                    "external": true,
+                    "httpHeader": true,
+                    "index": 0,
+                    "tmName": "Z-HEADER",
+                    "present": true,
+                    "remote": true,
+                    "request": true,
+                    "values": [
+                        "maybe"
+                    ]
+                },
+                {
+                    "name": "2",
+                    "all": true,
+                    "caseInsensitive": true,
+                    "equals": true,
+                    "external": true,
+                    "httpHeader": true,
+                    "index": 0,
+                    "tmName": "A-HEADER",
+                    "present": true,
+                    "remote": true,
+                    "request": true,
+                    "values": [
+                        "probably"
+                    ]
+                },
+                {
+                    "name": "3",
+                    "all": true,
+                    "caseInsensitive": true,
+                    "equals": true,
+                    "external": true,
+                    "httpHeader": true,
+                    "index": 0,
+                    "tmName": "B-HEADER",
+                    "present": true,
+                    "remote": true,
+                    "request": true,
+                    "values": [
+                        "unequivocally"
+                    ]
+                },
+                {
+                    "name": "4",
+                    "all": true,
+                    "caseInsensitive": true,
+                    "equals": true,
+                    "external": true,
+                    "httpHeader": true,
+                    "index": 0,
+                    "tmName": "C-HEADER",
+                    "present": true,
+                    "remote": true,
+                    "request": true,
+                    "values": [
+                        "certainly"
+                    ]
+                }
+            ]
+        }
+    ]
+}

--- a/f5/bigip/tm/ltm/test/functional/test_policy.py
+++ b/f5/bigip/tm/ltm/test/functional/test_policy.py
@@ -17,6 +17,7 @@ import copy
 from distutils.version import LooseVersion
 from icontrol.session import iControlUnexpectedHTTPError
 import json
+import os
 from pprint import pprint as pp
 import pytest
 
@@ -25,6 +26,7 @@ from f5.bigip.tm.ltm.policy import OperationNotSupportedOnPublishedPolicy
 
 pp('')
 TESTDESCRIPTION = "TESTDESCRIPTION"
+CURDIR = os.path.dirname(os.path.realpath(__file__))
 
 
 @pytest.fixture
@@ -115,7 +117,8 @@ class TestPolicy_legacy(object):
         assert msg == ex.value.message
 
     def test_policy_update_race(self, setup, request, mgmt_root):
-        full_pol_dict = json.load(open('full_policy.json'))
+        full_pol_dict = json.load(
+            open(os.path.join(CURDIR, 'full_policy.json')))
         empty_pol_dict = copy.deepcopy(full_pol_dict)
         empty_pol_dict['rules'] = []
         pol, pc = setup_policy_test(request, mgmt_root, 'Common', 'racetest')
@@ -260,7 +263,8 @@ class TestPolicy(object):
         pol1.delete()
 
     def test_policy_update_race(self, setup, request, mgmt_root):
-        full_pol_dict = json.load(open('full_policy.json'))
+        full_pol_dict = json.load(
+            open(os.path.join(CURDIR, 'full_policy.json')))
         empty_pol_dict = copy.deepcopy(full_pol_dict)
         empty_pol_dict['rules'] = []
         pol, pc = setup_policy_test(request, mgmt_root, 'Common', 'racetest',


### PR DESCRIPTION
@zancas 

Issues:
Fixes #788 and #790 

Problem:
When deploying a policy with the agent, we would like to deploy the
policy along with the rules and conditions and actions in one POST or
PUT. We need a test to assure this operation produces the expected state
on the device.

Analysis:
Added two new test to check this behavior. Found that we can do a PUT on
a policy to change the state of it and the accompanying rules
immediately. We validate that the state is as expected immediately after
updating.

Tests:
Both new tests pass against 12.1 and 11.6
