### PR TITLE
Fixes get_dossier tests

### DIFF
--- a/f5/bigip/mixins.py
+++ b/f5/bigip/mixins.py
@@ -254,6 +254,8 @@ class CommandExecutionMixin(object):
             raise UtilError('%s' % self.commandResult)
         if 'Invalid option' in self.commandResult:
             raise UtilError('%s' % self.commandResult)
+        if 'usage: /usr/bin/get_dossier' in self.commandResult:
+            raise UtilError('%s' % self.commandResult)
 
     def exec_cmd(self, command, **kwargs):
         """Wrapper method that can be changed in the inheriting classes."""

--- a/f5/bigip/tm/util/test/functional/test_get_dossier.py
+++ b/f5/bigip/tm/util/test/functional/test_get_dossier.py
@@ -30,7 +30,7 @@ def test_command_result_present(mgmt_root):
     dossier1 = mgmt_root.tm.util.get_dossier.exec_cmd(
         'run', utilCmdArgs='-b registration-key')
     assert 'commandResult' in dossier1.__dict__
-    assert len(dossier1.commandResult) == 2048
+    assert len(dossier1.commandResult) > 0
 
 
 def test_invalid_get_dossier_options(mgmt_root):

--- a/f5/bigip/tm/util/test/functional/test_get_dossier.py
+++ b/f5/bigip/tm/util/test/functional/test_get_dossier.py
@@ -37,7 +37,7 @@ def test_invalid_get_dossier_options(mgmt_root):
     with pytest.raises(UtilError) as err:
         mgmt_root.tm.util.get_dossier.exec_cmd(
             'run', utilCmdArgs='-x registration-key')
-    assert 'Invalid option' in str(err.value)
+    assert 'usage: /usr/bin/get_dossier' in str(err.value)
 
 
 def test_unbalanced_quotes(mgmt_root):


### PR DESCRIPTION
Fixes #883

Problem:
Some tests were failing due to wrong assumptions, and some tests failed due to missing code

Analysis:
Corrected tests, added code to command mixin to accomodate get_dossier output

Tests:
Functional
Unit
Flake8