### PR TITLE
Fixes Assertions in some tests

### DIFF
--- a/f5/bigip/tm/asm/test/functional/test_atack_types.py
+++ b/f5/bigip/tm/asm/test/functional/test_atack_types.py
@@ -29,7 +29,7 @@ class TestAttackTypes(object):
     def test_load_no_object(self, mgmt_root):
         with pytest.raises(HTTPError) as err:
             mgmt_root.tm.asm.attack_types_s.attack_type.load(id='Lx3553-321')
-            assert err.response.status_code == 404
+        assert err.value.response.status_code == 404
 
     def test_load(self, request, mgmt_root):
         hashid = get_atckid(request, mgmt_root)

--- a/f5/bigip/tm/asm/test/functional/test_tasks.py
+++ b/f5/bigip/tm/asm/test/functional/test_tasks.py
@@ -102,7 +102,7 @@ class TestCheckSignature(object):
         with pytest.raises(HTTPError) as err:
             mgmt_root.tm.asm.tasks.check_signatures_s.check_signature.load(
                 id='Lx3553-321')
-            assert err.response.status_code == 404
+        assert err.value.response.status_code == 404
 
     def test_load(self, request, mgmt_root):
         chk1 = set_chksig_test(request, mgmt_root)
@@ -195,7 +195,7 @@ class TestExportSignature(object):
         with pytest.raises(HTTPError) as err:
             mgmt_root.tm.asm.tasks.export_signatures_s.export_signature \
                 .load(id='Lx3553-321')
-            assert err.response.status_code == 404
+        assert err.value.response.status_code == 404
 
     def test_load(self, request, mgmt_root):
         f = 'fake_export.xml'
@@ -213,7 +213,7 @@ class TestExportSignature(object):
         with pytest.raises(HTTPError) as err:
             mgmt_root.tm.asm.tasks.export_signatures_s.export_signature.load(
                 id=hashid)
-            assert err.response.status_code == 404
+        assert err.value.response.status_code == 404
 
     def test_signature_export_collection(self, request, mgmt_root):
         f = 'fake_export.xml'


### PR DESCRIPTION
Problem:
Some Assertions were inside 'when' statement causing them to always pass

Analysis:
This is one of series of fixes to address #874

Tests:
Functional
Unit
Flake8