### PR TITLE
LTM policy needs to be capable of update and modify with 12.1.0 with legacy

### DIFF
--- a/f5/bigip/tm/ltm/policy.py
+++ b/f5/bigip/tm/ltm/policy.py
@@ -101,9 +101,11 @@ class Policy(Resource):
         :raises: OperationNotSupportedOnPublishedPolicy
         '''
 
+        legacy = patch.pop('legacy', False)
         tmos_ver = self._meta_data['bigip']._meta_data['tmos_version']
         if 'Drafts' not in self._meta_data['uri'] and \
-                LooseVersion(tmos_ver) >= LooseVersion('12.1.0'):
+                LooseVersion(tmos_ver) >= LooseVersion('12.1.0') and \
+                not legacy:
             msg = 'Modify operation not allowed on a published policy.'
             raise OperationNotSupportedOnPublishedPolicy(msg)
         super(Policy, self)._modify(**patch)
@@ -115,9 +117,11 @@ class Policy(Resource):
         :raises: OperationNotSupportedOnPublishedPolicy
         '''
 
+        legacy = kwargs.pop('legacy', False)
         tmos_ver = self._meta_data['bigip']._meta_data['tmos_version']
         if 'Drafts' not in self._meta_data['uri'] and \
-                LooseVersion(tmos_ver) >= LooseVersion('12.1.0'):
+                LooseVersion(tmos_ver) >= LooseVersion('12.1.0') and \
+                not legacy:
             msg = 'Update operation not allowed on a published policy.'
             raise OperationNotSupportedOnPublishedPolicy(msg)
         super(Policy, self)._update(**kwargs)

--- a/f5/bigip/tm/ltm/test/functional/test_policy.py
+++ b/f5/bigip/tm/ltm/test/functional/test_policy.py
@@ -334,6 +334,12 @@ class TestPolicy(object):
         pol1, pc1 = setup_policy_test(request, mgmt_root, 'Common',
                                       'poltest1', legacy=True)
         pol1.update(legacy=True, rules=[])
-        pol1.update(legacy=False, rules=[])
         pol1.modify(legacy=True, rules=[])
-        pol1.modify(legacy=False, rules=[])
+        with pytest.raises(OperationNotSupportedOnPublishedPolicy) as ex1:
+            pol1.update(legacy=False, rules=[])
+        assert 'Update operation not allowed on a published policy.' in \
+            ex1.value.message
+        with pytest.raises(OperationNotSupportedOnPublishedPolicy) as ex2:
+            pol1.modify(legacy=False, rules=[])
+        assert 'Modify operation not allowed on a published policy.' in \
+            ex2.value.message

--- a/f5/bigip/tm/ltm/test/functional/test_policy.py
+++ b/f5/bigip/tm/ltm/test/functional/test_policy.py
@@ -131,6 +131,14 @@ class TestPolicy_legacy(object):
                                       'poltest1', legacy=False)
         assert pol1.name == 'poltest1'
 
+    def test_policy_update_modify_update(self, setup, request, mgmt_root):
+        pol1, pc1 = setup_policy_test(request, mgmt_root, 'Common',
+                                      'poltest1', legacy=True)
+        pol1.update(legacy=True, rules=[])
+        pol1.update(legacy=False, rules=[])
+        pol1.modify(legacy=True, rules=[])
+        pol1.modify(legacy=False, rules=[])
+
     def test_policy_update_race(self, setup, request, mgmt_root):
         full_pol_dict = json.load(
             open(os.path.join(CURDIR, 'full_policy.json')))
@@ -321,3 +329,11 @@ class TestPolicy(object):
         pol, pc = setup_policy_test(request, mgmt_root, 'Common', 'racetest',
                                     subPath='Drafts')
         assert pol.rules_s.rules.exists(name='bad_rule') is False
+
+    def test_policy_update_modify_update(self, setup, request, mgmt_root):
+        pol1, pc1 = setup_policy_test(request, mgmt_root, 'Common',
+                                      'poltest1', legacy=True)
+        pol1.update(legacy=True, rules=[])
+        pol1.update(legacy=False, rules=[])
+        pol1.modify(legacy=True, rules=[])
+        pol1.modify(legacy=False, rules=[])


### PR DESCRIPTION
@jlongstaf 

Issues:
Fixes #829

Problem:
There is a legacy key for deploying and modifying policies in 12.1.0.
When set to True, this deploys or modifies a policy as if it were one on
tmos versions prior to 12.1.0. We need to change the modify and update
operations to expect legacy as a keyword argument and allow the user to
update as they see fit.

Analysis:
Made changes to modify and update to allow legacy to be passed in and
used for changes against a 12.1.0 machine. If legacy is passed in and
the tmos version is < 12.1.0, it is simply ignored.

Tests:
All tests against 12.1.0 and 11.6.0 for policies pass