### PR TITLE
Gtm pool coverage fix

### DIFF
--- a/f5/bigip/tm/gtm/test/unit/test_pool.py
+++ b/f5/bigip/tm/gtm/test/unit/test_pool.py
@@ -20,14 +20,32 @@ from f5.bigip import ManagementRoot
 from f5.bigip.resource import Collection
 from f5.bigip.resource import MissingRequiredCreationParameter
 from f5.bigip.resource import OrganizingCollection
+from f5.bigip.resource import URICreationCollision
 from f5.bigip.tm.gtm.pool import A
 from f5.bigip.tm.gtm.pool import Aaaa
 from f5.bigip.tm.gtm.pool import Cname
+from f5.bigip.tm.gtm.pool import Member
+from f5.bigip.tm.gtm.pool import Members_s
+from f5.bigip.tm.gtm.pool import MembersCollection_v11
+from f5.bigip.tm.gtm.pool import MembersCollectionA
+from f5.bigip.tm.gtm.pool import MembersCollectionAAAA
+from f5.bigip.tm.gtm.pool import MembersCollectionCname
+from f5.bigip.tm.gtm.pool import MembersCollectionMx
+from f5.bigip.tm.gtm.pool import MembersCollectionNaptr
+from f5.bigip.tm.gtm.pool import MembersCollectionSrv
+from f5.bigip.tm.gtm.pool import MembersResource_v11
+from f5.bigip.tm.gtm.pool import MembersResourceA
+from f5.bigip.tm.gtm.pool import MembersResourceAAAA
+from f5.bigip.tm.gtm.pool import MembersResourceCname
+from f5.bigip.tm.gtm.pool import MembersResourceMx
+from f5.bigip.tm.gtm.pool import MembersResourceNaptr
+from f5.bigip.tm.gtm.pool import MembersResourceSrv
 from f5.bigip.tm.gtm.pool import Mx
 from f5.bigip.tm.gtm.pool import Naptr
 from f5.bigip.tm.gtm.pool import Pool
 from f5.bigip.tm.gtm.pool import PoolCollection
 from f5.bigip.tm.gtm.pool import Srv
+from requests import HTTPError
 
 from six import iterkeys
 
@@ -38,6 +56,22 @@ def FakePoolv11():
     fake_pool = PoolCollection(fake_gtm)
     fake_pool._meta_data['bigip'].tmos_version = '11.6.0'
     return fake_pool
+
+
+def Makepool(fakeicontrolsession):
+    b = ManagementRoot('192.168.1.1', 'admin', 'admin')
+    p = b.tm.gtm.pools.pool
+    p._meta_data['uri'] = \
+        'https://192.168.1.1:443/mgmt/tm/gtm/pool/~Common~testpool/'
+    return p
+
+
+class MockResponse(object):
+    def __init__(self, attr_dict):
+        self.__dict__ = attr_dict
+
+    def json(self):
+        return self.__dict__
 
 
 class TestPools(object):
@@ -66,7 +100,38 @@ class TestPools(object):
         assert hasattr(p1, 'srvs')
 
 
-class TestCreatev11(object):
+class TestMembers(object):
+    def test_members_s_subcoll_and_new_method_v11(self, fakeicontrolsession):
+        memc = Members_s(Makepool(fakeicontrolsession))
+        kind = 'tm:gtm:pool:members:membersstate'
+        test_meta = memc._meta_data['attribute_registry']
+        test_meta2 = memc._meta_data['allowed_lazy_attributes']
+        assert isinstance(memc, MembersCollection_v11)
+        assert hasattr(memc, 'member')
+        assert memc.__class__.__name__ == 'Members_s'
+        assert kind in list(iterkeys(test_meta))
+        assert Member in test_meta2
+
+    def test_members_new_method_v11(self, fakeicontrolsession):
+        memc = Members_s(Makepool(fakeicontrolsession))
+        memres = memc.member
+        assert isinstance(memres, MembersResource_v11)
+        assert memres.__class__.__name__ == 'Member'
+
+    def test_member_create_v11(self, fakeicontrolsession):
+        memc = Members_s(Makepool(fakeicontrolsession))
+        memc2 = Members_s(Makepool(fakeicontrolsession))
+        m1 = memc.member
+        m2 = memc2.member
+        assert m1 is not m2
+
+    def test_member_create_no_args_v11(self, fakeicontrolsession):
+        memc = Members_s(Makepool(fakeicontrolsession))
+        with pytest.raises(MissingRequiredCreationParameter):
+            memc.member.create()
+
+
+class TestPoolCreatev11(object):
     def test_create_two_v11(self, fakeicontrolsession):
         b = ManagementRoot('192.168.1.1', 'admin', 'admin')
         p1 = b.tm.gtm.pools.pool
