### PR TITLE
make common fixtures into pytest plugin

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,16 +14,13 @@ before_install:
   - git config --global user.name "Travis F5 Openstack"
   - git fetch --depth=100
 install:
-  - pip install hacking pytest pytest-cov tox
+  - pip install tox
   - pip install -r requirements.test.txt
   - pip install -r requirements.docs.txt
 script:
   - tox -e flake
   - tox -e unit
   - python setup.py sdist
-  - cd docs
-  - make html
-  - cd ../
   - ${DIST_REPO}/scripts/package.sh "redhat" "7"
   - ${DIST_REPO}/scripts/package.sh "ubuntu" "14.04"
   - sudo chown -R travis:travis ${DIST_REPO}/rpms/build

--- a/conftest.py
+++ b/conftest.py
@@ -13,8 +13,6 @@
 # limitations under the License.
 #
 
-from f5.bigip import BigIP
-from f5.bigip import ManagementRoot
 from f5.bigip.resource import UnsupportedOperation
 from f5.utils.testutils.registrytools import register_device
 from icontrol.session import iControlRESTSession
@@ -139,30 +137,6 @@ def opt_vcmp_host(request):
 
 
 @pytest.fixture(scope='session')
-def bigip(opt_bigip, opt_username, opt_password, opt_port, scope="module"):
-    '''bigip fixture'''
-    b = BigIP(opt_bigip, opt_username, opt_password, port=opt_port)
-    return b
-
-
-@pytest.fixture(scope='module')
-def mgmt_root(opt_bigip, opt_username, opt_password, opt_port, opt_token,
-              scope="module"):
-    '''bigip fixture'''
-    m = ManagementRoot(opt_bigip, opt_username, opt_password, port=opt_port,
-                       token=opt_token)
-    return m
-
-
-@pytest.fixture(scope='module')
-def vcmp_host(opt_vcmp_host, opt_username, opt_password, opt_port):
-    '''vcmp fixture'''
-    m = ManagementRoot(
-        opt_vcmp_host, opt_username, opt_password, port=opt_port)
-    return m
-
-
-@pytest.fixture(scope='session')
 def opt_release(request):
     return request.config.getoption("--release")
 
@@ -170,13 +144,6 @@ def opt_release(request):
 @pytest.fixture
 def opt_peer(request):
     return request.config.getoption("--peer")
-
-
-@pytest.fixture
-def peer(opt_peer, opt_username, opt_password, scope="module"):
-    '''peer bigip fixture'''
-    p = BigIP(opt_peer, opt_username, opt_password)
-    return p
 
 
 @pytest.fixture

--- a/f5/bigip/tm/net/test/functional/test_interface.py
+++ b/f5/bigip/tm/net/test/functional/test_interface.py
@@ -31,9 +31,11 @@ class TestInterfaces(object):
             assert ifc.generation
 
 
-@pytest.skip('A known issue with generation number.'
-             'See: https://github.com/F5Networks/f5-common-python/issues/334')
 class TestInterface(object):
+    @pytest.mark.skip(
+        'A known issue with generation number. '
+        'See: https://github.com/F5Networks/f5-common-python/issues/334'
+    )
     def test_RUL(self, request, bigip):
         cleanup_test(request, bigip)
         # We can't create or delete interfaces so we will load them to start

--- a/pytest_plugins/fixtures.py
+++ b/pytest_plugins/fixtures.py
@@ -1,0 +1,49 @@
+# Copyright 2015-2016 F5 Networks Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+import pytest
+
+from f5.bigip import BigIP
+from f5.bigip import ManagementRoot
+
+
+@pytest.fixture(scope='session')
+def bigip(opt_bigip, opt_username, opt_password, opt_port, scope="module"):
+    '''bigip fixture'''
+    b = BigIP(opt_bigip, opt_username, opt_password, port=opt_port)
+    return b
+
+
+@pytest.fixture(scope='module')
+def mgmt_root(opt_bigip, opt_username, opt_password, opt_port, opt_token,
+              scope="module"):
+    '''bigip fixture'''
+    m = ManagementRoot(opt_bigip, opt_username, opt_password, port=opt_port,
+                       token=opt_token)
+    return m
+
+
+@pytest.fixture(scope='module')
+def vcmp_host(opt_vcmp_host, opt_username, opt_password, opt_port):
+    '''vcmp fixture'''
+    m = ManagementRoot(
+        opt_vcmp_host, opt_username, opt_password, port=opt_port)
+    return m
+
+
+@pytest.fixture
+def peer(opt_peer, opt_username, opt_password, scope="module"):
+    '''peer bigip fixture'''
+    p = BigIP(opt_peer, opt_username, opt_password)
+    return p

--- a/requirements.test.txt
+++ b/requirements.test.txt
@@ -2,15 +2,11 @@
 -e .
 
 # Test Requirements
-flake8==2.6.2
-pep8==1.7.0
-pyflakes==1.3.0
-mccabe==0.5.2
-mock==1.3.0
-pytest==2.9.1
+hacking==0.13.0
+mock==2.0.0
+pytest==3.0.5
 pytest-cov>=2.2.1
 git+https://github.com/F5Networks/pytest-symbols.git
 python-coveralls==2.7.0
 pyOpenSSL==16.0.0
-ordereddict
-requests-mock==1.1.0
+requests-mock==1.2.0

--- a/setup.py
+++ b/setup.py
@@ -40,5 +40,6 @@ setup(
         'Operating System :: OS Independent',
         'Programming Language :: Python',
         'Intended Audience :: System Administrators',
-    ]
+    ],
+    entry_points={'pytest11': ['f5sdk_fixtures = pytest_plugins.fixtures']}
 )

--- a/tox.ini
+++ b/tox.ini
@@ -26,11 +26,4 @@ commands =
 
 [flake8]
 ignore = E226,W503,E123
-exclude =
-    .tox,
-    .git,
-    __pycache__,
-    build,
-    *.pyc,
-    docs,
-    devtools
+exclude = docs/conf.py,docs/userguide/code_example.py,docs/conf.py,.tox,.git,__pycache__,build,*.pyc,docs,devtools


### PR DESCRIPTION
Author: Za Wilgustus <za@f5.com>
Date:   Thu Dec 15 20:15:32 2016 +0000

    migrate common fixtures into pytest_plugins

    Issues:
    Fixes #845

    Problem: Accessing useful fixtures in other Python
    applications/libraries was too difficult.

    Analysis: This commit makes generally useful fixtures
    accessible to pytest via the standard pytest11 entry_point
    as a plugin.

    Tests: There are no new test failures in my local environment.
