### PR TITLE
Cleans up debug statements in test code

### DIFF
--- a/f5/bigip/shared/test/functional/test___init__.py
+++ b/f5/bigip/shared/test/functional/test___init__.py
@@ -11,19 +11,16 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from pprint import pprint as pp
 
 from f5.bigip.tm.shared import Shared
 
 
 def test_shared(request, mgmt_root):
     s = mgmt_root.tm.shared
-    pp(s.raw)
     assert s._meta_data['allowed_lazy_attributes'][0].__name__ == "Licensing"
     suri = s._meta_data['uri']
     assert suri.endswith('/mgmt/tm/shared/')
     l = mgmt_root.tm.shared.licensing
-    pp(l.raw)
     assert isinstance(l._meta_data['container'], Shared)
     luri = l._meta_data['uri']
     assert luri.endswith('/mgmt/tm/shared/licensing/')

--- a/f5/bigip/shared/test/functional/test_licensing.py
+++ b/f5/bigip/shared/test/functional/test_licensing.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from pprint import pprint as pp
 import pytest
 
 from f5.bigip.mixins import UnsupportedMethod
@@ -34,6 +33,5 @@ class TestRegistration(object):
         assert hasattr(reg, 'generation')
 
     def test_update(self, request, bigip):
-        pp(bigip.shared.raw)
         with pytest.raises(UnsupportedMethod):
             bigip.shared.licensing.registration.update()

--- a/f5/bigip/tm/asm/test/functional/test_signature_systems.py
+++ b/f5/bigip/tm/asm/test/functional/test_signature_systems.py
@@ -14,7 +14,6 @@
 #
 
 from f5.bigip.tm.asm.signature_systems import Signature_System
-from pprint import pprint as pp
 
 
 class TestSignatureSystems(object):
@@ -41,8 +40,6 @@ class TestSignatureSystems(object):
         assert sig1.name != sig2.name
         assert sig1.id == coll[0].id
         assert sig2.id == coll[1].id
-        pp(sig1.raw)
-        pp(sig2.raw)
 
     def test_refresh(self, request, mgmt_root):
         coll = mgmt_root.tm.asm.signature_systems_s.get_collection()
@@ -58,5 +55,3 @@ class TestSignatureSystems(object):
         assert sig1.name == sig2.name
         assert sig1.id == coll[0].id
         assert sig2.id == coll[0].id
-        pp(sig1.raw)
-        pp(sig2.raw)

--- a/f5/bigip/tm/asm/test/functional/test_signature_update.py
+++ b/f5/bigip/tm/asm/test/functional/test_signature_update.py
@@ -14,7 +14,6 @@
 #
 
 import copy
-from pprint import pprint as pp
 from six import iteritems
 
 
@@ -34,8 +33,6 @@ class TestSignatureUpdate(object):
         sig1, interval = setup_sig_test(request, mgmt_root)
         sig2 = mgmt_root.tm.asm.signature_update.load()
         assert sig1.updateInterval == sig2.updateInterval
-        pp(sig1.raw)
-        pp(sig2.raw)
 
         # Refresh
         sig1.modify(updateInterval=inter)

--- a/f5/bigip/tm/auth/test/functional/test_password_policy.py
+++ b/f5/bigip/tm/auth/test/functional/test_password_policy.py
@@ -13,16 +13,12 @@
 # limitations under the License.
 #
 
-from pprint import pprint as pp
-
 import copy
 
 
 class TestPasswordPolicy(object):
     def test_load(self, bigip):
         password_policy = bigip.auth.password_policy.load()
-        pp(password_policy._meta_data['uri'])
-        pp(password_policy.raw)
         assert password_policy.maxLoginFailures == 0
         password_policy.refresh()
         assert password_policy.maxLoginFailures == 0

--- a/f5/bigip/tm/cm/test/functional/test_sync_status.py
+++ b/f5/bigip/tm/cm/test/functional/test_sync_status.py
@@ -13,13 +13,10 @@
 # limitations under the License.
 #
 
-from pprint import pprint as pp
-
 
 class TestSyncStatus(object):
     def test_get_status(self, request, bigip):
         sync_status = bigip.cm.sync_status
-        pp(sync_status.raw)
         assert sync_status._meta_data['uri'].endswith(
             "/mgmt/tm/cm/sync-status/")
         sync_status.refresh()

--- a/f5/bigip/tm/gtm/test/functional/test_pool.py
+++ b/f5/bigip/tm/gtm/test/functional/test_pool.py
@@ -30,14 +30,10 @@ from f5.bigip.tm.gtm.pool import Naptr
 from f5.bigip.tm.gtm.pool import Pool
 from f5.bigip.tm.gtm.pool import Srv
 import mock
-from pprint import pprint as pp
 import pytest
 
 from requests.exceptions import HTTPError
 from six import iteritems
-
-
-pp(__file__)
 
 
 GTM_SERVER = 'fake_serv1'
@@ -210,7 +206,6 @@ class HelperTest(object):
 
         # Testing update
         pool.description = TESTDESCRIPTION
-        pp(pool.raw)
         pool.update()
         if hasattr(pool, 'description'):
             assert pool.description == TESTDESCRIPTION
@@ -302,7 +297,6 @@ class HelperTest(object):
 
         # Testing update
         member.description = TESTDESCRIPTION
-        pp(member.raw)
         member.update()
         if hasattr(member, 'description'):
             assert member.description == TESTDESCRIPTION

--- a/f5/bigip/tm/gtm/test/functional/test_wideips.py
+++ b/f5/bigip/tm/gtm/test/functional/test_wideips.py
@@ -24,7 +24,6 @@ from f5.bigip.tm.gtm.wideip import Mx
 from f5.bigip.tm.gtm.wideip import Naptr
 from f5.bigip.tm.gtm.wideip import Srv
 from f5.bigip.tm.gtm.wideip import Wideip
-from pprint import pprint as pp
 from requests.exceptions import HTTPError
 from six import iteritems
 
@@ -88,7 +87,6 @@ class HelperTest(object):
 
         # Testing update
         wideip.description = TESTDESCRIPTION
-        pp(wideip.raw)
         wideip.update()
         if hasattr(wideip, 'description'):
             assert wideip.description == TESTDESCRIPTION

--- a/f5/bigip/tm/ltm/test/functional/test_auth.py
+++ b/f5/bigip/tm/ltm/test/functional/test_auth.py
@@ -28,12 +28,10 @@ from f5.bigip.tm.ltm.auth import Ssl_Cc_Ldap
 from f5.bigip.tm.ltm.auth import Ssl_Crldp
 from f5.bigip.tm.ltm.auth import Ssl_Ocsp
 from f5.bigip.tm.ltm.auth import Tacacs
-from pprint import pprint as pp
 import pytest
 from requests.exceptions import HTTPError
 from six import iteritems
 TESTDESCRIPTION = "TESTDESCRIPTION"
-pp(__file__)
 
 
 def delete_dependency(mgmt_root, name):
@@ -118,7 +116,6 @@ class HelperTest(object):
 
         # Testing update
         authres.description = TESTDESCRIPTION
-        pp(authres.raw)
         authres.update()
         assert hasattr(authres, 'description')
         assert authres.description == TESTDESCRIPTION

--- a/f5/bigip/tm/ltm/test/functional/test_monitor.py
+++ b/f5/bigip/tm/ltm/test/functional/test_monitor.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 #
 
-from pprint import pprint as pp
 
 TESTDESCRIPTION = "TESTDESCRIPTION"
 
@@ -42,7 +41,6 @@ def delete_resource(resources):
                 and rn != 'tcp' and rn != 'tcp_echo'\
                 and rn != 'tcp_half_open' and rn != 'udp'\
                 and rn != 'virtual_location' and rn != 'wap' and rn != 'wmi':
-            pp(resource.__dict__)
             resource.delete()
 
 
@@ -51,7 +49,6 @@ def setup_http_test(request, bigip, partition, name):
         delete_resource(hc1)
     request.addfinalizer(teardown)
     hc1 = bigip.ltm.monitor.https
-    pp(hc1._meta_data)
     http1 = hc1.http.create(name=name, partition=partition)
     return http1, hc1
 
@@ -757,7 +754,6 @@ class TestMonitorSASP(object):
         sasp1, hc1 = setup_sasp_test(request, bigip, 'Common', 'sasptest')
         assert sasp1.name == 'sasptest'
         sasp1.description = TESTDESCRIPTION
-        pp(sasp1.__dict__)
         sasp1.update()
         assert sasp1.description == TESTDESCRIPTION
         sasp1.description = ''

--- a/f5/bigip/tm/ltm/test/functional/test_nat.py
+++ b/f5/bigip/tm/ltm/test/functional/test_nat.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 #
 
-from pprint import pprint as pp
 import pytest
 
 from f5.bigip.resource import MissingRequiredCreationParameter
@@ -188,7 +187,6 @@ class TestCreate(object):
                         translationAddress='192.168.1.1',
                         originatingAddress='192.168.2.1',
                         disabled=False)
-        pp(n1.raw)
         assert 'disabled' not in n1.raw
         assert n1.enabled is True
         n1.enabled = False

--- a/f5/bigip/tm/ltm/test/functional/test_persistence.py
+++ b/f5/bigip/tm/ltm/test/functional/test_persistence.py
@@ -13,9 +13,6 @@
 # limitations under the License.
 #
 
-from pprint import pprint as pp
-pp('')
-
 
 def test_persist_universal_CURDLE(bigip, opt_release):
     u1 = bigip.ltm.persistence.universals.universal.create(

--- a/f5/bigip/tm/ltm/test/functional/test_policy.py
+++ b/f5/bigip/tm/ltm/test/functional/test_policy.py
@@ -17,14 +17,12 @@ import copy
 from distutils.version import LooseVersion
 import json
 import os
-from pprint import pprint as pp
 import pytest
 
 from f5.bigip.resource import MissingRequiredCreationParameter
 from f5.bigip.tm.ltm.policy import NonExtantPolicyRule
 from f5.bigip.tm.ltm.policy import OperationNotSupportedOnPublishedPolicy
 
-pp('')
 TESTDESCRIPTION = "TESTDESCRIPTION"
 CURDIR = os.path.dirname(os.path.realpath(__file__))
 

--- a/f5/bigip/tm/ltm/test/functional/test_pool.py
+++ b/f5/bigip/tm/ltm/test/functional/test_pool.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 #
 
-from pprint import pprint as pp
 import pytest
 
 from requests.exceptions import HTTPError
@@ -127,7 +126,6 @@ class TestPoolMembers(object):
     def test_members_exists(self, request, bigip):
         member1, pool1 = setup_member_test(request, bigip, 'membertestpool1',
                                            'Common')
-        pp(member1.raw)
         assert\
             member1.exists(partition="Common", name="192.168.15.15:80") is True
         assert\

--- a/f5/bigip/tm/ltm/test/functional/test_profile.py
+++ b/f5/bigip/tm/ltm/test/functional/test_profile.py
@@ -13,16 +13,12 @@
 # limitations under the License.
 #
 
-
 import copy
 import pytest
 
 from distutils.version import LooseVersion
 from f5.bigip.mixins import UnsupportedTmosVersion
-from pprint import pprint as pp
 from six import iteritems
-
-pp(__file__)
 
 
 TESTDESCRIPTION = "TESTDESCRIPTION"
@@ -63,7 +59,6 @@ class HelperTest(object):
 
         # Testing update
         profile1.description = TESTDESCRIPTION
-        pp(profile1.raw)
         profile1.update()
         if hasattr(profile1, 'description'):
             assert profile1.description == TESTDESCRIPTION
@@ -665,7 +660,6 @@ class TestOcspStaplingParams(object):
         reason='This collection exists on 11.6.0 or greater.'
     )
     def test_MCURDL_11_6_and_greater(self, request, mgmt_root):
-
         # Setup DNS resolver as prerequisite
         dns = setup_dns_resolver(request, mgmt_root, 'test_resolv')
 
@@ -678,7 +672,6 @@ class TestOcspStaplingParams(object):
             trustedCa='/Common/ca-bundle.crt',
             useProxyServer='disabled')
 
-        pp(ocsp1.raw)
         assert ocsp1.name == 'test.ocsp_stapling_params'
         del ocsphc
 
@@ -705,7 +698,6 @@ class TestOcspStaplingParams(object):
         reason='This collection does not exist on 11.5.4 or less.'
     )
     def test_MCURDL_11_6_and_less(self, request, mgmt_root):
-
         # Setup DNS resolver as prerequisite
         dns = setup_dns_resolver(request, mgmt_root, 'test_resolv')
 

--- a/f5/bigip/tm/ltm/test/functional/test_snat_translation.py
+++ b/f5/bigip/tm/ltm/test/functional/test_snat_translation.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-from pprint import pprint as pp
 
 
 def setup(request, bigip, name, partition, ipaddr):
@@ -53,7 +52,6 @@ class TestSnatTranslation(object):
         assert st1.name == st2.name
 
         #  Update
-        pp(st1.raw)
         st1.disabled = True
         st1.update()
         assert st1.disabled is True

--- a/f5/bigip/tm/ltm/test/functional/test_ssl_profile_creation.py
+++ b/f5/bigip/tm/ltm/test/functional/test_ssl_profile_creation.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 #
 
-from pprint import pprint as pp
 import pytest
 
 from f5.bigip import ManagementRoot
@@ -59,7 +58,6 @@ def cleaner(request, symbols):
     def cleaner():
         sslclientprofiles = mr.tm.ltm.profile.client_ssls.get_collection()
         for sscp in sslclientprofiles:
-            pp(sscp.raw)
             if sscp.fullPath not in initfullpaths:
                 sscp.delete()
     request.addfinalizer(cleaner)
@@ -81,7 +79,6 @@ def test_ssl_profile_creation(cleaner, symbols, tmpdir):
                         port=symbols.bigip_port)
     uploader = mr.shared.file_transfer.uploads
     cert_registrar = mr.tm.sys.crypto.certs
-    pp(cert_registrar.raw)
     key_registrar = mr.tm.sys.crypto.keys
     ssl_client_profile = mr.tm.ltm.profile.client_ssls.client_ssl
     uploader.upload_file(str(certpath))
@@ -91,11 +88,8 @@ def test_ssl_profile_creation(cleaner, symbols, tmpdir):
     cert_set = {'from-local-file': CERTPATH, 'name': 'faketestcert'}
     key_set = {'from-local-file': KEYPATH, 'name': 'faketestkey'}
     cert_registrar.exec_cmd('install', **cert_set)
-    pp([cert.raw for cert in cert_registrar.get_collection()])
     key_registrar.exec_cmd('install', **key_set)
-    pp([key.raw for key in key_registrar.get_collection()])
     chain = [{'name': 'newestcert',
               'cert': '/Common/NEWTESTCLIENTPROFILENAME.crt',
               'key': '/Common/NEWTESTCLIENTPROFILENAME.key'}]
     ssl_client_profile.create(name='test_cert', certKeyChain=chain)
-    pp(ssl_client_profile.raw)

--- a/f5/bigip/tm/ltm/test/functional/test_traffic_class.py
+++ b/f5/bigip/tm/ltm/test/functional/test_traffic_class.py
@@ -14,7 +14,6 @@
 #
 
 import copy
-from pprint import pprint as pp
 from six import iteritems
 
 
@@ -31,7 +30,6 @@ def setup_traffic_test(request, mgmt_root, name, classification):
         delete_resource(tc1)
     request.addfinalizer(teardown)
     tc1 = mgmt_root.tm.ltm.traffic_class_s
-    pp('****')
     traffic1 = tc1.traffic_class.create(name=name,
                                         classification=classification)
     return traffic1, tc1

--- a/f5/bigip/tm/ltm/test/functional/test_virtual.py
+++ b/f5/bigip/tm/ltm/test/functional/test_virtual.py
@@ -16,7 +16,6 @@
 from distutils.version import LooseVersion
 from f5.bigip.resource import MissingRequiredCreationParameter
 from f5.bigip.resource import MissingRequiredReadParameter
-from pprint import pprint as pp
 from six import iteritems
 
 import copy
@@ -84,7 +83,6 @@ def setup_virtual_test(request, mgmt_root, partition, name):
         delete_resource(vc1)
     request.addfinalizer(teardown)
     vc1 = mgmt_root.tm.ltm.virtuals
-    pp('****')
     virtual1 = vc1.virtual.create(name=name, partition=partition)
     return virtual1, vc1
 

--- a/f5/bigip/tm/sys/test/functional/test_dns.py
+++ b/f5/bigip/tm/sys/test/functional/test_dns.py
@@ -13,8 +13,6 @@
 #   limitations under the License.
 #
 
-from pprint import pprint as pp
-
 
 def setup_dns_test(request, bigip):
     def teardown():
@@ -34,11 +32,8 @@ class TestDns(object):
         dns2 = bigip.sys.dns.load()
         assert len(dns1.nameServers) == len(dns2.nameServers)
 
-        pp(dns1.raw)
-        pp(dns2.raw)
         # Update
         dns1.nameServers = [ip]
-        pp(dns2.raw)
         dns1.update()
         assert ip in dns1.nameServers
         assert ip not in dns2.nameServers

--- a/f5/bigip/tm/sys/test/functional/test_failover.py
+++ b/f5/bigip/tm/sys/test/functional/test_failover.py
@@ -16,7 +16,6 @@
 from f5.bigip.resource import BooleansToReduceHaveSameValue
 from f5.multi_device.utils import get_device_info
 from f5.multi_device.utils import pollster
-from pprint import pprint as pp
 
 import pytest
 
@@ -66,14 +65,10 @@ class TestFailover(object):
         fl = f.toggle_standby(trafficgroup="traffic-group-1", state=None)
         assert fl.standby is None
         assert fl.command == u"run"
-        pp(fl.raw)
         fl = f.toggle_standby(trafficgroup="traffic-group-1", state=True)
         assert fl.standby is True
         assert fl.command == u"run"
-        pp('************')
         fl.refresh()
-        pp('after refresh')
-        pp(fl.raw)
         assert 'Failover active' in fl.apiRawValues['apiAnonymous']
 
     def test_toggle_bad_kwargs_standby(self, mgmt_root):
@@ -105,12 +100,10 @@ class TestFailover(object):
         # trying.
         pollster(check_device_state_as_expected)(mgmt_root, 'forced-offline')
         fl.refresh()
-        pp(fl.raw)
         assert 'Failover forced_offline' in fl.apiRawValues['apiAnonymous']
         f.exec_cmd('run', offline=False, online=True)
         pollster(check_device_state_as_expected)(mgmt_root, 'active')
         fl.refresh()
-        pp(fl.raw)
         assert 'Failover active' in fl.apiRawValues['apiAnonymous']
 
     def test_exec_cmd_cmdargs(self, mgmt_root, teardown_device_failover_state):

--- a/f5/bigip/tm/sys/test/functional/test_sshd.py
+++ b/f5/bigip/tm/sys/test/functional/test_sshd.py
@@ -13,7 +13,6 @@
 #   limitations under the License.
 #
 
-from pprint import pprint as pp
 import pytest
 
 V11_SUPPORTED = ['11.5.4', '11.6.0', '11.6.1', '11.6.2']
@@ -51,15 +50,11 @@ class TestSshd11(object):
         assert ssh1.logLevel == ssh2.logLevel
         assert ssh1.login == ssh2.login
 
-        pp(ssh1.raw)
-        pp(ssh2.raw)
-
     def test_update_allow(self, request, bigip):
         ssh1 = setup_sshd_test(request, bigip)
         ssh2 = setup_sshd_test(request, bigip)
 
         ssh1.allow = ['192.168.1.1']
-        pp(ssh2.raw)
         ssh1.update()
         assert ['192.168.1.1'] == ssh1.allow
         assert ['192.168.1.1'] != ssh2.allow
@@ -76,7 +71,6 @@ class TestSshd11(object):
 
         for banner in banners:
             ssh1.banner = banner
-            pp(ssh2.raw)
             ssh1.update()
             assert banner == ssh1.banner
             assert banner != ssh2.banner
@@ -120,7 +114,6 @@ class TestSshd11(object):
 
         for level in levels:
             ssh1.logLevel = level
-            pp(ssh2.raw)
             ssh1.update()
             assert level == ssh1.logLevel
             assert level != ssh2.logLevel
@@ -137,7 +130,6 @@ class TestSshd11(object):
 
         for login in logins:
             ssh1.login = login
-            pp(ssh2.raw)
             ssh1.update()
             assert login == ssh1.login
             assert login != ssh2.login
@@ -160,9 +152,6 @@ class TestSshd12(object):
         assert ssh1.logLevel == ssh2.logLevel
         assert ssh1.login == ssh2.login
         assert ssh1.port == ssh2.port
-
-        pp(ssh1.raw)
-        pp(ssh2.raw)
 
     def test_update_allow(self, request, bigip):
         ssh1 = setup_sshd_test(request, bigip)

--- a/f5/utils/testutils/registrytools.py
+++ b/f5/utils/testutils/registrytools.py
@@ -14,7 +14,6 @@
 #
 
 import logging
-from pprint import pprint as pp
 from six import itervalues
 
 from f5.bigip.mixins import UnsupportedTmosVersion
@@ -39,7 +38,6 @@ def register_collection_atoms(collection):
             try:
                 resource_registry[resource.selfLink] = resource
             except KeyError as ex:
-                pp(resource.raw)
                 raise ex
             except UnsupportedTmosVersion as ex:
                 logging.debug(ex)


### PR DESCRIPTION
Issues:
Fixes #816

Problem:
Test code has a bunch of print statements that are not needed

Analysis:
This patch cleans up those statements

Tests:
functional