@@ -78,7 +143,7 @@ class TestCreatev11(object):
             FakePoolv11.pool.create()
 
 
-class TestCollectionv11(object):
+class TestPoolCollectionv11(object):
     def test_pool_attr_exists(self, fakeicontrolsession):
         b = ManagementRoot('192.168.1.1', 'admin', 'admin')
         p = b.tm.gtm.pools
@@ -102,6 +167,12 @@ class HelperTest(object):
                           'mx': 'tm:gtm:pool:mx:mxstate',
                           'naptr': 'tm:gtm:pool:naptr:naptrstate',
                           'srv': 'tm:gtm:pool:srv:srvstate'}
+        self.memkinds = {'a': 'tm:gtm:pool:a:members:membersstate',
+                         'aaaa': 'tm:gtm:pool:aaaa:members:membersstate',
+                         'cname': 'tm:gtm:pool:cname:members:membersstate',
+                         'mx': 'tm:gtm:pool:mx:members:membersstate',
+                         'naptr': 'tm:gtm:pool:naptr:members:membersstate',
+                         'srv': 'tm:gtm:pool:srv:members:membersstate'}
 
     def urielementname(self):
         if self.lowered[-2:] == '_s':
@@ -126,6 +197,16 @@ class HelperTest(object):
                     self.lowered)
         return resourcecollection
 
+    def set_subcoll_pool(self, fakeicontrolsession_v12):
+        r1, r2, = self.set_resources(fakeicontrolsession_v12)
+        r1._meta_data['uri'] = \
+            'https://192.168.1.1:443/mgmt/tm/gtm/pool/'+self.urielementname()\
+            + '~Common~testpool/'
+        r2._meta_data['uri'] = \
+            'https://192.168.1.1:443/mgmt/tm/gtm/pool/'+self.urielementname()\
+            + '~Common~testpool/'
+        return r1, r2
+
     def test_collections(self, fakeicontrolsession_v12, klass):
         rc = self.set_collections(fakeicontrolsession_v12)
         test_meta = rc._meta_data['attribute_registry']
@@ -140,43 +221,203 @@ class HelperTest(object):
 
     def test_create_no_args_v12(self, fakeicontrolsession_v12):
         r1, r2, = self.set_resources(fakeicontrolsession_v12)
-        del r2
         with pytest.raises(MissingRequiredCreationParameter):
             r1.create()
 
+    def test_members_s_subcoll_and_new_method_v12(
+            self, fakeicontrolsession_v12, klass):
+        r1, r2, = self.set_subcoll_pool(fakeicontrolsession_v12)
+        memc = Members_s(r1)
+        test_meta = memc._meta_data['attribute_registry']
+        test_meta2 = memc._meta_data['allowed_lazy_attributes']
+        kind = self.memkinds[self.urielementname()]
+        assert isinstance(memc, klass)
+        assert hasattr(memc, 'member')
+        assert memc.__class__.__name__ == 'Members_s'
+        assert kind in list(iterkeys(test_meta))
+        assert Member in test_meta2
 
