### PR TITLE
Fixes Update method #807

### DIFF
--- a/f5/bigip/resource.py
+++ b/f5/bigip/resource.py
@@ -100,8 +100,8 @@ from f5.bigip.mixins import LazyAttributeMixin
 from f5.bigip.mixins import ToDictMixin
 from f5.sdk_exception import F5SDKError
 from f5.sdk_exception import UnsupportedMethod
-from requests.exceptions import HTTPError
 from icontrol.exceptions import iControlUnexpectedHTTPError
+from requests.exceptions import HTTPError
 from six import iteritems
 from six import iterkeys
 from six import itervalues
@@ -515,13 +515,12 @@ class ResourceBase(PathElement, ToDictMixin):
         try:
             response = session.put(update_uri, json=data_dict,
                                    **requests_params)
-            self._meta_data = temp_meta
-            self._local_update(response.json())
         except iControlUnexpectedHTTPError:
                 response = session.get(update_uri, **requests_params)
-                self._meta_data = temp_meta
-                self._local_update(response.json())
                 raise
+        finally:
+            self._meta_data = temp_meta
+            self._local_update(response.json())
 
     def update(self, **kwargs):
         """Update the configuration of the resource on the BIG-IP®.


### PR DESCRIPTION
Issues:
Fixes #807

Problem:
The update method strips _meta_data during its update process. This works well when the update suceeds. The problem occurs when we receive exception from bigip. Not only we fail to update (for one reason or the other which is what we intended) but we also leave the calling object with this _meta_data removed.

Analysis:
This patch added the logic to return the object to its original state as well as passing on the raised exception. This means that we do see failure as intended but we no longer have objects with _meta_data stripped.

Tests:
unit tests
flake 8