### PR TITLE
Updating stdeb.cfg to reflect f5-icontrol-rest 1.2.0 requirement

### DIFF
--- a/f5-sdk-dist/deb_dist/stdeb.cfg
+++ b/f5-sdk-dist/deb_dist/stdeb.cfg
@@ -1,3 +1,3 @@
 [DEFAULT]
 Depends:
-	python-f5-icontrol-rest (=1.1.0-1)
+	python-f5-icontrol-rest (=1.2.0-1)


### PR DESCRIPTION
missed this in the previous merge