### PR TITLE
 Adds Headers Subcollection to ASM Policy

### DIFF
--- a/f5/bigip/test/unit/test_resource.py
+++ b/f5/bigip/test/unit/test_resource.py
@@ -759,7 +759,7 @@ class TestResource_exists(object):
         r._meta_data['icontrol_version'] = '12.1.0'
         with pytest.raises(requests.HTTPError) as err:
             r.exists(partition='Common', name='test_exists')
-            assert err.response.status_code == 400
+        assert err.value.response.status_code == 400
 
 
 def test_OrganizingCollection():
@@ -1100,7 +1100,7 @@ class TestAsmResource(object):
         }
         with pytest.raises(requests.HTTPError) as err:
             r.exists(id='T84Lsg_fb11W-QDXeCpdkA')
-            assert err.response.status_code == 400
+        assert err.value.response.status_code == 400
 
     def test_exists_pop_name_id_uri(self):
         r = AsmResource(mock.MagicMock())

--- a/f5/bigip/tm/asm/policies.py
+++ b/f5/bigip/tm/asm/policies.py
@@ -59,7 +59,8 @@ class Policy(AsmResource):
             'tm:asm:policies:signatures:signaturecollectionstate':
                 Signatures_s,
             'tm:asm:policies:signature-sets:signature-setcollectionstate':
-                Signature_Sets_s
+                Signature_Sets_s,
+            'tm:asm:policies:headers:headercollectionstate': Headers_s
         }
         self._set_attr_reg()
 
@@ -637,3 +638,24 @@ class Signature_Set(AsmResource):
             'tm:asm:policies:signature-sets:signature-setstate'
         self._meta_data['required_creation_parameters'] = \
             set(('signatureSetReference',))
+
+
+class Headers_s(Collection):
+    """BIG-IP® ASM Headers sub-collection."""
+    def __init__(self, policy):
+        super(Headers_s, self).__init__(policy)
+        self._meta_data['object_has_stats'] = False
+        self._meta_data['allowed_lazy_attributes'] = [Header]
+        self._meta_data['required_json_kind'] = \
+            'tm:asm:policies:headers:headercollectionstate'
+        self._meta_data['attribute_registry'] = {
+            'tm:asm:policies:headers:headerstate':
+                Header}
+
+
+class Header(AsmResource):
+    """BIG-IP® ASM Headers resource."""
+    def __init__(self, headers_s):
+        super(Header, self).__init__(headers_s)
+        self._meta_data['required_json_kind'] = \
+            'tm:asm:policies:headers:headerstate'

--- a/f5/bigip/tm/asm/test/functional/test_atack_types.py
+++ b/f5/bigip/tm/asm/test/functional/test_atack_types.py
@@ -29,7 +29,7 @@ class TestAttackTypes(object):
     def test_load_no_object(self, mgmt_root):
         with pytest.raises(HTTPError) as err:
             mgmt_root.tm.asm.attack_types_s.attack_type.load(id='Lx3553-321')
-            assert err.response.status_code == 404
+        assert err.value.response.status_code == 404
 
     def test_load(self, request, mgmt_root):
         hashid = get_atckid(request, mgmt_root)

--- a/f5/bigip/tm/asm/test/functional/test_policies.py
+++ b/f5/bigip/tm/asm/test/functional/test_policies.py
@@ -137,12 +137,12 @@ class TestPolicy(object):
         pol1.delete()
         with pytest.raises(HTTPError) as err:
             mgmt_root.tm.asm.policies_s.policy.load(id=idhash)
-            assert err.response.status_code == 404
+        assert err.value.response.status_code == 404
 
     def test_load_no_object(self, mgmt_root):
         with pytest.raises(HTTPError) as err:
             mgmt_root.tm.asm.policies_s.policy.load(id='Lx3553-321')
-            assert err.response.status_code == 404
+        assert err.value.response.status_code == 404
 
     def test_load(self, request, mgmt_root):
         pol1 = set_policy_test(request, mgmt_root, 'fake_policy')
@@ -233,13 +233,13 @@ class TestMethods(object):
         met1.delete()
         with pytest.raises(HTTPError) as err:
             pol1.methods_s.method.load(id=idhash)
-            assert err.response.status_code == 404
+        assert err.value.response.status_code == 404
 
     def test_load_no_object(self, request, mgmt_root):
         pol1 = set_policy_test(request, mgmt_root, 'fake_policy')
         with pytest.raises(HTTPError) as err:
             pol1.methods_s.method.load(id='Lx3553-321')
-            assert err.response.status_code == 404
+        assert err.value.response.status_code == 404
 
     def test_load(self, request, mgmt_root):
         pol1 = set_policy_test(request, mgmt_root, 'fake_policy')
@@ -311,13 +311,13 @@ class TestFiletypes(object):
         ft1.delete()
         with pytest.raises(HTTPError) as err:
             pol1.filetypes_s.filetype.load(id=idhash)
-            assert err.response.status_code == 404
+        assert err.value.response.status_code == 404
 
     def test_load_no_object(self, request, mgmt_root):
         pol1 = set_policy_test(request, mgmt_root, 'fake_policy')
         with pytest.raises(HTTPError) as err:
             pol1.filetypes_s.filetype.load(id='Lx3553-321')
-            assert err.response.status_code == 404
+        assert err.value.response.status_code == 404
 
     def test_load(self, request, mgmt_root):
         pol1 = set_policy_test(request, mgmt_root, 'fake_policy')
@@ -389,13 +389,13 @@ class TestCookies(object):
         cook1.delete()
         with pytest.raises(HTTPError) as err:
             pol1.cookies_s.cookie.load(id=idhash)
-            assert err.response.status_code == 404
+        assert err.value.response.status_code == 404
 
     def test_load_no_object(self, request, mgmt_root):
         pol1 = set_policy_test(request, mgmt_root, 'fake_policy')
         with pytest.raises(HTTPError) as err:
             pol1.cookies_s.cookie.load(id='Lx3553-321')
-            assert err.response.status_code == 404
+        assert err.value.response.status_code == 404
 
     def test_load(self, request, mgmt_root):
         pol1 = set_policy_test(request, mgmt_root, 'fake_policy')
@@ -467,13 +467,13 @@ class TestHostNames(object):
         host1.delete()
         with pytest.raises(HTTPError) as err:
             pol1.host_names_s.host_name.load(id=idhash)
-            assert err.response.status_code == 404
+        assert err.value.response.status_code == 404
 
     def test_load_no_object(self, request, mgmt_root):
         pol1 = set_policy_test(request, mgmt_root, 'fake_policy')
         with pytest.raises(HTTPError) as err:
             pol1.host_names_s.host_name.load(id='Lx3553-321')
-            assert err.response.status_code == 404
+        assert err.value.response.status_code == 404
 
     def test_load(self, request, mgmt_root):
         pol1 = set_policy_test(request, mgmt_root, 'fake_policy')
@@ -576,7 +576,7 @@ class TestEvasions(object):
         pol1 = set_policy_test(request, mgmt_root, 'fake_policy')
         with pytest.raises(HTTPError) as err:
             pol1.blocking_settings.evasions_s.evasion.load(id='Lx3553-321')
-            assert err.response.status_code == 404
+        assert err.value.response.status_code == 404
 
     def test_load(self, request, mgmt_root):
         pol1 = set_policy_test(request, mgmt_root, 'fake_policy')
@@ -646,7 +646,7 @@ class TestViolations(object):
         with pytest.raises(HTTPError) as err:
             pol1.blocking_settings.violations_s.violation.load(
                 id='Lx3553-321')
-            assert err.response.status_code == 404
+        assert err.value.response.status_code == 404
 
     def test_load(self, request, mgmt_root):
         pol1 = set_policy_test(request, mgmt_root, 'fake_policy')
@@ -719,7 +719,7 @@ class TestHTTPProtoccols(object):
         with pytest.raises(HTTPError) as err:
             pol1.blocking_settings.http_protocols_s.\
                 http_protocol.load(id='Lx3553-321')
-            assert err.response.status_code == 404
+        assert err.value.response.status_code == 404
 
     def test_load(self, request, mgmt_root):
         pol1 = set_policy_test(request, mgmt_root, 'fake_policy')
@@ -795,7 +795,7 @@ class TestWebServicesSecurities(object):
         wsc = pol1.blocking_settings.web_services_securities_s
         with pytest.raises(HTTPError) as err:
             wsc.web_services_security.load(id='Lx3553-321')
-            assert err.response.status_code == 404
+        assert err.value.response.status_code == 404
 
     def test_load(self, request, mgmt_root):
         pol1 = set_policy_test(request, mgmt_root, 'fake_policy')
@@ -872,13 +872,13 @@ class TestUrls(object):
         url1.delete()
         with pytest.raises(HTTPError) as err:
             pol1.urls_s.url.load(id=idhash)
-            assert err.response.status_code == 404
+        assert err.value.response.status_code == 404
 
     def test_load_no_object(self, request, mgmt_root):
         pol1 = set_policy_test(request, mgmt_root, 'fake_policy')
         with pytest.raises(HTTPError) as err:
             pol1.urls_s.url.load(id='Lx3553-321')
-            assert err.response.status_code == 404
+        assert err.value.response.status_code == 404
 
     def test_load(self, request, mgmt_root):
         pol1 = set_policy_test(request, mgmt_root, 'fake_policy')
@@ -1004,14 +1004,14 @@ class TestUrlParameters(object):
         param1.delete()
         with pytest.raises(HTTPError) as err:
             url.parameters_s.parameter.load(id=idhash)
-            assert err.response.status_code == 404
+        assert err.value.response.status_code == 404
 
     def test_load_no_object(self, request, mgmt_root):
         pol1 = set_policy_test(request, mgmt_root, 'fake_policy')
         url = pol1.urls_s.url.create(name='testing')
         with pytest.raises(HTTPError) as err:
             url.parameters_s.parameter.load(id='Lx3553-321')
-            assert err.response.status_code == 404
+        assert err.value.response.status_code == 404
 
     def test_load(self, request, mgmt_root):
         pol1 = set_policy_test(request, mgmt_root, 'fake_policy')
@@ -1097,13 +1097,13 @@ class TestPolicyParameters(object):
         param1.delete()
         with pytest.raises(HTTPError) as err:
             pol1.parameters_s.parameter.load(id=idhash)
-            assert err.response.status_code == 404
+        assert err.value.response.status_code == 404
 
     def test_load_no_object(self, request, mgmt_root):
         pol1 = set_policy_test(request, mgmt_root, 'fake_policy')
         with pytest.raises(HTTPError) as err:
             pol1.parameters_s.parameter.load(id='Lx3553-321')
-            assert err.response.status_code == 404
+        assert err.value.response.status_code == 404
 
     def test_load(self, request, mgmt_root):
         pol1 = set_policy_test(request, mgmt_root, 'fake_policy')
@@ -1196,13 +1196,13 @@ class TestWhitelistIps(object):
         ip1.delete()
         with pytest.raises(HTTPError) as err:
             pol1.whitelist_ips_s.whitelist_ip.load(id=idhash)
-            assert err.response.status_code == 404
+        assert err.value.response.status_code == 404
 
     def test_load_no_object(self, request, mgmt_root):
         pol1 = set_policy_test(request, mgmt_root, 'fake_policy')
         with pytest.raises(HTTPError) as err:
             pol1.whitelist_ips_s.whitelist_ip.load(id='Lx3553-321')
-            assert err.response.status_code == 404
+        assert err.value.response.status_code == 404
 
     def test_load(self, request, mgmt_root):
         pol1 = set_policy_test(request, mgmt_root, 'fake_policy')
@@ -1286,13 +1286,13 @@ class TestGwtProfiles(object):
         gwt1.delete()
         with pytest.raises(HTTPError) as err:
             pol1.gwt_profiles_s.gwt_profile.load(id=idhash)
-            assert err.response.status_code == 404
+        assert err.value.response.status_code == 404
 
     def test_load_no_object(self, request, mgmt_root):
         pol1 = set_policy_test(request, mgmt_root, 'fake_policy')
         with pytest.raises(HTTPError) as err:
             pol1.gwt_profiles_s.gwt_profile.load(id='Lx3553-321')
-            assert err.response.status_code == 404
+        assert err.value.response.status_code == 404
 
     def test_load(self, request, mgmt_root):
         pol1 = set_policy_test(request, mgmt_root, 'fake_policy')
@@ -1373,13 +1373,13 @@ class TestJsonProfile(object):
         json1.delete()
         with pytest.raises(HTTPError) as err:
             pol1.json_profiles_s.json_profile.load(id=idhash)
-            assert err.response.status_code == 404
+        assert err.value.response.status_code == 404
 
     def test_load_no_object(self, request, mgmt_root):
         pol1 = set_policy_test(request, mgmt_root, 'fake_policy')
         with pytest.raises(HTTPError) as err:
             pol1.json_profiles_s.json_profile.load(id='Lx3553-321')
-            assert err.response.status_code == 404
+        assert err.value.response.status_code == 404
 
     def test_load(self, request, mgmt_root):
         pol1 = set_policy_test(request, mgmt_root, 'fake_policy')
@@ -1460,13 +1460,13 @@ class TestXmlProfile(object):
         xml1.delete()
         with pytest.raises(HTTPError) as err:
             pol1.xml_profiles_s.xml_profile.load(id=idhash)
-            assert err.response.status_code == 404
+        assert err.value.response.status_code == 404
 
     def test_load_no_object(self, request, mgmt_root):
         pol1 = set_policy_test(request, mgmt_root, 'fake_policy')
         with pytest.raises(HTTPError) as err:
             pol1.xml_profiles_s.xml_profile.load(id='Lx3553-321')
-            assert err.response.status_code == 404
+        assert err.value.response.status_code == 404
 
     def test_load(self, request, mgmt_root):
         pol1 = set_policy_test(request, mgmt_root, 'fake_policy')
@@ -1537,7 +1537,7 @@ class TestSignature(object):
         pol1 = set_policy_test(request, mgmt_root, 'fake_policy')
         with pytest.raises(HTTPError) as err:
             pol1.signatures_s.signature.load(id='Lx3553-321')
-            assert err.response.status_code == 404
+        assert err.value.response.status_code == 404
 
     def test_load(self, request, mgmt_root):
         pol1 = set_policy_test(request, mgmt_root, 'fake_policy')
@@ -1628,13 +1628,13 @@ class TestSignatureSets(object):
         ss1.delete()
         with pytest.raises(HTTPError) as err:
             pol1.signature_sets_s.signature_set.load(id=idhash)
-            assert err.response.status_code == 404
+        assert err.value.response.status_code == 404
 
     def test_load_no_object(self, request, mgmt_root):
         pol1 = set_policy_test(request, mgmt_root, 'fake_policy')
         with pytest.raises(HTTPError) as err:
             pol1.signature_sets_s.signature_set.load(id='Lx3553-321')
-            assert err.response.status_code == 404
+        assert err.value.response.status_code == 404
 
     def test_load(self, request, mgmt_root):
         coll = mgmt_root.tm.asm.signature_sets_s.get_collection(

--- a/f5/bigip/tm/asm/test/functional/test_signature_sets.py
+++ b/f5/bigip/tm/asm/test/functional/test_signature_sets.py
@@ -76,7 +76,7 @@ class TestSignatureSets(object):
         with pytest.raises(HTTPError) as err:
             mgmt_root.tm.asm.signature_sets_s.signature_set.create(
                 name='fake_sig')
-            assert err.response.status_code == 400
+        assert err.value.response.status_code == 400
 
     def test_refresh(self, request, mgmt_root):
         sig1 = create_sigset(request, mgmt_root, name='fake_sig')
@@ -96,7 +96,7 @@ class TestSignatureSets(object):
         with pytest.raises(HTTPError) as err:
             mgmt_root.tm.asm.signature_sets_s.signature_set.load(
                 id='Lx3553-321')
-            assert err.response.status_code == 404
+        assert err.value.response.status_code == 404
 
     def test_load(self, request, mgmt_root):
         sig1 = create_sigset(request, mgmt_root, name='fake_sig')
@@ -123,7 +123,7 @@ class TestSignatureSets(object):
         sig.delete()
         with pytest.raises(HTTPError) as err:
             mgmt_root.tm.asm.signature_sets_s.signature_set.load(id=hashid)
-            assert err.response.status_code == 404
+        assert err.value.response.status_code == 404
 
     def test_modify(self, request, mgmt_root):
         sig = create_sigset(request, mgmt_root, name='fake_sig')

--- a/f5/bigip/tm/asm/test/functional/test_signatures.py
+++ b/f5/bigip/tm/asm/test/functional/test_signatures.py
@@ -125,12 +125,12 @@ class TestSignature(object):
         sig1.delete()
         with pytest.raises(HTTPError) as err:
             mgmt_root.tm.asm.signatures_s.signature.load(id=idhash)
-            assert err.response.status_code == 404
+        assert err.value.response.status_code == 404
 
     def test_load_no_object(self, mgmt_root):
         with pytest.raises(HTTPError) as err:
             mgmt_root.tm.asm.signatures_s.signature.load(id='Lx3553-321')
-            assert err.response.status_code == 404
+        assert err.value.response.status_code == 404
 
     def test_load(self, request, mgmt_root):
         rule = "content:\"ABC\"; depth:10;"

--- a/f5/bigip/tm/asm/test/functional/test_tasks.py
+++ b/f5/bigip/tm/asm/test/functional/test_tasks.py
@@ -102,7 +102,7 @@ class TestCheckSignature(object):
         with pytest.raises(HTTPError) as err:
             mgmt_root.tm.asm.tasks.check_signatures_s.check_signature.load(
                 id='Lx3553-321')
-            assert err.response.status_code == 404
+        assert err.value.response.status_code == 404
 
     def test_load(self, request, mgmt_root):
         chk1 = set_chksig_test(request, mgmt_root)
@@ -195,7 +195,7 @@ class TestExportSignature(object):
         with pytest.raises(HTTPError) as err:
             mgmt_root.tm.asm.tasks.export_signatures_s.export_signature \
                 .load(id='Lx3553-321')
-            assert err.response.status_code == 404
+        assert err.value.response.status_code == 404
 
     def test_load(self, request, mgmt_root):
         f = 'fake_export.xml'
@@ -213,7 +213,7 @@ class TestExportSignature(object):
         with pytest.raises(HTTPError) as err:
             mgmt_root.tm.asm.tasks.export_signatures_s.export_signature.load(
                 id=hashid)
-            assert err.response.status_code == 404
+        assert err.value.response.status_code == 404
 
     def test_signature_export_collection(self, request, mgmt_root):
         f = 'fake_export.xml'

--- a/f5/bigip/tm/asm/test/unit/test_file_transfer.py
+++ b/f5/bigip/tm/asm/test/unit/test_file_transfer.py
@@ -132,7 +132,7 @@ def test_404_response():
     try:
         dwnld.download_file('fakefile.txt')
     except HTTPError as err:
-        assert err.response.status_code == 404
+        assert err.value.response.status_code == 404
 
 
 def test_zero_content_length_header():

--- a/f5/bigip/tm/asm/test/unit/test_policies.py
+++ b/f5/bigip/tm/asm/test/unit/test_policies.py
@@ -18,6 +18,7 @@ from f5.bigip.resource import MissingRequiredCreationParameter
 from f5.bigip.resource import UnsupportedOperation
 from f5.bigip.tm.asm import Asm
 from f5.bigip.tm.asm.policies import Evasion
+from f5.bigip.tm.asm.policies import Header
 from f5.bigip.tm.asm.policies import Http_Protocol
 from f5.bigip.tm.asm.policies import Parameter
 from f5.bigip.tm.asm.policies import Parameters_s
@@ -97,8 +98,8 @@ def FakeWebsec():
 
 @pytest.fixture
 def FakeSignature():
-    fake_asm = mock.MagicMock()
-    fake_sig = Signature(fake_asm)
+    fake_policy = mock.MagicMock()
+    fake_sig = Signature(fake_policy)
     fake_sig._meta_data['bigip'].tmos_version = '11.6.0'
     return fake_sig
 
@@ -115,6 +116,14 @@ def FakePolicyParameters():
 def FakeUrlParameters():
     fake_policy = mock.MagicMock()
     fake_param = UrlParametersCollection(fake_policy)
+    fake_param._meta_data['bigip'].tmos_version = '11.6.0'
+    return fake_param
+
+
+@pytest.fixture
+def FakeHeader():
+    fake_policy = mock.MagicMock()
+    fake_param = Header(fake_policy)
     fake_param._meta_data['bigip'].tmos_version = '11.6.0'
     return fake_param
 
@@ -222,3 +231,9 @@ class TestSignature(object):
     def test_delete_raises(self, FakeSignature):
         with pytest.raises(UnsupportedOperation):
             FakeSignature.delete()
+
+
+class TestHeader(object):
+    def test_create_no_args(self, FakeHeader):
+        with pytest.raises(MissingRequiredCreationParameter):
+            FakeHeader.create()

--- a/f5/bigip/tm/cm/test/functional/test_device_group.py
+++ b/f5/bigip/tm/cm/test/functional/test_device_group.py
@@ -104,6 +104,6 @@ class TestDeviceGroup(object):
         with pytest.raises(iControlUnexpectedHTTPError) as err:
             sync_cmd = 'config-sync from-group %s' % dg1.name
             mgmt_root.tm.cm.exec_cmd('run', utilCmdArgs=sync_cmd)
-            assert err.response.status_code == 400
-            assert 'is not allowed until a push has been done first' \
-                   in err.response.text
+        assert err.value.response.status_code == 400
+        assert 'is not allowed until a push has been done first' \
+               in err.value.response.text

--- a/f5/bigip/tm/gtm/test/functional/test_datacenter.py
+++ b/f5/bigip/tm/gtm/test/functional/test_datacenter.py
@@ -91,7 +91,7 @@ class TestCreate(object):
         with pytest.raises(HTTPError) as err:
             mgmt_root.tm.gtm.datacenters.datacenter.create(
                 name='dc1', partition='Common')
-            assert err.response.status_code == 400
+        assert err.value.response.status_code == 409
 
 
 class TestRefresh(object):
@@ -117,7 +117,7 @@ class TestLoad(object):
         with pytest.raises(HTTPError) as err:
             mgmt_root.tm.gtm.datacenters.datacenter.load(
                 name='dc1', partition='Common')
-            assert err.response.status_code == 404
+        assert err.value.response.status_code == 404
 
     def test_load(self, request, mgmt_root):
         setup_basic_test(request, mgmt_root, 'dc1', 'Common')
@@ -153,7 +153,7 @@ class TestDelete(object):
         with pytest.raises(HTTPError) as err:
             mgmt_root.tm.gtm.datacenters.datacenter.load(
                 name='dc1', partition='Common')
-            assert err.response.status_code == 404
+        assert err.value.response.status_code == 404
 
 
 class TestDatacenterCollection(object):

--- a/f5/bigip/tm/gtm/test/functional/test_pool.py
+++ b/f5/bigip/tm/gtm/test/functional/test_pool.py
@@ -724,7 +724,7 @@ class TestPools_v11(object):
     def test_load_no_object(self, mgmt_root):
         with pytest.raises(HTTPError) as err:
             mgmt_root.tm.gtm.pools.pool.load(name='fake_pool')
-            assert err.response.status_code == 404
+        assert err.value.response.status_code == 404
 
     def test_load(self, request, mgmt_root):
         setup_pool_basic_test(request, mgmt_root, 'fake_pool', 'Common')
@@ -763,7 +763,7 @@ class TestPools_v11(object):
         p1.delete()
         with pytest.raises(HTTPError) as err:
             mgmt_root.tm.gtm.wideips.wideip.load(name='fake_pool')
-            assert err.response.status_code == 404
+        assert err.value.response.status_code == 404
 
     def test_pool_collection(self, request, mgmt_root):
         pool1, pcoll = setup_pool_basic_test(request, mgmt_root,

--- a/f5/bigip/tm/gtm/test/functional/test_rule.py
+++ b/f5/bigip/tm/gtm/test/functional/test_rule.py
@@ -123,7 +123,7 @@ class TestCreate(object):
             rule2.create(name='rule1', partition='Common',
                          apiAnonymous=RULE,
                          check='syntax')
-            assert err.response.status_code == 400
+        assert err.value.response.status_code == 409
 
 
 class TestRefresh(object):
@@ -149,7 +149,7 @@ class TestLoad(object):
         with pytest.raises(HTTPError) as err:
             mgmt_root.tm.gtm.rules.rule.load(
                 name='rule1', partition='Common')
-            assert err.response.status_code == 404
+        assert err.value.response.status_code == 404
 
     def test_load(self, request, mgmt_root):
         setup_basic_test(request, mgmt_root, 'rule1', 'Common')
@@ -182,7 +182,7 @@ class TestDelete(object):
         with pytest.raises(HTTPError) as err:
             mgmt_root.tm.gtm.rules.rule.load(
                 name='rule1', partition='Common')
-            assert err.response.status_code == 404
+        assert err.value.response.status_code == 404
 
 
 class TestRuleCollection(object):

--- a/f5/bigip/tm/gtm/test/functional/test_server.py
+++ b/f5/bigip/tm/gtm/test/functional/test_server.py
@@ -149,7 +149,7 @@ class TestCreate(object):
             mgmt_root.tm.gtm.servers.server.create(
                 name='fake_serv1', datacenter='dc1',
                 addresses=[{'name': '1.1.1.1'}])
-            assert err.response.status_code == 400
+        assert err.value.response.status_code == 409
 
 
 class TestRefresh(object):
@@ -174,7 +174,7 @@ class TestLoad(object):
         with pytest.raises(HTTPError) as err:
             mgmt_root.tm.gtm.servers.server.load(
                 name='fake_serv1')
-            assert err.response.status_code == 404
+        assert err.value.response.status_code == 404
 
     @pytest.mark.skipif(LooseVersion(pytest.config.getoption('--release')) ==
                         '11.5.4',
@@ -231,7 +231,7 @@ class TestDelete(object):
         s1.delete()
         with pytest.raises(HTTPError) as err:
             mgmt_root.tm.gtm.servers.server.load(name='fake_serv1')
-            assert err.response.status_code == 404
+        assert err.value.response.status_code == 404
 
 
 class TestServerCollection(object):

--- a/f5/bigip/tm/gtm/test/functional/test_wideips.py
+++ b/f5/bigip/tm/gtm/test/functional/test_wideips.py
@@ -289,7 +289,7 @@ class TestWideips_v11(object):
     def test_load_no_object(self, mgmt_root):
         with pytest.raises(HTTPError) as err:
             mgmt_root.tm.gtm.wideips.wideip.load(name='fake.lab.local')
-            assert err.response.status_code == 404
+        assert err.value.response.status_code == 404
 
     def test_load(self, request, mgmt_root):
         setup_basic_test(request, mgmt_root, 'fake.lab.local')
@@ -325,7 +325,7 @@ class TestWideips_v11(object):
         s1.delete()
         with pytest.raises(HTTPError) as err:
             mgmt_root.tm.gtm.wideips.wideip.load(name='fake.lab.local')
-            assert err.response.status_code == 404
+        assert err.value.response.status_code == 404
 
     def test_wideips_collection(self, request, mgmt_root):
         wideip1 = setup_basic_test(request, mgmt_root, 'fake.lab.local',

--- a/f5/bigip/tm/net/test/functional/test_vlan.py
+++ b/f5/bigip/tm/net/test/functional/test_vlan.py
@@ -156,8 +156,8 @@ class TestVLANInterfaces(object):
         assert i.untagged is True
         with pytest.raises(iControlUnexpectedHTTPError) as err:
             i.update(tagged=True, tagMode='service')
-            assert err.response.status_code == 400
-            assert "may not be specified with" in err.response.text
+        assert err.value.response.status_code == 400
+        assert "may not be specified with" in err.value.response.text
 
     @pytest.mark.skipif(
         LooseVersion(


### PR DESCRIPTION
 Adds Headers Subcollection to ASM Policy

Fixes #885

Problem:
Added missed subcollection to asm policy

Analysis:
Added missed subcollection along with its tests

Tests:
Functional
Unit
Flake8