### PR TITLE
Corrects tox targets

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist =
-    py{26,35}-v{11.5.1,11.6.0,11.6.1,12.0.0,12.1.0,12.1.1}
+    py{26,27,35}-v{11.5.4,11.6.0,11.6.1,12.0.0,12.1.0,12.1.1}
     unit
     flake
 
@@ -14,7 +14,7 @@ basepython =
 deps =
     -rrequirements.test.txt
 commands =
-    py{26,27,35}-v11.5.1: py.test --bigip localhost --port 10443 -s -vv --release 11.5.1 {posargs}
+    py{26,27,35}-v11.5.4: py.test --bigip localhost --port 10443 -s -vv --release 11.5.4 {posargs}
     py{26,27,35}-v11.6.0: py.test --bigip localhost --port 10443 -s -vv --release 11.6.0 {posargs}
     py{26,27,35}-v11.6.1: py.test --bigip localhost --port 10443 -s -vv --release 11.6.1 {posargs}
     py{26,27,35}-v12.0.0: py.test --bigip localhost --port 10443 -s -vv --release 12.0.0 {posargs}


### PR DESCRIPTION
Issues:
Fixes #838

Problem:
The tox targets did not include python 2.7 and included a version of
BIG-IP that did not xist (11.5.1)

Analysis:
This patch correct the bigip version and adds python 2.7 support

Tests: