### PR TITLE
Adds GTM Topology Endpoint

### DIFF
--- a/f5/bigip/resource.py
+++ b/f5/bigip/resource.py
@@ -175,6 +175,11 @@ class InvalidForceType(ValueError):
     pass
 
 
+class InvalidName(ValueError):
+    """Raised during creationm when a given resource name is invalid"""
+    pass
+
+
 class URICreationCollision(F5SDKError):
     """self._meta_data['uri'] can only be assigned once. In create or load."""
     pass
@@ -663,13 +668,13 @@ class ResourceBase(PathElement, ToDictMixin):
         return new_instance
 
     def _reduce_boolean_pair(self, config_dict, key1, key2):
-        '''Ensure only one key with a boolean value is present in dict.
+        """Ensure only one key with a boolean value is present in dict.
 
         :param config_dict: dict -- dictionary of config or kwargs
         :param key1: string -- first key name
         :param key2: string -- second key name
         :raises: BooleansToReduceHaveSameValue
-        '''
+        """
 
         if key1 in config_dict and key2 in config_dict \
                 and config_dict[key1] == config_dict[key2]:
@@ -1064,19 +1069,19 @@ class UnnamedResource(ResourceBase):
     """
 
     def create(self, **kwargs):
-        '''Create is not supported for unnamed resources
+        """Create is not supported for unnamed resources
 
         :raises: UnsupportedOperation
-        '''
+        """
         raise UnsupportedMethod(
             "%s does not support the create method" % self.__class__.__name__
         )
 
     def delete(self, **kwargs):
-        '''Delete is not supported for unnamed resources
+        """Delete is not supported for unnamed resources
 
         :raises: UnsupportedOperation
-        '''
+        """
         raise UnsupportedMethod(
             "%s does not support the delete method" % self.__class__.__name__
         )
@@ -1088,13 +1093,13 @@ class UnnamedResource(ResourceBase):
 
 
 class Stats(UnnamedResource):
-    '''For stats resources.'''
+    """For stats resources."""
 
     def modify(self, **kwargs):
-        '''Modify is not supported for unnamed resources
+        """Modify is not supported for unnamed resources
 
         :raises: UnsupportedOperation
-        '''
+        """
         raise UnsupportedMethod(
             "%s does not support the modify method" % self.__class__.__name__
         )

--- a/f5/bigip/tm/gtm/__init__.py
+++ b/f5/bigip/tm/gtm/__init__.py
@@ -33,6 +33,7 @@ from f5.bigip.tm.gtm.datacenter import Datacenters
 from f5.bigip.tm.gtm.pool import Pools
 from f5.bigip.tm.gtm.rule import Rules
 from f5.bigip.tm.gtm.server import Servers
+from f5.bigip.tm.gtm.topology import Topology_s
 from f5.bigip.tm.gtm.wideip import Wideips
 
 
@@ -45,5 +46,6 @@ class Gtm(OrganizingCollection):
             Pools,
             Rules,
             Servers,
+            Topology_s,
             Wideips,
         ]

--- a/f5/bigip/tm/gtm/test/functional/test_topology.py
+++ b/f5/bigip/tm/gtm/test/functional/test_topology.py
@@ -1,0 +1,290 @@
+# Copyright 2015 F5 Networks Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+
+import pytest
+
+from distutils.version import LooseVersion
+from f5.bigip.mixins import UnsupportedTmosVersion
+from f5.bigip.resource import InvalidName
+from f5.bigip.resource import MissingRequiredCreationParameter
+from f5.bigip.resource import UnsupportedOperation
+from f5.bigip.tm.gtm.topology import Topology
+from pytest import symbols
+from requests.exceptions import HTTPError
+
+pytestmark = pytest.mark.skipif(
+    symbols
+    and hasattr(symbols, 'modules')
+    and not symbols.modules['gtm'],
+    reason='The modules symbol for GTM is set to False.'
+)
+
+MSG = "Topology record name should contain both 'ldns', 'server' keywords " \
+      "with their proper arguments"
+NAME = 'ldns: subnet 192.168.100.0/24 server: subnet 192.168.200.0/24'
+NAME_SPACES = ' ldns: subnet 192.168.100.0/24  server: subnet 192.168.200.0/24'
+
+
+def delete_topology(mgmt_root, name):
+    try:
+        foo = mgmt_root.tm.gtm.topology_s.topology.load(
+            name=name)
+    except HTTPError as err:
+        if err.response.status_code != 404:
+            raise
+        return
+    foo.delete()
+
+
+def setup_create_test(request, mgmt_root, name):
+    def teardown():
+        delete_topology(mgmt_root, name)
+    request.addfinalizer(teardown)
+
+
+def setup_basic_test(request, mgmt_root, name):
+    def teardown():
+        delete_topology(mgmt_root, name)
+
+    top1 = mgmt_root.tm.gtm.topology_s.topology.create(
+        name=name)
+    request.addfinalizer(teardown)
+    return top1
+
+
+@pytest.mark.skipif(LooseVersion(pytest.config.getoption('--release')) <
+                    '12.1.0' or
+                    LooseVersion(pytest.config.getoption('--release')) ==
+                    '12.0.0', reason='Needs > v12.1.0 TMOS to pass')
+class TestCreate(object):
+    def test_create_no_args(self, mgmt_root):
+        with pytest.raises(MissingRequiredCreationParameter):
+            mgmt_root.tm.gtm.topology_s.topology.create()
+
+    def test_invalid_name_raises(self, mgmt_root):
+        with pytest.raises(InvalidName) as err:
+            mgmt_root.tm.gtm.topology_s.topology.create(name='fake_wrong')
+        assert err.value.message == MSG
+
+    def test_create(self, request, mgmt_root):
+        setup_create_test(request, mgmt_root, NAME)
+        top1 = mgmt_root.tm.gtm.topology_s.topology.create(
+            name=NAME)
+        assert top1.name == NAME
+        assert top1.score and isinstance(top1.score, int)
+        assert top1.kind == 'tm:gtm:topology:topologystate'
+        assert top1.selfLink.startswith(
+            'https://localhost/mgmt/tm/gtm/topology/'
+            'ldns:%20subnet%20192.168.100.0~24%20'
+            'server:%20subnet%20192.168.200.0~24')
+
+    def test_create_optional_args(self, request, mgmt_root):
+        setup_create_test(request, mgmt_root, NAME)
+        reg1 = mgmt_root.tm.gtm.topology_s.topology.create(
+            name=NAME, description='NewFakeTopology')
+        assert hasattr(reg1, 'description')
+        assert reg1.description == 'NewFakeTopology'
+
+    def test_create_duplicate(self, request, mgmt_root):
+        setup_basic_test(request, mgmt_root, NAME)
+        with pytest.raises(HTTPError) as err:
+            mgmt_root.tm.gtm.topology_s.topology.create(
+                name=NAME)
+        assert err.value.response.status_code == 409
+
+
+@pytest.mark.skipif(LooseVersion(pytest.config.getoption('--release')) >=
+                    '12.1.0' or
+                    LooseVersion(pytest.config.getoption('--release')) ==
+                    '12.0.0', reason='Needs < v12.1.0 TMOS to pass')
+class TestCreate_pre_12_1_0(object):
+    def test_create_no_args(self, mgmt_root):
+        with pytest.raises(MissingRequiredCreationParameter):
+            mgmt_root.tm.gtm.topology_s.topology.create()
+
+    def test_invalid_name_raises(self, mgmt_root):
+        with pytest.raises(InvalidName) as err:
+            mgmt_root.tm.gtm.topology_s.topology.create(name='fake_wrong')
+        assert err.value.message == MSG
+
+    def test_create(self, request, mgmt_root):
+        setup_create_test(request, mgmt_root, NAME_SPACES)
+        top1 = mgmt_root.tm.gtm.topology_s.topology.create(
+            name=NAME_SPACES)
+        assert top1.name == NAME_SPACES
+        assert top1.score and isinstance(top1.score, int)
+        assert top1.kind == 'tm:gtm:topology:topologystate'
+        assert top1.selfLink.startswith(
+            'https://localhost/mgmt/tm/gtm/topology/'
+            '%20ldns:%20subnet%20192.168.100.0~24%20%20'
+            'server:%20subnet%20192.168.200.0~24')
+
+    def test_create_optional_args(self, request, mgmt_root):
+        setup_create_test(request, mgmt_root, NAME_SPACES)
+        reg1 = mgmt_root.tm.gtm.topology_s.topology.create(
+            name=NAME_SPACES, description='NewFakeTopology')
+        assert hasattr(reg1, 'description')
+        assert reg1.description == 'NewFakeTopology'
+
+    def test_create_duplicate(self, request, mgmt_root):
+        setup_basic_test(request, mgmt_root, NAME_SPACES)
+        with pytest.raises(HTTPError) as err:
+            mgmt_root.tm.gtm.topology_s.topology.create(
+                name=NAME_SPACES)
+        assert err.value.response.status_code == 409
+
+
+@pytest.mark.skipif(LooseVersion(pytest.config.getoption('--release')) ==
+                    '12.0.0', reason='Resource disabled for TMOS 12.0.0')
+class TestRefresh(object):
+    def test_refresh_raises(self, mgmt_root):
+        with pytest.raises(UnsupportedOperation):
+            mgmt_root.tm.gtm.topology_s.topology.refresh()
+
+
+@pytest.mark.skipif(LooseVersion(pytest.config.getoption('--release')) <
+                    '12.1.0' or
+                    LooseVersion(pytest.config.getoption('--release')) ==
+                    '12.0.0', reason='Needs > v12.1.0 TMOS to pass')
+class TestLoad(object):
+    def test_load_no_object(self, mgmt_root):
+        with pytest.raises(HTTPError) as err:
+            mgmt_root.tm.gtm.topology_s.topology.load(name=NAME)
+        assert err.value.response.status_code == 404
+
+    def test_load(self, request, mgmt_root):
+        setup_basic_test(request, mgmt_root, NAME)
+        t1 = mgmt_root.tm.gtm.topology_s.topology.load(name=NAME)
+        assert t1.name == NAME
+        assert t1.kind == 'tm:gtm:topology:topologystate'
+        t2 = mgmt_root.tm.gtm.topology_s.topology.load(name=NAME)
+        assert t1.kind == t2.kind
+        assert t1.selfLink == t2.selfLink
+
+
+@pytest.mark.skipif(LooseVersion(pytest.config.getoption('--release')) >=
+                    '12.1.0' or
+                    LooseVersion(pytest.config.getoption('--release')) ==
+                    '12.0.0', reason='Needs < v12.1.0 TMOS to pass')
+class TestLoad_pre_12_1_0(object):
+    def test_load_no_object(self, mgmt_root):
+        with pytest.raises(HTTPError) as err:
+            mgmt_root.tm.gtm.topology_s.topology.load(name=NAME_SPACES)
+        assert err.value.response.status_code == 404
+
+    def test_load(self, request, mgmt_root):
+        setup_basic_test(request, mgmt_root, NAME_SPACES)
+        t1 = mgmt_root.tm.gtm.topology_s.topology.load(name=NAME_SPACES)
+        assert t1.name == NAME_SPACES
+        assert t1.kind == 'tm:gtm:topology:topologystate'
+        t2 = mgmt_root.tm.gtm.topology_s.topology.load(name=NAME_SPACES)
+        assert t1.kind == t2.kind
+        assert t1.selfLink == t2.selfLink
+
+
+@pytest.mark.skipif(LooseVersion(pytest.config.getoption('--release')) ==
+                    '12.0.0', reason='Resource disabled for TMOS 12.0.0')
+class TestUpdate(object):
+    def test_update_raises(self, mgmt_root):
+        with pytest.raises(UnsupportedOperation):
+            mgmt_root.tm.gtm.topology_s.topology.update()
+
+
+@pytest.mark.skipif(LooseVersion(pytest.config.getoption('--release')) ==
+                    '12.0.0', reason='Resource disabled for TMOS 12.0.0')
+class TestModify(object):
+    def test_modify_raises(self, mgmt_root):
+        with pytest.raises(UnsupportedOperation):
+            mgmt_root.tm.gtm.topology_s.topology.modify()
+
+
+@pytest.mark.skipif(LooseVersion(pytest.config.getoption('--release')) <
+                    '12.1.0', reason='Needs > v12.1.0 TMOS to pass')
+class TestDelete(object):
+    def test_delete(self, request, mgmt_root):
+        r1 = setup_basic_test(request, mgmt_root, NAME)
+        r1.delete()
+        with pytest.raises(HTTPError) as err:
+            mgmt_root.tm.gtm.topology_s.topology.load(name=NAME)
+        assert err.value.response.status_code == 404
+
+
+@pytest.mark.skipif(LooseVersion(pytest.config.getoption('--release')) >=
+                    '12.1.0' or
+                    LooseVersion(pytest.config.getoption('--release')) ==
+                    '12.0.0', reason='Needs < v12.1.0 TMOS to pass')
+class TestDelete_pre_12_1_0(object):
+    def test_delete(self, request, mgmt_root):
+        r1 = setup_basic_test(request, mgmt_root, NAME_SPACES)
+        r1.delete()
+        with pytest.raises(HTTPError) as err:
+            mgmt_root.tm.gtm.topology_s.topology.load(name=NAME_SPACES)
+        assert err.value.response.status_code == 404
+
+
+@pytest.mark.skipif(LooseVersion(pytest.config.getoption('--release')) <
+                    '12.1.0' or
+                    LooseVersion(pytest.config.getoption('--release')) ==
+                    '12.0.0', reason='Needs > v12.1.0 TMOS to pass')
+class TestTopologyCollection(object):
+    def test_region_collection(self, request, mgmt_root):
+        setup_create_test(request, mgmt_root, NAME)
+        top1 = mgmt_root.tm.gtm.topology_s.topology.create(
+            name=NAME)
+        assert top1.name == NAME
+        assert top1.kind == 'tm:gtm:topology:topologystate'
+        assert top1.score and isinstance(top1.score, int)
+        assert top1.selfLink.startswith(
+            'https://localhost/mgmt/tm/gtm/topology/'
+            'ldns:%20subnet%20192.168.100.0~24%20'
+            'server:%20subnet%20192.168.200.0~24')
+
+        rc = mgmt_root.tm.gtm.topology_s.get_collection()
+        assert isinstance(rc, list)
+        assert len(rc)
+        assert isinstance(rc[0], Topology)
+
+
+@pytest.mark.skipif(LooseVersion(pytest.config.getoption('--release')) >=
+                    '12.1.0' or
+                    LooseVersion(pytest.config.getoption('--release')) ==
+                    '12.0.0', reason='Needs < v12.1.0 TMOS to pass')
+class TestTopologyCollection_pre_12_1_0(object):
+    def test_region_collection(self, request, mgmt_root):
+        setup_create_test(request, mgmt_root, NAME_SPACES)
+        top1 = mgmt_root.tm.gtm.topology_s.topology.create(
+            name=NAME_SPACES)
+        assert top1.name == NAME_SPACES
+        assert top1.score and isinstance(top1.score, int)
+        assert top1.kind == 'tm:gtm:topology:topologystate'
+        assert top1.selfLink.startswith(
+            'https://localhost/mgmt/tm/gtm/topology/'
+            '%20ldns:%20subnet%20192.168.100.0~24%20%20'
+            'server:%20subnet%20192.168.200.0~24')
+
+        rc = mgmt_root.tm.gtm.topology_s.get_collection()
+        assert isinstance(rc, list)
+        assert len(rc)
+        assert isinstance(rc[0], Topology)
+
+
+@pytest.mark.skipif(LooseVersion(pytest.config.getoption('--release')) !=
+                    '12.0.0', reason='Only TMOS 12.0.0 test')
+class TestTopology_12_0_0(object):
+    def test_topology_raises(self, request, mgmt_root):
+        with pytest.raises(UnsupportedTmosVersion):
+            a = mgmt_root.tm.gtm.topology_s.topology
+        del a

