### PR TITLE
Adds GTM Listener Endpoint

### DIFF
--- a/f5/bigip/tm/gtm/__init__.py
+++ b/f5/bigip/tm/gtm/__init__.py
@@ -30,6 +30,7 @@ REST Kind
 
 from f5.bigip.resource import OrganizingCollection
 from f5.bigip.tm.gtm.datacenter import Datacenters
+from f5.bigip.tm.gtm.listener import Listeners
 from f5.bigip.tm.gtm.pool import Pools
 from f5.bigip.tm.gtm.region import Regions
 from f5.bigip.tm.gtm.rule import Rules
@@ -44,6 +45,7 @@ class Gtm(OrganizingCollection):
         super(Gtm, self).__init__(tm)
         self._meta_data['allowed_lazy_attributes'] = [
             Datacenters,
+            Listeners,
             Pools,
             Regions,
             Rules,

--- a/f5/bigip/tm/gtm/listener.py
+++ b/f5/bigip/tm/gtm/listener.py
@@ -1,0 +1,118 @@
+# coding=utf-8
+#
+#  Copyright 2014-2016 F5 Networks Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""BIG-IP® Global Traffic Manager™ (GTM®) Topology Records module.
+
+REST URI
+    ``http://localhost/mgmt/tm/gtm/listener``
+
+GUI Path
+    ``DNS --> Delivery : Topology : Records``
+
+REST Kind
+    ``tm:gtm:listener:*``
+"""
+
+from f5.bigip.resource import Collection
+from f5.bigip.resource import Resource
+from f5.bigip.resource import UnsupportedOperation
+
+
+class Listeners(Collection):
+    """BIG-IP® GTM Listener collection"""
+    def __init__(self, gtm):
+        super(Listeners, self).__init__(gtm)
+        self._meta_data['allowed_lazy_attributes'] = [Listener]
+        self._meta_data['attribute_registry'] = \
+            {'tm:gtm:listener:listenerstate': Listener}
+
+
+class Listener(Resource):
+    """BIG-IP® GTM Listener resource"""
+    def __init__(self, listeners):
+        super(Listener, self).__init__(listeners)
+        self._meta_data['required_json_kind'] = 'tm:gtm:listener:listenerstate'
+        self._meta_data['required_creation_parameters'].update(('address',))
+        self._meta_data['attribute_registry'] = {
+            'tm:gtm:listener:profiles:profilescollectionstate':
+                Profiles_s
+        }
+
+
+class Profiles_s(Collection):
+    """BIG-IP® GTM Listener Profile sub-collection"""
+    def __init__(self, server):
+        super(Profiles_s, self).__init__(server)
+        self._meta_data['allowed_lazy_attributes'] = [Profile]
+        self._meta_data['required_json_kind'] = \
+            'tm:gtm:listener:profiles:profilescollectionstate'
+        self._meta_data['attribute_registry'] = {
+            'tm:gtm:listener:profiles:profilesstate':
+                Profile}
+
+
+class Profile(Resource):
+    """BIG-IP® GTM Listener Profile sub-collection
+
+    Since GTM listener is a wrapper for LTM virtual,
+    profile removal and profile attachment should be done via the created
+    LTM virtual. Only loading or refresh of profiles is supported.
+    Remainder of operations(Create, Update, Modify, Delete) should be done via
+    LTM Virtual Server Profiles endpoint.
+    """
+
+    def __init__(self, profiles):
+        super(Profile, self).__init__(profiles)
+        self._meta_data['required_json_kind'] = \
+            'tm:gtm:listener:profiles:profilesstate'
+        self._meta_data['required_load_parameters'].update(('partition',))
+
+    def create(self, **kwargs):
+        """Create is not supported for profile sub-collection
+
+        :raises: UnsupportedOperation
+        """
+        raise UnsupportedOperation(
+            "%s does not support the modify method" % self.__class__.__name__
+        )
+
+    def modify(self, **kwargs):
+        """Modify is not supported for profile sub-collection
+
+        :raises: UnsupportedOperation
+        """
+        raise UnsupportedOperation(
+            "%s does not support the modify method" % self.__class__.__name__
+        )
+
+    def update(self, **kwargs):
+        """Update is not supported for profile sub-collection
+
+        :raises: UnsupportedOperation
+        """
+        raise UnsupportedOperation(
+            "%s does not support the update method" % self.__class__.__name__
+        )
+
+    def delete(self, **kwargs):
+        """Delete is not supported for profile sub-collection
+
+        :raises: UnsupportedOperation
+        """
+        raise UnsupportedOperation(
+            "%s does not support the delete method" % self.__class__.__name__
+        )

--- a/f5/bigip/tm/gtm/test/functional/test_listener.py
+++ b/f5/bigip/tm/gtm/test/functional/test_listener.py
@@ -1,0 +1,268 @@
+# Copyright 2015 F5 Networks Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import copy
+import pytest
+
+from distutils.version import LooseVersion
+from f5.bigip.resource import MissingRequiredCreationParameter
+from f5.bigip.resource import MissingRequiredReadParameter
+from f5.bigip.resource import UnsupportedOperation
+from f5.bigip.tm.gtm.listener import Listener
+from pytest import symbols
+from requests.exceptions import HTTPError
+from six import iteritems
+
+pytestmark = pytest.mark.skipif(
+    symbols
+    and hasattr(symbols, 'modules')
+    and not symbols.modules['gtm'],
+    reason='The modules symbol for GTM is set to False.'
+)
+
+
+def delete_listener(mgmt_root, name, partition):
+    try:
+        foo = mgmt_root.tm.gtm.listeners.listener.load(name=name,
+                                                       partition=partition)
+    except HTTPError as err:
+        if err.response.status_code != 404:
+            raise
+        return
+    foo.delete()
+
+
+def setup_create_test(request, mgmt_root, name, partition):
+    def teardown():
+        delete_listener(mgmt_root, name, partition)
+    request.addfinalizer(teardown)
+
+
+def setup_basic_test(request, mgmt_root, name, address, partition):
+    def teardown():
+        delete_listener(mgmt_root, name, partition)
+
+    reg1 = mgmt_root.tm.gtm.listeners.listener.create(name=name,
+                                                      address=address,
+                                                      partition=partition)
+    request.addfinalizer(teardown)
+    return reg1
+
+
+class TestCreate(object):
+    def test_create_no_args(self, mgmt_root):
+        with pytest.raises(MissingRequiredCreationParameter):
+            mgmt_root.tm.gtm.listeners.listener.create()
+
+    def test_create(self, request, mgmt_root):
+        setup_create_test(request, mgmt_root, 'fake_listener', 'Common')
+        reg1 = mgmt_root.tm.gtm.listeners.listener.create(
+            name='fake_listener', partition='Common', address='10.10.10.10')
+        assert reg1.name == 'fake_listener'
+        assert reg1.partition == 'Common'
+        assert reg1.address == '10.10.10.10'
+        assert reg1.generation and isinstance(reg1.generation, int)
+        assert reg1.kind == 'tm:gtm:listener:listenerstate'
+        assert reg1.selfLink.startswith(
+            'https://localhost/mgmt/tm/gtm/listener/~Common~fake_listener')
+
+    def test_create_optional_args(self, request, mgmt_root):
+        setup_create_test(request, mgmt_root, 'fake_listener', 'Common')
+        reg1 = mgmt_root.tm.gtm.listeners.listener.create(
+            name='fake_listener', partition='Common', address='10.10.10.10',
+            description='NewListener')
+        assert hasattr(reg1, 'description')
+        assert reg1.description == 'NewListener'
+
+    def test_create_duplicate(self, request, mgmt_root):
+        setup_basic_test(request, mgmt_root, 'fake_listener',
+                         '10.10.10.10', 'Common')
+        with pytest.raises(HTTPError) as err:
+            mgmt_root.tm.gtm.listeners.listener.create(
+                name='fake_listener', partition='Common',
+                address='10.10.10.10')
+        assert err.value.response.status_code == 409
+
+
+class TestRefresh(object):
+    def test_refresh(self, request, mgmt_root):
+        setup_basic_test(request, mgmt_root, 'fake_listener',
+                         '10.10.10.10', 'Common')
+        r1 = mgmt_root.tm.gtm.listeners.listener.load(
+            name='fake_listener', partition='Common')
+        r2 = mgmt_root.tm.gtm.listeners.listener.load(
+            name='fake_listener', partition='Common')
+
+        assert r1.name == 'fake_listener'
+        assert r2.name == 'fake_listener'
+
+        r2.update(description='NewListener')
+        assert hasattr(r2, 'description')
+        assert not hasattr(r1, 'description')
+        assert r2.description == 'NewListener'
+        r1.refresh()
+        assert hasattr(r1, 'description')
+        assert r1.description == 'NewListener'
+
+
+class TestLoad(object):
+    def test_load_no_object(self, mgmt_root):
+        with pytest.raises(HTTPError) as err:
+            mgmt_root.tm.gtm.listeners.listener.load(
+                name='fake_listener', partition='Common')
+        if LooseVersion(pytest.config.getoption('--release')) >= \
+                LooseVersion('12.0.0'):
+            assert err.value.response.status_code == 400
+        else:
+            assert err.value.response.status_code == 500
+
+    def test_load(self, request, mgmt_root):
+        setup_basic_test(request, mgmt_root, 'fake_listener',
+                         '10.10.10.10', 'Common')
+        r1 = mgmt_root.tm.gtm.listeners.listener.load(
+            name='fake_listener', partition='Common')
+        assert r1.name == 'fake_listener'
+        assert not hasattr(r1, 'description')
+        r1.update(description='NewListener')
+        assert hasattr(r1, 'description')
+        assert r1.description == 'NewListener'
+
+        r2 = mgmt_root.tm.gtm.listeners.listener.load(
+            name='fake_listener', partition='Common')
+        assert hasattr(r2, 'description')
+        assert r2.description == 'NewListener'
+
+
+class TestUpdate(object):
+    def test_update(self, request, mgmt_root):
+        r1 = setup_basic_test(request, mgmt_root, 'fake_listener',
+                              '10.10.10.10', 'Common')
+        assert r1.name == 'fake_listener'
+        assert not hasattr(r1, 'description')
+        r1.update(description='NewListener')
+        assert hasattr(r1, 'description')
+        assert r1.description == 'NewListener'
+
+
+class TestModify(object):
+    def test_modify(self, request, mgmt_root):
+        r1 = setup_basic_test(request, mgmt_root, 'fake_listener',
+                              '10.10.10.10', 'Common')
+        original_dict = copy.copy(r1.__dict__)
+        value = 'description'
+        r1.modify(description='NewListener')
+        for k, v in iteritems(original_dict):
+            if k != value:
+                original_dict[k] = r1.__dict__[k]
+            elif k == value:
+                assert r1.__dict__[k] == 'NewListener'
+
+
+class TestDelete(object):
+    def test_delete(self, request, mgmt_root):
+        r1 = mgmt_root.tm.gtm.listeners.listener.create(
+            name='fake_listener', address='10.10.10.10')
+        r1.delete()
+        with pytest.raises(HTTPError) as err:
+            mgmt_root.tm.gtm.listeners.listener.load(
+                name='fake_region', partition='Common')
+        if LooseVersion(pytest.config.getoption('--release')) >= \
+                LooseVersion('12.0.0'):
+            assert err.value.response.status_code == 400
+        else:
+            assert err.value.response.status_code == 500
+
+
+class TestListenerCollection(object):
+    def test_listener_collection(self, request, mgmt_root):
+        reg1 = setup_basic_test(request, mgmt_root, 'fake_listener',
+                                '10.10.10.10', 'Common')
+        assert reg1.name == 'fake_listener'
+        assert reg1.partition == 'Common'
+        assert reg1.address == '10.10.10.10'
+        assert reg1.generation and isinstance(reg1.generation, int)
+        assert reg1.kind == 'tm:gtm:listener:listenerstate'
+        assert reg1.selfLink.startswith(
+            'https://localhost/mgmt/tm/gtm/listener/~Common~fake_listener')
+
+        rc = mgmt_root.tm.gtm.listeners.get_collection()
+        assert isinstance(rc, list)
+        assert len(rc)
+        assert isinstance(rc[0], Listener)
+
+
+class TestProfile(object):
+    def test_load_missing_args(self, request, mgmt_root):
+        reg1 = setup_basic_test(request, mgmt_root, 'fake_listener',
+                                '10.10.10.10', 'Common')
+        profcol = reg1.profiles_s.get_collection()
+        prname = str(profcol[0].name)
+        with pytest.raises(MissingRequiredReadParameter):
+            reg1.profiles_s.profile.load(name=prname)
+
+    def test_load(self, request, mgmt_root):
+        reg1 = setup_basic_test(request, mgmt_root, 'fake_listener',
+                                '10.10.10.10', 'Common')
+        profcol = reg1.profiles_s.get_collection()
+        prname = str(profcol[0].name)
+        prpart = str(profcol[0].partition)
+        pr1 = reg1.profiles_s.profile.load(name=prname, partition=prpart)
+        assert pr1.kind == 'tm:gtm:listener:profiles:profilesstate'
+        assert pr1.selfLink.startswith('https://localhost/mgmt/tm/gtm/listener'
+                                       '/~Common~fake_listener/profiles/'
+                                       '~Common~dns')
+
+    def test_refresh(self, request, mgmt_root):
+        reg1 = setup_basic_test(request, mgmt_root, 'fake_listener',
+                                '10.10.10.10', 'Common')
+        profcol = reg1.profiles_s.get_collection()
+        prname = str(profcol[0].name)
+        prpart = str(profcol[0].partition)
+        pr1 = reg1.profiles_s.profile.load(name=prname, partition=prpart)
+        assert pr1.kind == 'tm:gtm:listener:profiles:profilesstate'
+        assert pr1.selfLink.startswith('https://localhost/mgmt/tm/gtm/listener'
+                                       '/~Common~fake_listener/profiles/'
+                                       '~Common~dns')
+        pr2 = reg1.profiles_s.profile.load(name=prname, partition=prpart)
+        pr1.refresh()
+        assert pr1.kind == pr2.kind
+        assert pr1.selfLink == pr2.selfLink
+        pr2.refresh()
+        assert pr2.kind == pr1.kind
+        assert pr2.selfLink == pr1.selfLink
+
+    def test_create_raises(self, request, mgmt_root):
+        reg1 = setup_basic_test(request, mgmt_root, 'fake_listener',
+                                '10.10.10.10', 'Common')
+        with pytest.raises(UnsupportedOperation):
+            reg1.profiles_s.profile.create()
+
+    def test_modify_raises(self, request, mgmt_root):
+        reg1 = setup_basic_test(request, mgmt_root, 'fake_listener',
+                                '10.10.10.10', 'Common')
+        with pytest.raises(UnsupportedOperation):
+            reg1.profiles_s.profile.modify()
+
+    def test_update_raises(self, request, mgmt_root):
+        reg1 = setup_basic_test(request, mgmt_root, 'fake_listener',
+                                '10.10.10.10', 'Common')
+        with pytest.raises(UnsupportedOperation):
+            reg1.profiles_s.profile.update()
+
+    def test_delete_raises(self, request, mgmt_root):
+        reg1 = setup_basic_test(request, mgmt_root, 'fake_listener',
+                                '10.10.10.10', 'Common')
+        with pytest.raises(UnsupportedOperation):
+            reg1.profiles_s.profile.delete()

--- a/f5/bigip/tm/gtm/test/unit/test_listener.py
+++ b/f5/bigip/tm/gtm/test/unit/test_listener.py
@@ -1,0 +1,71 @@
+# Copyright 2015 F5 Networks Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import mock
+import pytest
+
+from f5.bigip import ManagementRoot
+from f5.bigip.resource import MissingRequiredCreationParameter
+from f5.bigip.resource import UnsupportedOperation
+from f5.bigip.tm.gtm.listener import Listener
+from f5.bigip.tm.gtm.listener import Profile
+
+
+@pytest.fixture
+def FakeListener():
+    fake_list_s = mock.MagicMock()
+    fake_list = Listener(fake_list_s)
+    return fake_list
+
+
+@pytest.fixture
+def FakeProfile():
+    fake_prof_s = mock.MagicMock()
+    fake_prof = Profile(fake_prof_s)
+    return fake_prof
+
+
+class TestListener(object):
+    def test_create_two(self, fakeicontrolsession):
+        b = ManagementRoot('192.168.1.1', 'admin', 'admin')
+        r1 = b.tm.gtm.listeners.listener
+        r2 = b.tm.gtm.listeners.listener
+        assert r1 is not r2
+
+    def test_create_no_args(self, FakeListener):
+        with pytest.raises(MissingRequiredCreationParameter):
+            FakeListener.create()
+
+    def test_create_partition(self, FakeListener):
+        with pytest.raises(MissingRequiredCreationParameter):
+            FakeListener.create(name='fake_listener')
+
+
+class TestProfile(object):
+    def test_create_raises(self, FakeProfile):
+        with pytest.raises(UnsupportedOperation):
+            FakeProfile.create()
+
+    def test_delete_raises(self, FakeProfile):
+        with pytest.raises(UnsupportedOperation):
+            FakeProfile.delete()
+
+    def test_modify_raises(self, FakeProfile):
+        with pytest.raises(UnsupportedOperation):
+            FakeProfile.modify()
+
+    def test_update_raises(self, FakeProfile):
+        with pytest.raises(UnsupportedOperation):
+            FakeProfile.update()


### PR DESCRIPTION
Fixes #877

Problem:
GTM Listener endpoint was not in SDK.

Analysis:
Adds GTM Listener endpoint to SDK. Since GTM listener is a wrapper for LTM virtual, profile subcollection is read only. This means that  removal and profile attachment should be done via the created LTM virtual. Only loading or refresh of profiles is supported. Remainder of operations(Create, Update, Modify, Delete) should be done via LTM Virtual Server Profiles endpoint.

Tests:
Functional
Unit
Flake8