### PR TITLE
Fixes exec_cmd aliasing issue

### DIFF
--- a/f5/bigip/tm/sys/failover.py
+++ b/f5/bigip/tm/sys/failover.py
@@ -98,7 +98,8 @@ class Failover(UnnamedResource, CommandExecutionMixin):
         if 'online' in kwargs:
             self._meta_data['exclusive_attributes'].append(
                 ('online', 'standby'))
-
+        self._is_allowed_command(command)
+        self._check_command_parameters(**kwargs)
         return self._exec_cmd(command, **kwargs)
 
     def toggle_standby(self, **kwargs):
@@ -116,4 +117,4 @@ class Failover(UnnamedResource, CommandExecutionMixin):
         if kwargs:
             raise TypeError('Unexpected **kwargs: %r' % kwargs)
         arguments = {'standby': state, 'traffic-group': trafficgroup}
-        self.exec_cmd('run', **arguments)
+        return self.exec_cmd('run', **arguments)

--- a/f5/bigip/tm/sys/test/functional/test_failover.py
+++ b/f5/bigip/tm/sys/test/functional/test_failover.py
@@ -63,18 +63,18 @@ class TestFailover(object):
 
     def test_toggle_standby(self, bigip):
         f = bigip.sys.failover
-        f.toggle_standby(trafficgroup="traffic-group-1", state=None)
-        assert f.standby is None
-        assert f.command == u"run"
-        pp(f.raw)
-        f.toggle_standby(trafficgroup="traffic-group-1", state=True)
-        assert f.standby is True
-        assert f.command == u"run"
+        fl = f.toggle_standby(trafficgroup="traffic-group-1", state=None)
+        assert fl.standby is None
+        assert fl.command == u"run"
+        pp(fl.raw)
+        fl = f.toggle_standby(trafficgroup="traffic-group-1", state=True)
+        assert fl.standby is True
+        assert fl.command == u"run"
         pp('************')
-        f.refresh()
+        fl.refresh()
         pp('after refresh')
-        pp(f.raw)
-        assert 'Failover active' in f.apiRawValues['apiAnonymous']
+        pp(fl.raw)
+        assert 'Failover active' in fl.apiRawValues['apiAnonymous']
 
     def test_toggle_bad_kwargs_standby(self, mgmt_root):
         with pytest.raises(TypeError) as ex:

--- a/f5/bigip/tm/sys/ucs.py
+++ b/f5/bigip/tm/sys/ucs.py
@@ -27,7 +27,6 @@ REST Kind
 """
 
 from f5.bigip.mixins import CommandExecutionMixin
-from f5.bigip.mixins import InvalidCommand
 from f5.bigip.resource import UnnamedResource
 from requests.exceptions import HTTPError
 
@@ -59,19 +58,14 @@ class Ucs(UnnamedResource, CommandExecutionMixin):
         self._meta_data['minimum_version'] = '12.0.0'
 
     def exec_cmd(self, command, **kwargs):
-        """Due to ID476518 the load command need special treatment"""
-        cmds = self._meta_data['allowed_commands']
-
-        if command not in self._meta_data['allowed_commands']:
-            error_message = "The command value {0} does not exist" \
-                            "Valid commands are {1}".format(command, cmds)
-            raise InvalidCommand(error_message)
+        """Due to ID476518 the load command need special treatment."""
+        self._is_allowed_command(command)
+        self._check_command_parameters(**kwargs)
 
         if command == 'load':
             kwargs['command'] = command
             self._check_exclusive_parameters(**kwargs)
             requests_params = self._handle_requests_params(kwargs)
-            self._check_command_parameters(**kwargs)
             session = self._meta_data['bigip']._meta_data['icr_session']
             try:
 

--- a/f5/bigip/tm/util/Dig.py
+++ b/f5/bigip/tm/util/Dig.py
@@ -28,7 +28,6 @@ REST Kind
 
 from f5.bigip.mixins import CommandExecutionMixin
 from f5.bigip.resource import UnnamedResource
-from f5.utils.util_exceptions import UtilError
 
 
 class Dig(UnnamedResource, CommandExecutionMixin):
@@ -45,22 +44,3 @@ class Dig(UnnamedResource, CommandExecutionMixin):
         self._meta_data['required_command_parameters'].update(('utilCmdArgs',))
         self._meta_data['required_json_kind'] = 'tm:util:dig:runstate'
         self._meta_data['allowed_commands'].append('run')
-
-    def _exec_cmd(self, command, **kwargs):
-        kwargs['command'] = command
-        self._check_exclusive_parameters(**kwargs)
-        requests_params = self._handle_requests_params(kwargs)
-        self._check_command_parameters(**kwargs)
-
-        session = self._meta_data['bigip']._meta_data['icr_session']
-        response = session.post(
-            self._meta_data['uri'], json=kwargs, **requests_params)
-        self._local_update(response.json())
-
-        if 'commandResult' in self.__dict__:
-            if 'Invalid option' in self.commandResult:
-                raise UtilError('%s' % self.commandResult)
-            else:
-                return self
-        else:
-            return self

--- a/f5/bigip/tm/util/Qkview.py
+++ b/f5/bigip/tm/util/Qkview.py
@@ -28,7 +28,6 @@ REST Kind
 
 from f5.bigip.mixins import CommandExecutionMixin
 from f5.bigip.resource import UnnamedResource
-from f5.utils.util_exceptions import UtilError
 
 
 class Qkview(UnnamedResource, CommandExecutionMixin):
@@ -45,22 +44,3 @@ class Qkview(UnnamedResource, CommandExecutionMixin):
         self._meta_data['required_command_parameters'].update(('utilCmdArgs',))
         self._meta_data['required_json_kind'] = 'tm:util:qkview:runstate'
         self._meta_data['allowed_commands'].append('run')
-
-    def _exec_cmd(self, command, **kwargs):
-        kwargs['command'] = command
-        self._check_exclusive_parameters(**kwargs)
-        requests_params = self._handle_requests_params(kwargs)
-        self._check_command_parameters(**kwargs)
-
-        session = self._meta_data['bigip']._meta_data['icr_session']
-        response = session.post(
-            self._meta_data['uri'], json=kwargs, **requests_params)
-        self._local_update(response.json())
-
-        if 'commandResult' in self.__dict__:
-            if 'invalid option' in self.commandResult:
-                raise UtilError('%s' % self.commandResult)
-            else:
-                return self
-        else:
-            return self

--- a/f5/bigip/tm/util/Unix_Ls.py
+++ b/f5/bigip/tm/util/Unix_Ls.py
@@ -28,7 +28,6 @@ REST Kind
 
 from f5.bigip.mixins import CommandExecutionMixin
 from f5.bigip.resource import UnnamedResource
-from f5.utils.util_exceptions import UtilError
 
 
 class Unix_Ls(UnnamedResource, CommandExecutionMixin):
@@ -38,21 +37,3 @@ class Unix_Ls(UnnamedResource, CommandExecutionMixin):
         self._meta_data['required_command_parameters'].update(('utilCmdArgs',))
         self._meta_data['required_json_kind'] = 'tm:util:unix-ls:runstate'
         self._meta_data['allowed_commands'].append('run')
-
-    def _exec_cmd(self, command, **kwargs):
-        kwargs['command'] = command
-        self._check_exclusive_parameters(**kwargs)
-        requests_params = self._handle_requests_params(kwargs)
-        self._check_command_parameters(**kwargs)
-        session = self._meta_data['bigip']._meta_data['icr_session']
-        response = session.post(
-            self._meta_data['uri'], json=kwargs, **requests_params)
-        self._local_update(response.json())
-
-        if 'commandResult' in self.__dict__:
-            if self.commandResult.startswith('/bin/ls'):
-                raise UtilError('%s' % self.commandResult.split(' ', 1)[1])
-            else:
-                return self
-        else:
-            return self

--- a/f5/bigip/tm/util/Unix_Mv.py
+++ b/f5/bigip/tm/util/Unix_Mv.py
@@ -28,7 +28,6 @@ REST Kind
 
 from f5.bigip.mixins import CommandExecutionMixin
 from f5.bigip.resource import UnnamedResource
-from f5.utils.util_exceptions import UtilError
 
 
 class Unix_Mv(UnnamedResource, CommandExecutionMixin):
@@ -38,19 +37,3 @@ class Unix_Mv(UnnamedResource, CommandExecutionMixin):
         self._meta_data['required_command_parameters'].update(('utilCmdArgs',))
         self._meta_data['required_json_kind'] = 'tm:util:unix-mv:runstate'
         self._meta_data['allowed_commands'].append('run')
-
-    def _exec_cmd(self, command, **kwargs):
-        kwargs['command'] = command
-        self._check_exclusive_parameters(**kwargs)
-        requests_params = self._handle_requests_params(kwargs)
-        self._check_command_parameters(**kwargs)
-        session = self._meta_data['bigip']._meta_data['icr_session']
-        response = session.post(
-            self._meta_data['uri'], json=kwargs, **requests_params)
-        self._local_update(response.json())
-
-        if 'commandResult' in self.__dict__:
-            if self.commandResult.startswith('/bin/mv'):
-                raise UtilError('%s' % self.commandResult.split(' ', 1)[1])
-        else:
-            return self

--- a/f5/bigip/tm/util/Unix_Rm.py
+++ b/f5/bigip/tm/util/Unix_Rm.py
@@ -28,7 +28,6 @@ REST Kind
 
 from f5.bigip.mixins import CommandExecutionMixin
 from f5.bigip.resource import UnnamedResource
-from f5.utils.util_exceptions import UtilError
 
 
 class Unix_Rm(UnnamedResource, CommandExecutionMixin):
@@ -38,19 +37,3 @@ class Unix_Rm(UnnamedResource, CommandExecutionMixin):
         self._meta_data['required_command_parameters'].update(('utilCmdArgs',))
         self._meta_data['required_json_kind'] = 'tm:util:unix-rm:runstate'
         self._meta_data['allowed_commands'].append('run')
-
-    def _exec_cmd(self, command, **kwargs):
-        kwargs['command'] = command
-        self._check_exclusive_parameters(**kwargs)
-        requests_params = self._handle_requests_params(kwargs)
-        self._check_command_parameters(**kwargs)
-        session = self._meta_data['bigip']._meta_data['icr_session']
-        response = session.post(
-            self._meta_data['uri'], json=kwargs, **requests_params)
-        self._local_update(response.json())
-
-        if 'commandResult' in self.__dict__:
-            if self.commandResult.startswith('/bin/rm'):
-                raise UtilError('%s' % self.commandResult.split(' ', 1)[1])
-        else:
-            return self

--- a/f5/bigip/tm/util/test/functional/test_bash.py
+++ b/f5/bigip/tm/util/test/functional/test_bash.py
@@ -16,8 +16,8 @@
 
 import pytest
 
+from f5.bigip.mixins import UtilError
 from f5.bigip.resource import MissingRequiredCommandParameter
-from f5.utils.util_exceptions import UtilError
 from icontrol.session import iControlUnexpectedHTTPError
 
 

--- a/f5/bigip/tm/util/test/functional/test_dig.py
+++ b/f5/bigip/tm/util/test/functional/test_dig.py
@@ -16,8 +16,8 @@
 
 import pytest
 
+from f5.bigip.mixins import UtilError
 from f5.bigip.resource import MissingRequiredCommandParameter
-from f5.utils.util_exceptions import UtilError
 from icontrol.session import iControlUnexpectedHTTPError
 
 

--- a/f5/bigip/tm/util/test/functional/test_qkview.py
+++ b/f5/bigip/tm/util/test/functional/test_qkview.py
@@ -16,8 +16,8 @@
 
 import pytest
 
+from f5.bigip.mixins import UtilError
 from f5.bigip.resource import MissingRequiredCommandParameter
-from f5.utils.util_exceptions import UtilError
 from icontrol.session import iControlUnexpectedHTTPError
 
 

--- a/f5/bigip/tm/util/test/functional/test_unix_ls.py
+++ b/f5/bigip/tm/util/test/functional/test_unix_ls.py
@@ -17,7 +17,7 @@
 from distutils.version import LooseVersion
 import pytest
 
-from f5.utils.util_exceptions import UtilError
+from f5.bigip.mixins import UtilError
 from icontrol.session import iControlUnexpectedHTTPError
 import os
 from tempfile import NamedTemporaryFile

--- a/f5/bigip/tm/util/test/functional/test_unix_mv.py
+++ b/f5/bigip/tm/util/test/functional/test_unix_mv.py
@@ -16,7 +16,7 @@
 
 import pytest
 
-from f5.utils.util_exceptions import UtilError
+from f5.bigip.mixins import UtilError
 import os
 from tempfile import NamedTemporaryFile
 

--- a/f5/bigip/tm/util/test/functional/test_unix_rm.py
+++ b/f5/bigip/tm/util/test/functional/test_unix_rm.py
@@ -16,7 +16,7 @@
 
 import pytest
 
-from f5.utils.util_exceptions import UtilError
+from f5.bigip.mixins import UtilError
 import os
 from tempfile import NamedTemporaryFile
 


### PR DESCRIPTION
Fixes #768, #793, #810

Problem:
Exec_cmd mixin is suffering from the same problem described in #407. Given the fact that /sys/util endpoint is using exec_cmd logic heavily, this was required to be fixed sooner than later.

Analysis:
Added new private methods inside CommandExecutionMixin class and moved command parameter checks to occur after valid command check. the new methods  contain most of the non-repeated code from /sys/util endpoint. Failover endpoint's toggle_standby method had to be changed slightly to return a _exec_cmd. Subsequently this required a minor tweak in one of the tests.

Tests:
unit tests
functional tests
flake 8