### PR TITLE
Incrementing required f5-icontrol-rest version from 1.1.0 -> 1.2.0.

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,3 +1,3 @@
 [bdist_rpm]
 release = 1
-requires = f5-icontrol-rest == 1.1.0
+requires = f5-icontrol-rest == 1.2.0

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ setup(
     author_email='f5_common_python@f5.com',
     url='https://github.com/F5Networks/f5-common-python',
     keywords=['F5', 'sdk', 'api', 'icontrol', 'bigip', 'api', 'ltm'],
-    install_requires=['f5-icontrol-rest == 1.1.0', 'ordereddict', 'six'],
+    install_requires=['f5-icontrol-rest == 1.2.0', 'ordereddict', 'six'],
     packages=find_packages(
         exclude=["*.test", "*.test.*", "test.*", "test_*", "test", "test*"]
     ),


### PR DESCRIPTION
Only change: version increment in setup.cfg