### PR TITLE
Adding ASM Signature Systems

### DIFF
--- a/f5/bigip/tm/asm/__init__.py
+++ b/f5/bigip/tm/asm/__init__.py
@@ -32,6 +32,7 @@ from f5.bigip.tm.asm.attack_types import Attack_Types_s
 from f5.bigip.tm.asm.file_transfer import File_Transfer
 from f5.bigip.tm.asm.signature_sets import Signature_Sets_s
 from f5.bigip.tm.asm.signature_statuses import Signature_Statuses_s
+from f5.bigip.tm.asm.signature_systems import Signature_Systems_s
 from f5.bigip.tm.asm.signature_update import Signature_Update
 from f5.bigip.tm.asm.signatures import Signatures_s
 from f5.bigip.tm.asm.tasks import Tasks
@@ -50,6 +51,7 @@ class Asm(OrganizingCollection):
             File_Transfer,
             Signature_Sets_s,
             Signature_Statuses_s,
+            Signature_Systems_s,
             Signature_Update,
             Signatures_s,
             Tasks,

--- a/f5/bigip/tm/asm/signature_systems.py
+++ b/f5/bigip/tm/asm/signature_systems.py
@@ -1,0 +1,75 @@
+# coding=utf-8
+#
+# Copyright 2015-2016 F5 Networks Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+from f5.bigip.resource import AsmResource
+from f5.bigip.resource import Collection
+from f5.bigip.resource import UnsupportedOperation
+
+
+class Signature_Systems_s(Collection):
+    """BIG-IP® ASM Signature Systems collection."""
+    def __init__(self, asm):
+        super(Signature_Systems_s, self).__init__(asm)
+        self._meta_data['object_has_stats'] = False
+        self._meta_data['allowed_lazy_attributes'] = [Signature_System]
+        self._meta_data['attribute_registry'] = {
+            'tm:asm:signature-systems:signature-systemstate':
+                Signature_System}
+
+
+class Signature_System(AsmResource):
+    """BIG-IP® ASM Signature System resource"""
+    def __init__(self, signature_systems_s):
+        super(Signature_System, self).__init__(signature_systems_s)
+        self._meta_data['required_json_kind'] =\
+            'tm:asm:signature-systems:signature-systemstate'
+
+    def create(self, **kwargs):
+        """Create is not supported for Signature System resource
+
+                :raises: UnsupportedOperation
+        """
+        raise UnsupportedOperation(
+            "%s does not support the create method" % self.__class__.__name__
+        )
+
+    def modify(self, **kwargs):
+        """Modify is not supported for Signature System resource
+
+                :raises: UnsupportedOperation
+        """
+        raise UnsupportedOperation(
+            "%s does not support the modify method" % self.__class__.__name__
+        )
+
+    def fetch(self):
+        """Fetch is not supported for Signature System resource
+
+                :raises: UnsupportedOperation
+        """
+        raise UnsupportedOperation(
+            "%s does not support the fetch method" % self.__class__.__name__
+        )
+
+    def delete(self):
+        """Delete is not supported for Signature System resource
+
+                :raises: UnsupportedOperation
+        """
+        raise UnsupportedOperation(
+            "%s does not support the delete method" % self.__class__.__name__
+        )

--- a/f5/bigip/tm/asm/signature_update.py
+++ b/f5/bigip/tm/asm/signature_update.py
@@ -20,9 +20,9 @@ from f5.bigip.resource import UnsupportedOperation
 
 
 class Signature_Update(UnnamedResource):
-    """BIG-IP® ASM Signature System resource"""
-    def __init__(self, signature_systems_s):
-        super(Signature_Update, self).__init__(signature_systems_s)
+    """BIG-IP® ASM Signature Update resource"""
+    def __init__(self, asm):
+        super(Signature_Update, self).__init__(asm)
         self._meta_data['object_has_stats'] = False
         self._meta_data['required_load_parameters'] = set()
         self._meta_data['required_json_kind'] =\

--- a/f5/bigip/tm/asm/test/functional/test_signature_systems.py
+++ b/f5/bigip/tm/asm/test/functional/test_signature_systems.py
@@ -1,0 +1,62 @@
+# Copyright 2016 F5 Networks Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+
+from f5.bigip.tm.asm.signature_systems import Signature_System
+from pprint import pprint as pp
+
+
+class TestSignatureSystems(object):
+    def test_collection(self, request, mgmt_root):
+        coll = mgmt_root.tm.asm.signature_systems_s.get_collection()
+        assert coll
+        assert coll[0] is not coll[1]
+        assert isinstance(coll[0], Signature_System)
+        assert isinstance(coll[1], Signature_System)
+        assert coll[0].kind == coll[1].kind
+        assert coll[0].id != coll[1].id
+        assert coll[0].name != coll[0].name
+
+    def test_load(self, request, mgmt_root):
+        coll = mgmt_root.tm.asm.signature_systems_s.get_collection()
+        idhash1 = str(coll[0].id)
+        sig1 = mgmt_root.tm.asm.signature_systems_s.signature_system.load(
+            id=idhash1)
+        idhash2 = str(coll[1].id)
+        sig2 = mgmt_root.tm.asm.signature_systems_s.signature_system.load(
+            id=idhash2)
+        assert sig1.kind == 'tm:asm:signature-systems:signature-systemstate'
+        assert sig2.kind == sig1.kind
+        assert sig1.name != sig2.name
+        assert sig1.id == coll[0].id
+        assert sig2.id == coll[1].id
+        pp(sig1.raw)
+        pp(sig2.raw)
+
+    def test_refresh(self, request, mgmt_root):
+        coll = mgmt_root.tm.asm.signature_systems_s.get_collection()
+        idhash1 = str(coll[0].id)
+        sig1 = mgmt_root.tm.asm.signature_systems_s.signature_system.load(
+            id=idhash1)
+        sig2 = mgmt_root.tm.asm.signature_systems_s.signature_system.load(
+            id=idhash1)
+
+        assert sig1.kind == 'tm:asm:signature-systems:signature-systemstate'
+        sig2.referesh()
+        assert sig2.kind == sig1.kind
+        assert sig1.name == sig2.name
+        assert sig1.id == coll[0].id
+        assert sig2.id == coll[0].id
+        pp(sig1.raw)
+        pp(sig2.raw)

--- a/f5/bigip/tm/asm/test/functional/test_signature_systems.py
+++ b/f5/bigip/tm/asm/test/functional/test_signature_systems.py
@@ -26,7 +26,7 @@ class TestSignatureSystems(object):
         assert isinstance(coll[1], Signature_System)
         assert coll[0].kind == coll[1].kind
         assert coll[0].id != coll[1].id
-        assert coll[0].name != coll[0].name
+        assert coll[0].name != coll[1].name
 
     def test_load(self, request, mgmt_root):
         coll = mgmt_root.tm.asm.signature_systems_s.get_collection()
@@ -53,7 +53,7 @@ class TestSignatureSystems(object):
             id=idhash1)
 
         assert sig1.kind == 'tm:asm:signature-systems:signature-systemstate'
-        sig2.referesh()
+        sig2.refresh()
         assert sig2.kind == sig1.kind
         assert sig1.name == sig2.name
         assert sig1.id == coll[0].id

--- a/f5/bigip/tm/asm/test/unit/test_signature_systems.py
+++ b/f5/bigip/tm/asm/test/unit/test_signature_systems.py
@@ -1,0 +1,52 @@
+# Copyright 2015 F5 Networks Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+from f5.bigip.resource import UnsupportedOperation
+from f5.bigip.tm.asm.signature_systems import Signature_System
+
+import mock
+import pytest
+
+
+@pytest.fixture
+def FakeSignatureSystem():
+    fake_asm = mock.MagicMock()
+    fake_sig = Signature_System(fake_asm)
+    fake_sig._meta_data['bigip'].tmos_version = '11.6.0'
+    return fake_sig
+
+
+class TestSignatureModify(object):
+    def test_update_raises(self, FakeSignatureSystem):
+        with pytest.raises(UnsupportedOperation):
+            FakeSignatureSystem.modify()
+
+
+class TestSignatureCreate(object):
+    def test_update_raises(self, FakeSignatureSystem):
+        with pytest.raises(UnsupportedOperation):
+            FakeSignatureSystem.create()
+
+
+class TestSignatureFetch(object):
+    def test_update_raises(self, FakeSignatureSystem):
+        with pytest.raises(UnsupportedOperation):
+            FakeSignatureSystem.fetch()
+
+
+class TestSignatureDelete(object):
+    def test_update_raises(self, FakeSignatureSystem):
+        with pytest.raises(UnsupportedOperation):
+            FakeSignatureSystem.delete()


### PR DESCRIPTION
Issues:
Fixes #706

Problem:
Signature Systems were missing from SDK, as they are crucial when configuring ASM policy they were a blocker for phase 2

Analysis:
Added Signature Systems endpoint to SDK with relevant tests, also correct minor typos in signature update class.

Files Changed/Added:

f5/bigip/asm/**init**.py
f5/bigip/asm/signature_systems.py
f5/bigip/asm/signature_update.py
f5/bigip/asm/test/unit/test_signature_systems.py
f5/bigip/asm/test/functional/test_signature_systems.py

Tests:
Flake 8
Unit
Functional
