### PR TITLE
Fixes detecting names for the incremental builder

### DIFF
--- a/devtools/bin/create-test-list.py
+++ b/devtools/bin/create-test-list.py
@@ -96,7 +96,7 @@ def determine_files_to_test(product, commit):
     if results:
         results = set(results)
         fh = open(output_file, 'w')
-        fh.writelines(results)
+        fh.writelines("%s\n" % l for l in results)
         fh.close()
 
 


### PR DESCRIPTION
Problem:
The detector for files to incrementally test was busted

Analysis:
This fixes it

Tests: