### PR TITLE
DeviceProvidesIncompatibleKey exception when 'not' is given as object attribute

### DIFF
--- a/f5/bigip/resource.py
+++ b/f5/bigip/resource.py
@@ -88,6 +88,7 @@ Available Classes:
       and supports a customized 'load' that doesn't require name/partition
       parameters.
 """
+import copy
 import keyword
 import re
 import tokenize
@@ -392,6 +393,7 @@ class ResourceBase(PathElement, ToDictMixin):
                 % read_only_mutations
             raise AttemptedMutationOfReadOnly(msg)
 
+        patch = self._check_for_python_keywords(patch)
         response = session.patch(patch_uri, json=patch, **requests_params)
         self._local_update(response.json())
 
@@ -419,14 +421,43 @@ class ResourceBase(PathElement, ToDictMixin):
         read_only = self._meta_data.get('read_only_attributes', [])
         return requests_params, update_uri, session, read_only
 
+    def _iter_list_for_dicts(self, check_list):
+        '''Iterate over list to find dicts and check for python keywords.'''
+
+        list_copy = copy.deepcopy(check_list)
+        for index, elem in enumerate(check_list):
+            if isinstance(elem, dict):
+                list_copy[index] = self._check_for_python_keywords(elem)
+            elif isinstance(elem, list):
+                list_copy[index] = self._iter_list_for_dicts(elem)
+            else:
+                list_copy[index] = elem
+        return list_copy
+
+    def _check_for_python_keywords(self, kwargs):
+        '''When Python keywords seen, mutate to remove trailing underscore.'''
+
+        kwargs_copy = copy.deepcopy(kwargs)
+        for key, val in kwargs.iteritems():
+            if isinstance(val, dict):
+                kwargs_copy[key] = self._check_for_python_keywords(val)
+            elif isinstance(val, list):
+                kwargs_copy[key] = self._iter_list_for_dicts(val)
+            else:
+                if key.endswith('_'):
+                    strip_key = key.rstrip('_')
+                    if keyword.iskeyword(strip_key):
+                        kwargs_copy[strip_key] = val
+                        kwargs_copy.pop(key)
+        return kwargs_copy
+
     def _check_keys(self, rdict):
         """Call this from _local_update to validate response keys
 
         disallowed server-response json keys:
         1. The string-literal '_meta_data'
         2. strings that are not valid Python 2.7 identifiers
-        3. strings that are Python keywords
-        4. strings beginning with '__'.
+        3. strings beginning with '__'.
 
         :param rdict: from response.json()
         :raises: DeviceProvidesIncompatibleKey
@@ -442,9 +473,9 @@ class ResourceBase(PathElement, ToDictMixin):
                     " because it's not a valid Python 2.7 identifier." % x
                 raise DeviceProvidesIncompatibleKey(error_message)
             elif keyword.iskeyword(x):
-                error_message = "Device provided %r which is disallowed"\
-                    " because it's a Python keyword." % x
-                raise DeviceProvidesIncompatibleKey(error_message)
+                # If attribute is keyword, append underscore to attribute name
+                rdict[x + '_'] = rdict[x]
+                rdict.pop(x)
             elif x.startswith('__'):
                 error_message = "Device provided %r which is disallowed"\
                     ", it mangles into a Python non-public attribute." % x
@@ -508,6 +539,7 @@ class ResourceBase(PathElement, ToDictMixin):
             data_dict.pop(attr, '')
 
         data_dict.update(kwargs)
+        data_dict = self._check_for_python_keywords(data_dict)
 
         # This is necessary as when we receive exception the returned object
         # has its _meta_data stripped.
@@ -843,6 +875,7 @@ class Resource(ResourceBase):
         _create_uri = self._meta_data['container']._meta_data['uri']
         session = self._meta_data['bigip']._meta_data['icr_session']
 
+        kwargs = self._check_for_python_keywords(kwargs)
         # Invoke the REST operation on the device.
         response = session.post(_create_uri, json=kwargs, **requests_params)
 
@@ -907,6 +940,7 @@ class Resource(ResourceBase):
         kwargs.update(requests_params)
         for key1, key2 in self._meta_data['reduction_forcing_pairs']:
             kwargs = self._reduce_boolean_pair(kwargs, key1, key2)
+        kwargs = self._check_for_python_keywords(kwargs)
         response = refresh_session.get(base_uri, **kwargs)
         # Make new instance of self
         return self._produce_instance(response)
@@ -988,6 +1022,8 @@ class Resource(ResourceBase):
         session = self._meta_data['bigip']._meta_data['icr_session']
         base_uri = self._meta_data['container']._meta_data['uri']
         kwargs.update(requests_params)
+        kwargs = self._check_for_python_keywords(kwargs)
+
         try:
             session.get(base_uri, **kwargs)
         except HTTPError as err:

--- a/f5/bigip/test/unit/test_resource.py
+++ b/f5/bigip/test/unit/test_resource.py
@@ -12,6 +12,10 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 #
+try:
+        from collections import OrderedDict
+except ImportError:
+        from ordereddict import OrderedDict
 import mock
 import pytest
 import requests
@@ -172,11 +176,19 @@ def test_Resource__check_for_python_keywords_recursive():
     checked = r._check_for_python_keywords(
         {'for_': 1, 'test': {'if_': False},
          't': [{'not_': False}, [{'def_': 1}]]})
-    print(checked)
     assert 'for' in checked
     assert 'if' in checked['test']
     assert 'not' in checked['t'][0]
     assert 'def' in checked['t'][1][0]
+
+
+def test_Resource__prepare_request_json():
+    r = Resource(mock.MagicMock(name='test'))
+    kwargs = {'name': 'rule1', 'partition': 'Common',
+              'apiAnonymous': 'test', 'check': 'syntax'}
+    prepped = r._prepare_request_json(kwargs)
+    assert prepped == kwargs
+    assert isinstance(prepped, OrderedDict)
 
 
 def test_Resource__local_update(fake_vs):

--- a/f5/bigip/tm/gtm/test/functional/test_rule.py
+++ b/f5/bigip/tm/gtm/test/functional/test_rule.py
@@ -96,6 +96,22 @@ class TestCreate(object):
         )
         assert 'check syntax' in rule1.apiAnonymous
 
+    def test_create_optional_args_bad_order(self, request, mgmt_root):
+        '''The device requires the check key to be before apiAnonymous.
+
+        Apparently order matters against the device when it comes to
+        the check key value and the apiAnonymous key value in the JSON blob.
+        This test is to ensure we at least try for a different ordering.
+        '''
+
+        setup_create_test(request, mgmt_root, 'rule1', 'Common')
+
+        rule1 = mgmt_root.tm.gtm.rules.rule.create(
+            name='rule1', check='syntax', partition='Common',
+            apiAnonymous=RULE
+        )
+        assert 'check syntax' in rule1.apiAnonymous
+
     def test_create_duplicate(self, request, mgmt_root):
         setup_create_test(request, mgmt_root, 'rule1', 'Common')
         rule1 = mgmt_root.tm.gtm.rules.rule

--- a/f5/bigip/tm/ltm/test/functional/full_policy.json
+++ b/f5/bigip/tm/ltm/test/functional/full_policy.json
@@ -41,6 +41,7 @@
                     "external": true,
                     "httpHeader": true,
                     "index": 0,
+                    "not_": true,
                     "tmName": "X-HEADER",
                     "present": true,
                     "remote": true,

--- a/f5/bigip/tm/ltm/test/functional/test_policy.py
+++ b/f5/bigip/tm/ltm/test/functional/test_policy.py
@@ -398,9 +398,17 @@ def test_policy_condition_python_keyword_get_collection(
     rule = pol.rules_s.rules.load(name='test_rule')
     cond = rule.conditions_s.conditions.load(name='0')
     assert cond.not_ is True
-    rules = pol.rules_s.get_collection()
-    for r in rules:
-        if r.name == '0':
-            assert r.not_ is True
+    conds = rule.conditions_s.get_collection()
+    for cond in conds:
+        if cond.name == '0':
+            assert cond.not_ is True
         else:
-            assert not hasattr(r, 'not_')
+            assert not hasattr(cond, 'not_')
+    # Let's modify one of the conditions that doesn't have not as True
+    c2 = rule.conditions_s.conditions.load(name='1')
+    assert not hasattr(c2, 'not_')
+    c2.modify(not_=True)
+    c2.refresh()
+    assert c2.not_ is True
+    backup_c2 = rule.conditions_s.conditions.load(name='1')
+    assert backup_c2.not_ is True

--- a/f5/bigip/tm/ltm/test/functional/test_policy.py
+++ b/f5/bigip/tm/ltm/test/functional/test_policy.py
@@ -343,3 +343,64 @@ class TestPolicy(object):
             pol1.modify(legacy=False, rules=[])
         assert 'Modify operation not allowed on a published policy.' in \
             ex2.value.message
+
+
+@pytest.mark.skipif(
+    LooseVersion(
+        pytest.config.getoption('--release')
+    ) <= LooseVersion('12.1.1'),
+    reason='Bug exists where not attr is not honored from request.'
+)
+def test_policy_condition_python_keyword(setup, request, mgmt_root):
+    full_pol_dict = json.load(
+        open(os.path.join(CURDIR, 'full_policy.json')))
+    empty_pol_dict = copy.deepcopy(full_pol_dict)
+    empty_pol_dict['rules'] = []
+    pol, pc = setup_policy_test(request, mgmt_root, 'Common', 'racetest')
+    # Start out with an empty policy (no rules)
+    pol.refresh()
+    assert pol.rules_s.rules.exists(name='test_rule') is False
+    assert list(pol.rules_s.get_collection()) == []
+    # Update policy to have rules, which have conditions and actions
+    pol.update(**full_pol_dict)
+    rule = pol.rules_s.rules.load(name='test_rule')
+    cond = rule.conditions_s.conditions.load(name='0')
+    assert cond.not_ is True
+    # The following operation does not make any change to the
+    # specified rule. This has been verified on 11.6.0, 11.6.1, and 12.1.1
+    # This test will be skipped since this bug still exists on those
+    # versions
+    cond.not_ = False
+    cond.update()
+    # When not is False, it is not included in response from device
+    assert hasattr(cond, 'not_') is False
+    cond.modify(not_=True)
+    assert cond.not_ is True
+
+
+def test_policy_condition_python_keyword_get_collection(
+        setup, request, mgmt_root):
+    full_pol_dict = json.load(
+        open(os.path.join(CURDIR, 'full_policy.json')))
+    empty_pol_dict = copy.deepcopy(full_pol_dict)
+    empty_pol_dict['rules'] = []
+    # Because of the legacy keyword, this will work on all supported versions
+    # If it is present on a version that does not support legacy, the keyword
+    # will be evicted from the request.
+    pol, pc = setup_policy_test(
+        request, mgmt_root, 'Common', 'racetest', legacy=True)
+    # Start out with an empty policy (no rules)
+    pol.refresh()
+    assert pol.rules_s.rules.exists(name='test_rule') is False
+    assert list(pol.rules_s.get_collection()) == []
+    # Update policy to have rules, which have conditions and actions
+    pol.update(legacy=True, **full_pol_dict)
+    rule = pol.rules_s.rules.load(name='test_rule')
+    cond = rule.conditions_s.conditions.load(name='0')
+    assert cond.not_ is True
+    rules = pol.rules_s.get_collection()
+    for r in rules:
+        if r.name == '0':
+            assert r.not_ is True
+        else:
+            assert not hasattr(r, 'not_')

--- a/f5/bigip/tm/ltm/test/functional/test_virtual.py
+++ b/f5/bigip/tm/ltm/test/functional/test_virtual.py
@@ -168,6 +168,8 @@ def test_policies(policy_setup, virtual_setup, setup_device_snapshot):
     vs_pol = v1.policies_s.policies.create(name='pol', partition='Common')
     loaded_pol = v1.policies_s.policies.load(name='pol', partition='Common')
     assert vs_pol.name == pol.name == loaded_pol.name
+    pc = list(v1.policies_s.get_collection())
+    assert len(pc) == 1
     vs_pol.delete()
     v1.refresh()
     # Bump to check the below call

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ setup(
     author_email='f5_common_python@f5.com',
     url='https://github.com/F5Networks/f5-common-python',
     keywords=['F5', 'sdk', 'api', 'icontrol', 'bigip', 'api', 'ltm'],
-    install_requires=['f5-icontrol-rest == 1.1.0', 'six'],
+    install_requires=['f5-icontrol-rest == 1.1.0', 'ordereddict', 'six'],
     packages=find_packages(
         exclude=["*.test", "*.test.*", "test.*", "test_*", "test", "test*"]
     ),


### PR DESCRIPTION
@caphrim007 @jlongstaf 

Fixes: Issue #835 

#### Any background context?
For LTM Conditions, 'not' is a valid JSON field, and this is a valid
Python keyword. We can get around it (which is what we are doing
currently) by doing a setattr and getattr, but this is not sustainable.
We must brainstorm a few ideas to convert such things that can be
accessible via Python dotted attribute access. (condition._not or
condition.invert).

#### What's this change do?
Implemented a helper function where python keywords are appended with a
trailing underscore. This change takes care of the outgoing request and
the reverse translation on the response. Implemented a few new tests, but unconvered a new bug #836, which highlights an issue on the device around setting the 'not' attribute.

#### Where should the reviewer start?
This is a fix needed for running tests for L7 Content Switching in the OpenStack agent and driver.