### PR TITLE
Fixes default success assertions in util tests

### DIFF
--- a/f5/bigip/tm/util/test/functional/test_dig.py
+++ b/f5/bigip/tm/util/test/functional/test_dig.py
@@ -1,4 +1,3 @@
-
 # Copyright 2016 F5 Networks Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -21,25 +20,25 @@ from f5.bigip.resource import MissingRequiredCommandParameter
 from icontrol.session import iControlUnexpectedHTTPError
 
 
-def test_E_dig(mgmt_root):
-
+def test_missing_required_params(mgmt_root):
     with pytest.raises(MissingRequiredCommandParameter) as err:
         mgmt_root.tm.util.dig.exec_cmd('run')
-        assert "Missing required params: ['utilCmdArgs']" in err.response.text
+    assert "Missing required params: ['utilCmdArgs']" in str(err)
 
+
+def test_command_result_present(mgmt_root):
     dig1 = mgmt_root.tm.util.dig.exec_cmd('run', utilCmdArgs='f5.com NS')
-
-    # commandResult should be present with data from 'f5.com NS'
     assert 'commandResult' in dig1.__dict__
     assert 'DiG' in dig1.commandResult
 
-    # UtilError should be raised if there is an invalid option for dig
+
+def test_invalid_dig_options(mgmt_root):
     with pytest.raises(UtilError) as err:
         mgmt_root.tm.util.dig.exec_cmd('run', utilCmdArgs='-9 f5.com NS')
-        assert 'Invalid option' in err.response.text
+    assert 'Invalid option' in str(err.value)
 
-    # iControlUnexpectedHTTPError should be raised if quotes don't match
+
+def test_unbalanced_quotes(mgmt_root):
     with pytest.raises(iControlUnexpectedHTTPError) as err:
         mgmt_root.tm.util.dig.exec_cmd('run', utilCmdArgs='"')
-        assert err.response.status_code == 400
-        assert 'quotes are not balanced' in err.response.text
+    assert 'quotes are not balanced' in err.value.response.text

--- a/f5/bigip/tm/util/test/functional/test_qkview.py
+++ b/f5/bigip/tm/util/test/functional/test_qkview.py
@@ -1,4 +1,3 @@
-
 # Copyright 2016 F5 Networks Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -21,25 +20,25 @@ from f5.bigip.resource import MissingRequiredCommandParameter
 from icontrol.session import iControlUnexpectedHTTPError
 
 
-def test_E_qkview(mgmt_root):
-
+def test_missing_required_params(mgmt_root):
     with pytest.raises(MissingRequiredCommandParameter) as err:
         mgmt_root.tm.util.qkview.exec_cmd('run')
-        assert "Missing required params: ['utilCmdArgs']" in err.response.text
+    assert "Missing required params: ['utilCmdArgs']" in str(err)
 
+
+def test_command_result_present(mgmt_root):
     qv1 = mgmt_root.tm.util.qkview.exec_cmd('run', utilCmdArgs='-h')
-
-    # commandResult should be present with data from '-h'
     assert 'commandResult' in qv1.__dict__
     assert 'usage: qkview' in qv1.commandResult
 
-    # UtilError should be raised if there is an invalid option for qkview
+
+def test_invalid_option_for_qkview(mgmt_root):
     with pytest.raises(UtilError) as err:
         mgmt_root.tm.util.qkview.exec_cmd('run', utilCmdArgs='-9')
-        assert 'invalid option' in err.response.text
+    assert 'invalid option' in str(err.value)
 
-    # iControlUnexpectedHTTPError should be raised if quotes don't match
+
+def test_unbalanced_quotes(mgmt_root):
     with pytest.raises(iControlUnexpectedHTTPError) as err:
         mgmt_root.tm.util.qkview.exec_cmd('run', utilCmdArgs='"')
-        assert err.response.status_code == 400
-        assert 'quotes are not balanced' in err.response.text
+    assert 'quotes are not balanced' in err.value.response.text

--- a/f5/bigip/tm/util/test/functional/test_unix_mv.py
+++ b/f5/bigip/tm/util/test/functional/test_unix_mv.py
@@ -1,4 +1,3 @@
-
 # Copyright 2016 F5 Networks Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -41,7 +40,9 @@ def test_E_unix_mv(mgmt_root):
     # if command was successful, commandResult should not be present
     assert 'commandResult' not in fm1.__dict__
 
+
+def test_mv_file_does_not_exist(mgmt_root):
     # UtilError should be raised when non-existent file is mentioned
-    with pytest.raises(UtilError):
-        mgmt_root.tm.util.unix_mv.exec_cmd(
-            'run', utilCmdArgs='{0}/mf.txt'.format(tpath_name))
+    with pytest.raises(UtilError) as err:
+        mgmt_root.tm.util.unix_mv.exec_cmd('run', utilCmdArgs='/foo/mf.txt')
+    assert 'missing destination file operand after' in str(err.value)

--- a/f5/bigip/tm/util/test/functional/test_unix_rm.py
+++ b/f5/bigip/tm/util/test/functional/test_unix_rm.py
@@ -1,4 +1,3 @@
-
 # Copyright 2016 F5 Networks Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -38,6 +37,9 @@ def test_E_unix_rm(mgmt_root):
     # if command was successful, commandResult should not be present
     assert 'commandResult' not in fr1.__dict__
 
+
+def test_rm_file_does_not_exist(mgmt_root):
     # UtilError should be raised when non-existent file is mentioned
-    with pytest.raises(UtilError):
+    with pytest.raises(UtilError) as err:
         mgmt_root.tm.util.unix_rm.exec_cmd('run', utilCmdArgs='testfile.txt')
+    assert 'No such file or directory' in str(err.value)


### PR DESCRIPTION
Issues:
Fixes #812

Problem:
The tests for all of the util functional tests were always returning
`true` because the assertions were being skipped

Analysis:
this patch fixes the tests by moving the assertion up and also refactoring
the tests so that they are in their own test functions and classes where
appropriate

Tests:
functional