### PR TITLE
Exceptions move part3

### DIFF
--- a/f5/bigip/mixins.py
+++ b/f5/bigip/mixins.py
@@ -27,37 +27,11 @@ from six import iteritems
 
 import logging
 
-from f5.sdk_exception import F5SDKError
+from f5.sdk_exception import InvalidCommand
+from f5.sdk_exception import LazyAttributesRequired
 from f5.sdk_exception import UnsupportedMethod
+from f5.sdk_exception import UnsupportedTmosVersion
 from f5.sdk_exception import UtilError
-
-
-class InvalidCommand(F5SDKError):
-    """Raise this if command argument supplied is invalid."""
-    pass
-
-
-class UnsupportedTmosVersion(F5SDKError):
-    """Raise the error if a class of an API is instantiated,
-
-    on a TMOS version where API was not yet implemented/supported.
-    """
-    pass
-
-
-class EmptyContent(F5SDKError):
-    """Raise an error if the returned content size is 0"""
-    pass
-
-
-class MissingHttpHeader(F5SDKError):
-    """We raise this when the expected http header in response is missing"""
-    pass
-
-
-class LazyAttributesRequired(F5SDKError):
-    """Raised when a object accesses a lazy attribute that is not listed"""
-    pass
 
 
 class ToDictMixin(object):

--- a/f5/bigip/mixins.py
+++ b/f5/bigip/mixins.py
@@ -27,10 +27,10 @@ from six import iteritems
 
 import logging
 
-from f5.sdk_exception import InvalidCommand
 from f5.sdk_exception import EmptyContent
-from f5.sdk_exception import MissingHttpHeader
+from f5.sdk_exception import InvalidCommand
 from f5.sdk_exception import LazyAttributesRequired
+from f5.sdk_exception import MissingHttpHeader
 from f5.sdk_exception import UnsupportedMethod
 from f5.sdk_exception import UnsupportedTmosVersion
 from f5.sdk_exception import UtilError

--- a/f5/bigip/mixins.py
+++ b/f5/bigip/mixins.py
@@ -28,6 +28,8 @@ from six import iteritems
 import logging
 
 from f5.sdk_exception import InvalidCommand
+from f5.sdk_exception import EmptyContent
+from f5.sdk_exception import MissingHttpHeader
 from f5.sdk_exception import LazyAttributesRequired
 from f5.sdk_exception import UnsupportedMethod
 from f5.sdk_exception import UnsupportedTmosVersion
@@ -324,7 +326,7 @@ class AsmFileMixin(object):
                     writefh.write(response.content)
                 else:
                     error = "Invalid Content-Length value returned: %s ," \
-                            "the value should be reater than 0" % length
+                            "the value should be greater than 0" % length
                     raise EmptyContent(error)
 
     def _upload_file(self, filepathname, **kwargs):

--- a/f5/bigip/test/unit/test_mixins.py
+++ b/f5/bigip/test/unit/test_mixins.py
@@ -22,11 +22,11 @@ import struct
 
 from f5.bigip.mixins import AsmFileMixin
 from f5.bigip.mixins import CommandExecutionMixin
-from f5.bigip.mixins import EmptyContent
-from f5.bigip.mixins import MissingHttpHeader
 from f5.bigip.mixins import ToDictMixin
 from f5.bigip.mixins import UnsupportedMethod
 from f5.bigip.resource import Resource
+from f5.sdk_exception import EmptyContent
+from f5.sdk_exception import MissingHttpHeader
 
 from requests import HTTPError
 

--- a/f5/bigip/tm/asm/test/unit/test_file_transfer.py
+++ b/f5/bigip/tm/asm/test/unit/test_file_transfer.py
@@ -20,11 +20,11 @@ import requests_mock
 import struct
 
 from f5.bigip import ManagementRoot
-from f5.bigip.mixins import EmptyContent
-from f5.bigip.mixins import MissingHttpHeader
 from f5.bigip.resource import OrganizingCollection
 from f5.bigip.tm.asm.file_transfer import Downloads
 from f5.bigip.tm.asm.file_transfer import FileMustNotHaveDotISOExtension
+from f5.sdk_exception import EmptyContent
+from f5.sdk_exception import MissingHttpHeader
 
 from requests import HTTPError
 

--- a/f5/bigip/tm/asm/test/unit/test_file_transfer.py
+++ b/f5/bigip/tm/asm/test/unit/test_file_transfer.py
@@ -132,7 +132,7 @@ def test_404_response():
     try:
         dwnld.download_file('fakefile.txt')
     except HTTPError as err:
-        assert err.value.response.status_code == 404
+        assert err.response.status_code == 404
 
 
 def test_zero_content_length_header():
@@ -143,11 +143,11 @@ def test_zero_content_length_header():
         'mock://test.com/fakefile.txt', headers=header,
         status_code=200)
     dwnld = FakeDownload(session)
+    msg = "Invalid Content-Length value returned: 0 ,the value " \
+          "should be greater than 0"
     with pytest.raises(EmptyContent) as err:
         dwnld.download_file('fakefile.txt')
-        msg = "Invalid Content-Length value returned: %s ,the value " \
-              "should be greater than 0"
-        assert err.value.message == msg
+    assert err.value.message == msg
 
 
 def test_no_content_length_header():
@@ -157,7 +157,7 @@ def test_no_content_length_header():
         'mock://test.com/fakefile.txt', headers=header,
         status_code=200)
     dwnld = FakeDownload(session)
+    msg = "The Content-Length header is not present."
     with pytest.raises(MissingHttpHeader) as err:
         dwnld.download_file('fakefile.txt')
-        msg = "The Content-Length header is not present."
-        assert err.value.message == msg
+    assert err.value.message == msg

--- a/f5/bigip/tm/cm/test/functional/test_trust.py
+++ b/f5/bigip/tm/cm/test/functional/test_trust.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 #
 
-from f5.bigip.mixins import InvalidCommand
+from f5.sdk_exception import InvalidCommand
 import pytest
 
 

--- a/f5/bigip/tm/gtm/test/functional/test_topology.py
+++ b/f5/bigip/tm/gtm/test/functional/test_topology.py
@@ -17,11 +17,11 @@
 import pytest
 
 from distutils.version import LooseVersion
-from f5.bigip.mixins import UnsupportedTmosVersion
 from f5.bigip.resource import InvalidName
 from f5.bigip.resource import MissingRequiredCreationParameter
 from f5.bigip.resource import UnsupportedOperation
 from f5.bigip.tm.gtm.topology import Topology
+from f5.sdk_exception import UnsupportedTmosVersion
 from pytest import symbols
 from requests.exceptions import HTTPError
 

--- a/f5/bigip/tm/gtm/topology.py
+++ b/f5/bigip/tm/gtm/topology.py
@@ -27,12 +27,12 @@ REST Kind
     ``tm:gtm:topology:*``
 """
 from distutils.version import LooseVersion
-from f5.bigip.mixins import UnsupportedTmosVersion
 from f5.bigip.resource import Collection
 from f5.bigip.resource import InvalidName
 from f5.bigip.resource import Resource
 from f5.bigip.resource import UnsupportedOperation
 from f5.bigip.resource import URICreationCollision
+from f5.sdk_exception import UnsupportedTmosVersion
 
 
 from requests import HTTPError

--- a/f5/bigip/tm/ltm/test/functional/test_profile.py
+++ b/f5/bigip/tm/ltm/test/functional/test_profile.py
@@ -17,7 +17,7 @@ import copy
 import pytest
 
 from distutils.version import LooseVersion
-from f5.bigip.mixins import UnsupportedTmosVersion
+from f5.sdk_exception import UnsupportedTmosVersion
 from six import iteritems
 
 

--- a/f5/bigip/tm/sys/test/functional/test_ucs.py
+++ b/f5/bigip/tm/sys/test/functional/test_ucs.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 #
 
-from f5.bigip.mixins import LazyAttributesRequired
+from f5.sdk_exception import LazyAttributesRequired
 import pytest
 import time
 

--- a/f5/bigip/tm/sys/test/unit/test_ucs.py
+++ b/f5/bigip/tm/sys/test/unit/test_ucs.py
@@ -20,8 +20,8 @@ import mock
 import pytest
 
 from f5.bigip import ManagementRoot
-from f5.bigip.mixins import UnsupportedTmosVersion
 from f5.bigip.tm.sys.ucs import Ucs
+from f5.sdk_exception import UnsupportedTmosVersion
 
 
 @pytest.fixture

--- a/f5/utils/testutils/registrytools.py
+++ b/f5/utils/testutils/registrytools.py
@@ -16,10 +16,10 @@
 import logging
 from six import itervalues
 
-from f5.bigip.mixins import UnsupportedTmosVersion
 from f5.bigip.resource import Collection
 from f5.bigip.resource import OrganizingCollection
 from f5.bigip.tm.asm import Asm
+from f5.sdk_exception import UnsupportedTmosVersion
 
 
 AGENT_LB_DEL_ORDER = {'/mgmt/tm/ltm/virtual': 1,


### PR DESCRIPTION
Problem:
Currently exception classes are scattered all over SDK, this will lead to unecessary duplication and confusion

Analysis:
Removed rest of exceptions from mixins, corrected related files

Tests:
Flake8