--- a/f5/bigip/tm/gtm/test/unit/test_topology.py
+++ b/f5/bigip/tm/gtm/test/unit/test_topology.py
@@ -1,0 +1,69 @@
+# Copyright 2015 F5 Networks Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import pytest
+
+from f5.bigip import ManagementRoot
+from f5.bigip.resource import InvalidName
+from f5.bigip.resource import MissingRequiredCreationParameter
+from f5.bigip.resource import UnsupportedOperation
+from f5.bigip.tm import Gtm
+from f5.bigip.tm.gtm.topology import Topology
+
+
+@pytest.fixture
+def FakeTopology(fakeicontrolsession):
+    mr = ManagementRoot('192.168.1.1', 'admin', 'admin')
+    fake_gtm = Gtm(mr.tm)
+    fake_top = Topology(fake_gtm)
+    return fake_top
+
+
+class TestCreate(object):
+    def test_create_two(self, fakeicontrolsession):
+        b = ManagementRoot('192.168.1.1', 'admin', 'admin')
+        r1 = b.tm.gtm.topology_s.topology
+        r2 = b.tm.gtm.topology_s.topology
+        assert r1 is not r2
+
+    def test_create_no_args(self, FakeTopology):
+        with pytest.raises(MissingRequiredCreationParameter):
+            FakeTopology.create()
+
+    def test_invalid_name_no_keywords(self, FakeTopology):
+        with pytest.raises(InvalidName):
+            FakeTopology.create(name='fake_stuff')
+
+    def test_invalid_name_no_ldns(self, FakeTopology):
+        with pytest.raises(InvalidName):
+            FakeTopology.create(name='server: fake_stuff')
+
+    def test_invalid_name_no_server(self, FakeTopology):
+        with pytest.raises(InvalidName):
+            FakeTopology.create(name='ldns: fake_stuff')
+
+
+class Test_Refresh_Modify_Update(object):
+    def test_refresh_raises(self, FakeTopology):
+        with pytest.raises(UnsupportedOperation):
+            FakeTopology.refresh()
+
+    def test_modify_raises(self, FakeTopology):
+        with pytest.raises(UnsupportedOperation):
+            FakeTopology.modify()
+
+    def test_update_raises(self, FakeTopology):
+        with pytest.raises(UnsupportedOperation):
+            FakeTopology.update()

