### PR TITLE
Issue #869 - 2.x std iteritems impacting some resources in 3.x usage

### DIFF
--- a/f5/bigip/resource.py
+++ b/f5/bigip/resource.py
@@ -456,7 +456,7 @@ class ResourceBase(PathElement, ToDictMixin):
         '''When Python keywords seen, mutate to remove trailing underscore.'''
 
         kwargs_copy = copy.deepcopy(kwargs)
-        for key, val in kwargs.iteritems():
+        for key, val in iteritems(kwargs):
             if isinstance(val, dict):
                 kwargs_copy[key] = self._check_for_python_keywords(val)
             elif isinstance(val, list):


### PR DESCRIPTION
Updated files
 - f5/bigip/resource.py

 Change
  - updated kwargs.iteritems to iteritems(kwargs) so the imported function from six would be referenced instead of the (missing in 3.x) method on kwargs.