### PR TITLE
Adds python 2.6 and bigip 12.1.2 to tox file

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -14,12 +14,13 @@ basepython =
 deps =
     -rrequirements.test.txt
 commands =
-    py{27,35}-v11.5.1: py.test --bigip localhost --port 10443 -s -vv --release 11.5.1 {posargs}
-    py{27,35}-v11.6.0: py.test --bigip localhost --port 10443 -s -vv --release 11.6.0 {posargs}
-    py{27,35}-v11.6.1: py.test --bigip localhost --port 10443 -s -vv --release 11.6.1 {posargs}
-    py{27,35}-v12.0.0: py.test --bigip localhost --port 10443 -s -vv --release 12.0.0 {posargs}
-    py{27,35}-v12.1.0: py.test --bigip localhost --port 10443 -s -vv --release 12.1.0 {posargs}
-    py{27,35}-v12.1.1: py.test --bigip localhost --port 10443 -s -vv --release 12.1.1 {posargs}
+    py{26,27,35}-v11.5.1: py.test --bigip localhost --port 10443 -s -vv --release 11.5.1 {posargs}
+    py{26,27,35}-v11.6.0: py.test --bigip localhost --port 10443 -s -vv --release 11.6.0 {posargs}
+    py{26,27,35}-v11.6.1: py.test --bigip localhost --port 10443 -s -vv --release 11.6.1 {posargs}
+    py{26,27,35}-v12.0.0: py.test --bigip localhost --port 10443 -s -vv --release 12.0.0 {posargs}
+    py{26,27,35}-v12.1.0: py.test --bigip localhost --port 10443 -s -vv --release 12.1.0 {posargs}
+    py{26,27,35}-v12.1.1: py.test --bigip localhost --port 10443 -s -vv --release 12.1.1 {posargs}
+    py{26,27,35}-v12.1.2: py.test --bigip localhost --port 10443 -s -vv --release 12.1.2 {posargs}
     unit: py.test -k "not /functional/" -vv --cov {posargs}
     flake: flake8
 


### PR DESCRIPTION
Issues:
Fixes #825

Problem:
python 2.6 and bigip 12.1.2 are not available in the tox file

Analysis:
this patch adds support for both of these

Tests: