### PR TITLE
Fixes the required creation parameters for the cm_cloud_managed_devic…

### DIFF
--- a/f5/iworkflow/shared/resolver/device_groups/cm_cloud_managed_devices.py
+++ b/f5/iworkflow/shared/resolver/device_groups/cm_cloud_managed_devices.py
@@ -57,6 +57,6 @@ class Device(Resource):
         self._meta_data['required_json_kind'] = \
             'shared:resolver:device-groups:restdeviceresolverdevicestate'
         self._meta_data['required_creation_parameters'] = set(
-            ('address', 'password', 'rootPassword')
+            ('address', 'password', 'userName')
         )
         self._meta_data['required_load_parameters'] = set(('uuid',))


### PR DESCRIPTION
…es api

Problem:
The api was too strict. it required parameters to be set that are not required
by iworkflow

Analysis:
This patch loosens the restrictions

Tests: