### PR TITLE
Exceptions move part1

### DIFF
--- a/f5/bigip/mixins.py
+++ b/f5/bigip/mixins.py
@@ -29,11 +29,7 @@ import logging
 
 from f5.sdk_exception import F5SDKError
 from f5.sdk_exception import UnsupportedMethod
-
-
-class UtilError(F5SDKError):
-    """Raise this if command excecution returns an error."""
-    pass
+from f5.sdk_exception import UtilError
 
 
 class InvalidCommand(F5SDKError):

--- a/f5/bigip/tm/util/Bash.py
+++ b/f5/bigip/tm/util/Bash.py
@@ -27,8 +27,8 @@ REST Kind
 """
 
 from f5.bigip.mixins import CommandExecutionMixin
-from f5.bigip.mixins import UtilError
 from f5.bigip.resource import UnnamedResource
+from f5.sdk_exception import UtilError
 
 
 class Bash(UnnamedResource, CommandExecutionMixin):

--- a/f5/bigip/tm/util/test/functional/test_bash.py
+++ b/f5/bigip/tm/util/test/functional/test_bash.py
@@ -15,8 +15,8 @@
 
 import pytest
 
-from f5.bigip.mixins import UtilError
 from f5.bigip.resource import MissingRequiredCommandParameter
+from f5.sdk_exception import UtilError
 from icontrol.session import iControlUnexpectedHTTPError
 
 

--- a/f5/bigip/tm/util/test/functional/test_dig.py
+++ b/f5/bigip/tm/util/test/functional/test_dig.py
@@ -15,8 +15,8 @@
 
 import pytest
 
-from f5.bigip.mixins import UtilError
 from f5.bigip.resource import MissingRequiredCommandParameter
+from f5.sdk_exception import UtilError
 from icontrol.session import iControlUnexpectedHTTPError
 
 

--- a/f5/bigip/tm/util/test/functional/test_get_dossier.py
+++ b/f5/bigip/tm/util/test/functional/test_get_dossier.py
@@ -15,8 +15,8 @@
 
 import pytest
 
-from f5.bigip.mixins import UtilError
 from f5.bigip.resource import MissingRequiredCommandParameter
+from f5.sdk_exception import UtilError
 from icontrol.session import iControlUnexpectedHTTPError
 
 

--- a/f5/bigip/tm/util/test/functional/test_qkview.py
+++ b/f5/bigip/tm/util/test/functional/test_qkview.py
@@ -15,8 +15,8 @@
 
 import pytest
 
-from f5.bigip.mixins import UtilError
 from f5.bigip.resource import MissingRequiredCommandParameter
+from f5.sdk_exception import UtilError
 from icontrol.session import iControlUnexpectedHTTPError
 
 

--- a/f5/bigip/tm/util/test/functional/test_unix_ls.py
+++ b/f5/bigip/tm/util/test/functional/test_unix_ls.py
@@ -16,7 +16,7 @@
 from distutils.version import LooseVersion
 import pytest
 
-from f5.bigip.mixins import UtilError
+from f5.sdk_exception import UtilError
 from icontrol.session import iControlUnexpectedHTTPError
 import os
 from tempfile import NamedTemporaryFile

--- a/f5/bigip/tm/util/test/functional/test_unix_mv.py
+++ b/f5/bigip/tm/util/test/functional/test_unix_mv.py
@@ -15,7 +15,7 @@
 
 import pytest
 
-from f5.bigip.mixins import UtilError
+from f5.sdk_exception import UtilError
 import os
 from tempfile import NamedTemporaryFile
 

--- a/f5/bigip/tm/util/test/functional/test_unix_rm.py
+++ b/f5/bigip/tm/util/test/functional/test_unix_rm.py
@@ -15,7 +15,7 @@
 
 import pytest
 
-from f5.bigip.mixins import UtilError
+from f5.sdk_exception import UtilError
 import os
 from tempfile import NamedTemporaryFile
 


### PR DESCRIPTION
Problem:
Currently exception classes are scattered all over SDK, this will lead to unecessary duplication and confusion

Analysis:
Removed UtilError exception class from mixin.py, corrected related files

Tests:
Flake8