--- a/f5/bigip/tm/gtm/topology.py
+++ b/f5/bigip/tm/gtm/topology.py
@@ -1,0 +1,177 @@
+# coding=utf-8
+#
+#  Copyright 2014-2016 F5 Networks Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""BIG-IP® Global Traffic Manager™ (GTM®) Topology Records module.
+
+REST URI
+    ``http://localhost/mgmt/tm/gtm/topology``
+
+GUI Path
+    ``DNS --> GSLB : Topology : Records``
+
+REST Kind
+    ``tm:gtm:topology:*``
+"""
+from distutils.version import LooseVersion
+from f5.bigip.mixins import UnsupportedTmosVersion
+from f5.bigip.resource import Collection
+from f5.bigip.resource import InvalidName
+from f5.bigip.resource import Resource
+from f5.bigip.resource import UnsupportedOperation
+from f5.bigip.resource import URICreationCollision
+
+
+from requests import HTTPError
+
+
+class Topology_s(Collection):
+    """BIG-IP® GTM Topology collection
+
+    Due to an bug where attempts to create/modify/load/delete etc. of this
+    resource in 12.0.0 Final, we have disabled this resource for version
+    12.0.0
+    """
+    def __init__(self, gtm):
+        super(Topology_s, self).__init__(gtm)
+        self._meta_data['allowed_lazy_attributes'] = [Topology]
+        self._meta_data['attribute_registry'] = \
+            {'tm:gtm:topology:topologystate': Topology}
+        self.disable_resource_for_version('12.0.0')
+
+    def disable_resource_for_version(self, version):
+        tmos_v = self._meta_data['bigip'].tmos_version
+        if LooseVersion(tmos_v) == LooseVersion(version):
+            error = "There was an attempt to access resource: \n{}\n which " \
+                    "is disabled for the device's TMOS version: {}.".\
+                format(self._meta_data['uri'], tmos_v)
+            raise UnsupportedTmosVersion(error)
+
+
+class Topology(Resource):
+    """BIG-IP® GTM Topology resource"""
+
+    def __init__(self, topology_s):
+        super(Topology, self).__init__(topology_s)
+        self._meta_data['required_json_kind'] = \
+            'tm:gtm:topology:topologystate'
+
+    def _create(self, **kwargs):
+        """This method needs to be created due to few bugs in 11.5.4 and 11.6.1
+
+
+        The issue arises when you attempt to create a Topology Record resource
+        and while the operation succeeds BIGIP responds with 404.
+        """
+        if 'uri' in self._meta_data:
+            error = "There was an attempt to assign a new uri to this " \
+                    "resource, the _meta_data['uri'] is %s and it should" \
+                    " not be changed." % (self._meta_data['uri'])
+            raise URICreationCollision(error)
+        self._check_exclusive_parameters(**kwargs)
+        requests_params = self._handle_requests_params(kwargs)
+        self._check_create_parameters(**kwargs)
+
+        # Reduce boolean pairs as specified by the meta_data entry below
+        for key1, key2 in self._meta_data['reduction_forcing_pairs']:
+            kwargs = self._reduce_boolean_pair(kwargs, key1, key2)
+
+        # Make convenience variable with short names for this method.
+        _create_uri = self._meta_data['container']._meta_data['uri']
+        session = self._meta_data['bigip']._meta_data['icr_session']
+
+        # This is a bit hacky but we need to do this so we are able to
+        # create a resource inside SDK properly. We also include the
+        # scenario where 20x range response occurs just in case this gets
+        # fixed in later release.
+
+        try:
+            response = session.post(
+                _create_uri, json=kwargs, **requests_params)
+
+        except HTTPError as err:
+            if err.response.status_code != 404:
+                raise
+            if err.response.status_code == 404:
+                kwargs['uri_as_parts'] = True
+                response = session.get(_create_uri, **kwargs)
+
+        # Make new instance of self
+        return self._produce_instance(response)
+
+    def create(self, **kwargs):
+        """Custom method to implement checking of kwarg['name'] contents.
+
+        ::Warning:
+            Be sure to format the gtm topology OID string using the
+            following rules:
+
+        1) Use only a single space between each item in the topology string.
+        2) Use a fully-pathed name for datacenter, isp, region, and pool
+        objects.
+
+        For example:
+        "ldns: subnet 11.11.11.0/24 server: datacenter /Common/DC"
+
+
+        """
+        if 'name' in kwargs:
+            if 'ldns' not in kwargs['name'] or 'server' not in kwargs['name']:
+                raise InvalidName("Topology record name should contain both "
+                                  "'ldns', 'server' keywords with their "
+                                  "proper arguments")
+        return self._create(**kwargs)
+
+    def load(self, **kwargs):
+        """Custom method to implement checking of kwarg['name'] contents."""
+        if 'name' in kwargs:
+            if 'ldns' not in kwargs['name'] or 'server' not in kwargs['name']:
+                raise InvalidName("Topology record name should contain both "
+                                  "'ldns', 'server' keywords with their "
+                                  "proper arguments")
+        kwargs['transform_name'] = True
+
+        return self._load(**kwargs)
+
+    def refresh(self, **kwargs):
+        """Refresh is not supported for Topology
+
+        :raises: UnsupportedOperation
+        """
+        raise UnsupportedOperation(
+            "%s does not support the refresh method" %
+            self.__class__.__name__
+        )
+
+    def modify(self, **patch):
+        """Modify is not supported for Topology
+
+        :raises: UnsupportedOperation
+        """
+        raise UnsupportedOperation(
+            "%s does not support the modify method" %
+            self.__class__.__name__
+        )
+
+    def update(self, **kwargs):
+        """Update is not supported for Topology
+
+        :raises: UnsupportedOperation
+        """
+        raise UnsupportedOperation(
+            "%s does not support the update method" %
+            self.__class__.__name__
+        )


### PR DESCRIPTION
Fixes #875

Problem:
GTM Topology Endpoint was not in SDK.

Analysis:
Adds GTM Topology endpoint to SDK, adds custom create method to accomodate for defects in 11.5.4 and 11.6.1 Final. Adds 'name' property checking to facilitate special name syntax used for GTM topology objects

Tests:
Functional
Unit
Flake8