-class Testv12(object):
-    def test_wideip_type_a(self, fakeicontrolsession_v12):
-        p = HelperTest('a_s')
+    def test_members_new_method_v12(self, fakeicontrolsession_v12, klass):
+        r1, r2, = self.set_subcoll_pool(fakeicontrolsession_v12)
+        memc = Members_s(r1)
+        memres = memc.member
+        assert isinstance(memres, klass)
+        assert memres.__class__.__name__ == 'Member'
+
+    def test_member_create_v12(self, fakeicontrolsession_v12):
+        r1, r2, = self.set_subcoll_pool(fakeicontrolsession_v12)
+        memc = Members_s(r1)
+        memc2 = Members_s(r2)
+        m1 = memc.member
+        m2 = memc2.member
+        assert m1 is not m2
+
+    def test_member_create_no_args_v12(self, fakeicontrolsession_v12):
+        r1, r2, = self.set_subcoll_pool(fakeicontrolsession_v12)
+        memc = Members_s(r1)
+        memres = memc.member
+        with pytest.raises(MissingRequiredCreationParameter):
+            memres.create()
+
+    def test_URI_creation_collision(self, fakeicontrolsession_v12):
+        r1, r2, = self.set_subcoll_pool(fakeicontrolsession_v12)
+        memc = Members_s(r1)
+        memres = memc.member
+        memres._meta_data['bigip']._meta_data['tmos_version'] = '12.1.0'
+        memres._meta_data['uri'] = 'URI'
+        with pytest.raises(URICreationCollision) as UCCEIO:
+            memres.create(uri='URI')
+        assert str(UCCEIO.value) == \
+            "There was an attempt to assign a new uri to this resource," \
+            " the _meta_data['uri'] is URI and it should not be changed."
+
+    def test_non_404_response__v12_1(self, fakeicontrolsession_v12):
+        r1, r2, = self.set_subcoll_pool(fakeicontrolsession_v12)
+        memc = Members_s(r1)
+        memc._meta_data['uri'] = 'mock://URI'
+        memres = memc.member
+        memres._meta_data['bigip']._meta_data['tmos_version'] = '12.1.0'
+        mock_response = mock.MagicMock()
+        mock_response.status_code = 500
+        mock_response.text = 'Internal Server Error'
+        error = HTTPError(response=mock_response)
+        session = mock.MagicMock(name='mock_session')
+        session.post.side_effect = error
+        memres._meta_data['bigip']._meta_data['icr_session'] = session
+        with pytest.raises(HTTPError) as err:
+                memres.create(name='fake', partition='fakepart')
+        assert err.value.response.status_code == 500
+
+    def test_404_response_v12_1(self, fakeicontrolsession_v12):
+        r1, r2, = self.set_subcoll_pool(fakeicontrolsession_v12)
+        memc = Members_s(r1)
+        memres = memc.member
+        memres._meta_data['bigip']._meta_data['tmos_version'] = '12.1.0'
+        mock_response = mock.MagicMock()
+        mock_response.status_code = 404
+        error = HTTPError(response=mock_response)
+        MRO = MockResponse({u"kind": self.memkinds[self.urielementname()],
+                            u"selfLink":
+                                u".../~Common~testpool/members/~Common~fake"})
+        session = mock.MagicMock(name='mock_session')
+        session.post.side_effect = error
+        session.get.return_value = MRO
+        memres._meta_data['bigip']._meta_data['icr_session'] = session
+        a = memres.create(name='fake', partition='Common')
+        assert a.selfLink == '.../~Common~testpool/members/~Common~fake'
+        assert a.kind == self.memkinds[self.urielementname()]
+
+    def test_200_response_v12_1(self, fakeicontrolsession_v12):
+        r1, r2, = self.set_subcoll_pool(fakeicontrolsession_v12)
+        memc = Members_s(r1)
+        memres = memc.member
+        memres._meta_data['bigip']._meta_data['tmos_version'] = '12.1.0'
+        MRO = MockResponse({u"kind": self.memkinds[self.urielementname()],
+                            u"selfLink":
+                                u".../~Common~testpool/members/~Common~fake"})
+        session = mock.MagicMock(name='mock_session')
+        session.post.return_value = MRO
+        memres._meta_data['bigip']._meta_data['icr_session'] = session
+        a = memres.create(name='fake', partition='Common')
+        assert a.selfLink == '.../~Common~testpool/members/~Common~fake'
+        assert a.kind == self.memkinds[self.urielementname()]
+
+
+class TestV12Members(object):
+    def test_members_type_a(self, fakeicontrolsession_v12):
+        p = HelperTest('A_s')
+        p.test_members_s_subcoll_and_new_method_v12(fakeicontrolsession_v12,
+                                                    MembersCollectionA)
+        p.test_members_new_method_v12(fakeicontrolsession_v12,
+                                      MembersResourceA)
+        p.test_member_create_v12(fakeicontrolsession_v12)
+        p.test_member_create_no_args_v12(fakeicontrolsession_v12)
+        p.test_URI_creation_collision(fakeicontrolsession_v12)
+        p.test_non_404_response__v12_1(fakeicontrolsession_v12)
+        p.test_404_response_v12_1(fakeicontrolsession_v12)
+        p.test_200_response_v12_1(fakeicontrolsession_v12)
+
+    def test_members_type_aaaa(self, fakeicontrolsession_v12):
+        p = HelperTest('Aaaas')
+        p.test_members_s_subcoll_and_new_method_v12(fakeicontrolsession_v12,
+                                                    MembersCollectionAAAA)
+        p.test_members_new_method_v12(fakeicontrolsession_v12,
+                                      MembersResourceAAAA)
+        p.test_member_create_v12(fakeicontrolsession_v12)
+        p.test_member_create_no_args_v12(fakeicontrolsession_v12)
+        p.test_non_404_response__v12_1(fakeicontrolsession_v12)
+        p.test_404_response_v12_1(fakeicontrolsession_v12)
+        p.test_200_response_v12_1(fakeicontrolsession_v12)
+
+    def test_members_type_cname(self, fakeicontrolsession_v12):
+        p = HelperTest('Cnames')
+        p.test_members_s_subcoll_and_new_method_v12(fakeicontrolsession_v12,
+                                                    MembersCollectionCname)
+        p.test_members_new_method_v12(fakeicontrolsession_v12,
+                                      MembersResourceCname)
+        p.test_member_create_v12(fakeicontrolsession_v12)
+        p.test_member_create_no_args_v12(fakeicontrolsession_v12)
+
+    def test_members_type_mx(self, fakeicontrolsession_v12):
+        p = HelperTest('Mxs')
+        p.test_members_s_subcoll_and_new_method_v12(fakeicontrolsession_v12,
+                                                    MembersCollectionMx)
+        p.test_members_new_method_v12(fakeicontrolsession_v12,
+                                      MembersResourceMx)
+        p.test_member_create_v12(fakeicontrolsession_v12)
+        p.test_member_create_no_args_v12(fakeicontrolsession_v12)
+
+    def test_members_type_naptr(self, fakeicontrolsession_v12):
+        p = HelperTest('Naptrs')
+        p.test_members_s_subcoll_and_new_method_v12(fakeicontrolsession_v12,
+                                                    MembersCollectionNaptr)
+        p.test_members_new_method_v12(fakeicontrolsession_v12,
+                                      MembersResourceNaptr)
+        p.test_member_create_v12(fakeicontrolsession_v12)
+        p.test_member_create_no_args_v12(fakeicontrolsession_v12)
+
+    def test_members_type_srv(self, fakeicontrolsession_v12):
+        p = HelperTest('Srvs')
+        p.test_members_s_subcoll_and_new_method_v12(fakeicontrolsession_v12,
+                                                    MembersCollectionSrv)
+        p.test_members_new_method_v12(fakeicontrolsession_v12,
+                                      MembersResourceSrv)
+        p.test_member_create_v12(fakeicontrolsession_v12)
+        p.test_member_create_no_args_v12(fakeicontrolsession_v12)
+
+
+class TestV12Pools(object):
+    def test_pool_type_a(self, fakeicontrolsession_v12):
+        p = HelperTest('A_s')
         p.test_collections(fakeicontrolsession_v12, A)
         p.test_create_two_v12(fakeicontrolsession_v12)
         p.test_create_no_args_v12(fakeicontrolsession_v12)
 
