### PR TITLE
Adds support for extracting template name with slashes

### DIFF
--- a/f5/utils/iapp_parser.py
+++ b/f5/utils/iapp_parser.py
@@ -108,14 +108,13 @@ class IappParser(object):
         :raises: NonextantTemplateNameException
         '''
 
-        start_pattern = 'sys application template\s+\w[\w\.\-]+\s*\{'
+        start_pattern = "sys application template\s+" \
+                        "(\/[\w\.\-]+\/)?" \
+                        "(?P<name>[\w\.\-]+)\s*\{"
 
         template_start = re.search(start_pattern, self.template_str)
         if template_start:
-            split_start = template_start.group(0).split()
-            if split_start[3][-1:] == u'{':
-                split_start[3] = split_start[3][:-1]
-            return split_start[3]
+            return template_start.group('name')
 
         raise NonextantTemplateNameException('Template name not found.')
 

--- a/f5/utils/test/unit/test_iapp_parser.py
+++ b/f5/utils/test/unit/test_iapp_parser.py
@@ -309,6 +309,27 @@ dot_hyphen_name_templ = '''sys application template good.-dot-hyphen.-templ {
   requires-modules { ltm }
 }'''
 
+slashes_name_templ = '''sys application template /Common/good_slashes_templ {
+  actions {
+    definition {
+      html-help {
+        # HTML Help for the template
+      }
+      implementation {
+        # TMSH implementation code
+      }
+      presentation {
+        # APL presentation language
+      }
+      role-acl { hello test }
+      run-as <user context>
+    }
+  }
+  description <template description>
+  partition <partition name>
+  requires-modules { ltm }
+}'''
+
 good_templ_dict = {
     u'name': u'good_templ',
     u'description': u'<template description>',
@@ -385,6 +406,21 @@ dot_name_templ_dict = {
 
 dot_hyphen_name_templ_dict = {
     u'name': u'good.-dot-hyphen.-templ',
+    u'description': u'<template description>',
+    u'partition': u'<partition name>',
+    u'requiresModules': [u'ltm'],
+    'actions': {
+        'definition': {
+            u'htmlHelp': u'# HTML Help for the template',
+            u'roleAcl': [u'hello', u'test'],
+            u'implementation': u'# TMSH implementation code',
+            u'presentation': u'# APL presentation language'
+        }
+    }
+}
+
+slashes_name_templ_dict = {
+    u'name': u'good_slashes_templ',
     u'description': u'<template description>',
     u'partition': u'<partition name>',
     u'requiresModules': [u'ltm'],
@@ -488,6 +524,11 @@ def test_get_template_name_with_dot():
 def test_get_template_name_with_dot_hyphen():
     prsr = ip.IappParser(dot_hyphen_name_templ)
     assert prsr.parse_template() == dot_hyphen_name_templ_dict
+
+
+def test_get_template_name_with_slashes():
+    prsr = ip.IappParser(slashes_name_templ)
+    assert prsr.parse_template() == slashes_name_templ_dict
 
 
 def test_parse_template():


### PR DESCRIPTION
Issues:
Fixes #801

Problem:
iapp template names can include the partition

Analysis:
this changes the regex to look for that partition component and
discard it if found. leaving only the name

Tests:
unit