-    def test_wideip_type_aaaa(self, fakeicontrolsession_v12):
-        p = HelperTest('aaaas')
+    def test_pool_type_aaaa(self, fakeicontrolsession_v12):
+        p = HelperTest('Aaaas')
         p.test_collections(fakeicontrolsession_v12, Aaaa)
         p.test_create_two_v12(fakeicontrolsession_v12)
         p.test_create_no_args_v12(fakeicontrolsession_v12)
 
-    def test_wideip_type_cname(self, fakeicontrolsession_v12):
-        p = HelperTest('cnames')
+    def test_pool_type_cname(self, fakeicontrolsession_v12):
+        p = HelperTest('Cnames')
         p.test_collections(fakeicontrolsession_v12, Cname)
         p.test_create_two_v12(fakeicontrolsession_v12)
         p.test_create_no_args_v12(fakeicontrolsession_v12)
 
-    def test_wideip_type_mx(self, fakeicontrolsession_v12):
+    def test_pool_type_mx(self, fakeicontrolsession_v12):
         p = HelperTest('Mxs')
         p.test_collections(fakeicontrolsession_v12, Mx)
         p.test_create_two_v12(fakeicontrolsession_v12)
         p.test_create_no_args_v12(fakeicontrolsession_v12)
 
-    def test_wideip_type_naptr(self, fakeicontrolsession_v12):
+    def test_pool_type_naptr(self, fakeicontrolsession_v12):
         p = HelperTest('Naptrs')
         p.test_collections(fakeicontrolsession_v12, Naptr)
         p.test_create_two_v12(fakeicontrolsession_v12)
         p.test_create_no_args_v12(fakeicontrolsession_v12)
 
-    def test_wideip_type_srv(self, fakeicontrolsession_v12):
+    def test_pool_type_srv(self, fakeicontrolsession_v12):
         p = HelperTest('Srvs')
         p.test_collections(fakeicontrolsession_v12, Srv)
         p.test_create_two_v12(fakeicontrolsession_v12)


### PR DESCRIPTION
Adds more test coverage to GTM pools.py

Issues:
Fixes #680

Problem:
Coverage of pools.py was quite low, given the implemented 12..1.0 workarounds

Analysis:
Completed Functional and Unit tests to fill in the gaps

Files Changed/Added:

f5/bigip/gtm/test/unit/test_pool.py
f5/bigip/gtm/test/functional/test_pool.py

Tests:
Flake 8
Unit
Functional
