### PR TITLE
Exceptions move part4

### DIFF
--- a/f5/bigip/resource.py
+++ b/f5/bigip/resource.py
@@ -104,17 +104,13 @@ except ImportError:
 from f5.bigip.mixins import LazyAttributeMixin
 from f5.bigip.mixins import ToDictMixin
 from f5.sdk_exception import F5SDKError
+from f5.sdk_exception import MissingRequiredCommandParameter
 from f5.sdk_exception import UnsupportedMethod
 from icontrol.exceptions import iControlUnexpectedHTTPError
 from requests.exceptions import HTTPError
 from six import iteritems
 from six import iterkeys
 from six import itervalues
-
-
-class MissingRequiredCommandParameter(F5SDKError):
-    """Various values MUST be provided to execute a command."""
-    pass
 
 
 class ExclusiveAttributesPresent(F5SDKError):

--- a/f5/bigip/shared/test/functional/test_bigip_failover_state.py
+++ b/f5/bigip/shared/test/functional/test_bigip_failover_state.py
@@ -14,7 +14,7 @@
 
 import pytest
 
-from f5.bigip.mixins import UnsupportedMethod
+from f5.sdk_exception import UnsupportedMethod
 
 
 @pytest.mark.skipif(pytest.config.getoption('--release') != '12.0.0',

--- a/f5/bigip/shared/test/functional/test_licensing.py
+++ b/f5/bigip/shared/test/functional/test_licensing.py
@@ -14,7 +14,7 @@
 
 import pytest
 
-from f5.bigip.mixins import UnsupportedMethod
+from f5.sdk_exception import UnsupportedMethod
 
 
 class TestActivation(object):

--- a/f5/bigip/test/unit/test_mixins.py
+++ b/f5/bigip/test/unit/test_mixins.py
@@ -23,10 +23,10 @@ import struct
 from f5.bigip.mixins import AsmFileMixin
 from f5.bigip.mixins import CommandExecutionMixin
 from f5.bigip.mixins import ToDictMixin
-from f5.bigip.mixins import UnsupportedMethod
 from f5.bigip.resource import Resource
 from f5.sdk_exception import EmptyContent
 from f5.sdk_exception import MissingHttpHeader
+from f5.sdk_exception import UnsupportedMethod
 
 from requests import HTTPError
 

--- a/f5/bigip/test/unit/test_resource.py
+++ b/f5/bigip/test/unit/test_resource.py
@@ -31,7 +31,6 @@ from f5.bigip.resource import GenerationMismatch
 from f5.bigip.resource import InvalidForceType
 from f5.bigip.resource import InvalidResource
 from f5.bigip.resource import KindTypeMismatch
-from f5.bigip.resource import MissingRequiredCommandParameter
 from f5.bigip.resource import MissingRequiredCreationParameter
 from f5.bigip.resource import MissingRequiredReadParameter
 from f5.bigip.resource import OrganizingCollection
@@ -50,6 +49,7 @@ from f5.bigip.tm.cm.sync_status import Sync_Status
 from f5.bigip.tm.ltm.virtual import Policies_s
 from f5.bigip.tm.ltm.virtual import Profiles_s
 from f5.bigip.tm.ltm.virtual import Virtual
+from f5.sdk_exception import MissingRequiredCommandParameter
 from f5.sdk_exception import UnsupportedMethod
 from icontrol.exceptions import iControlUnexpectedHTTPError
 

--- a/f5/bigip/tm/auth/test/unit/test_password_policy.py
+++ b/f5/bigip/tm/auth/test/unit/test_password_policy.py
@@ -16,8 +16,8 @@
 import mock
 import pytest
 
-from f5.bigip.mixins import UnsupportedMethod
 from f5.bigip.tm.auth.password_policy import Password_Policy
+from f5.sdk_exception import UnsupportedMethod
 
 
 @pytest.fixture

--- a/f5/bigip/tm/ltm/auth.py
+++ b/f5/bigip/tm/ltm/auth.py
@@ -25,10 +25,10 @@ GUI Path
 REST Kind
     ``tm:ltm:auth:*``
 """
-from f5.bigip.mixins import UnsupportedMethod
 from f5.bigip.resource import Collection
 from f5.bigip.resource import OrganizingCollection
 from f5.bigip.resource import Resource
+from f5.sdk_exception import UnsupportedMethod
 
 
 class Auth(OrganizingCollection):

--- a/f5/bigip/tm/shared/licensing.py
+++ b/f5/bigip/tm/shared/licensing.py
@@ -26,9 +26,9 @@ REST Kind
     ``tm:shared:licensing:*``
 """
 
-from f5.bigip.mixins import UnsupportedMethod
 from f5.bigip.resource import PathElement
 from f5.bigip.resource import UnnamedResource
+from f5.sdk_exception import UnsupportedMethod
 
 
 class Licensing(PathElement):

--- a/f5/bigip/tm/sys/software/test/unit/test_update.py
+++ b/f5/bigip/tm/sys/software/test/unit/test_update.py
@@ -17,8 +17,8 @@ import mock
 import pytest
 
 
-from f5.bigip.mixins import UnsupportedMethod
 from f5.bigip.tm.sys.software.update import Update
+from f5.sdk_exception import UnsupportedMethod
 
 
 @pytest.fixture

--- a/f5/bigip/tm/sys/test/unit/test_dns.py
+++ b/f5/bigip/tm/sys/test/unit/test_dns.py
@@ -16,8 +16,9 @@
 import mock
 import pytest
 
-from f5.bigip.mixins import UnsupportedMethod
+
 from f5.bigip.tm.sys.dns import Dns
+from f5.sdk_exception import UnsupportedMethod
 
 
 @pytest.fixture

--- a/f5/bigip/tm/sys/test/unit/test_httpd.py
+++ b/f5/bigip/tm/sys/test/unit/test_httpd.py
@@ -16,8 +16,8 @@
 import mock
 import pytest
 
-from f5.bigip.mixins import UnsupportedMethod
 from f5.bigip.tm.sys.httpd import Httpd
+from f5.sdk_exception import UnsupportedMethod
 
 
 @pytest.fixture

--- a/f5/bigip/tm/sys/test/unit/test_performance.py
+++ b/f5/bigip/tm/sys/test/unit/test_performance.py
@@ -16,9 +16,9 @@
 import mock
 import pytest
 
-from f5.bigip.mixins import UnsupportedMethod
 from f5.bigip.resource import UnsupportedOperation
 from f5.bigip.tm.sys.performance import Performances
+from f5.sdk_exception import UnsupportedMethod
 
 
 @pytest.fixture

--- a/f5/bigip/tm/sys/test/unit/test_snmp.py
+++ b/f5/bigip/tm/sys/test/unit/test_snmp.py
@@ -16,11 +16,11 @@
 import mock
 import pytest
 
-from f5.bigip.mixins import UnsupportedMethod
 from f5.bigip.resource import UnsupportedOperation
 from f5.bigip.tm.sys.snmp import Snmp
 from f5.bigip.tm.sys.snmp import Trap
 from f5.bigip.tm.sys.snmp import User
+from f5.sdk_exception import UnsupportedMethod
 
 
 @pytest.fixture

--- a/f5/bigip/tm/sys/test/unit/test_sshd.py
+++ b/f5/bigip/tm/sys/test/unit/test_sshd.py
@@ -16,8 +16,8 @@
 import mock
 import pytest
 
-from f5.bigip.mixins import UnsupportedMethod
 from f5.bigip.tm.sys.sshd import Sshd
+from f5.sdk_exception import UnsupportedMethod
 
 
 @pytest.fixture

--- a/f5/bigip/tm/sys/test/unit/test_syslog.py
+++ b/f5/bigip/tm/sys/test/unit/test_syslog.py
@@ -16,8 +16,8 @@
 import mock
 import pytest
 
-from f5.bigip.mixins import UnsupportedMethod
 from f5.bigip.tm.sys.syslog import Syslog
+from f5.sdk_exception import UnsupportedMethod
 
 
 @pytest.fixture

--- a/f5/bigip/tm/util/test/functional/test_bash.py
+++ b/f5/bigip/tm/util/test/functional/test_bash.py
@@ -15,7 +15,7 @@
 
 import pytest
 
-from f5.bigip.resource import MissingRequiredCommandParameter
+from f5.sdk_exception import MissingRequiredCommandParameter
 from f5.sdk_exception import UtilError
 from icontrol.session import iControlUnexpectedHTTPError
 

--- a/f5/bigip/tm/util/test/functional/test_clientssl_ciphers.py
+++ b/f5/bigip/tm/util/test/functional/test_clientssl_ciphers.py
@@ -16,7 +16,7 @@
 import pytest
 
 from distutils.version import LooseVersion
-from f5.bigip.resource import MissingRequiredCommandParameter
+from f5.sdk_exception import MissingRequiredCommandParameter
 from icontrol.session import iControlUnexpectedHTTPError
 
 

--- a/f5/bigip/tm/util/test/functional/test_dig.py
+++ b/f5/bigip/tm/util/test/functional/test_dig.py
@@ -15,7 +15,7 @@
 
 import pytest
 
-from f5.bigip.resource import MissingRequiredCommandParameter
+from f5.sdk_exception import MissingRequiredCommandParameter
 from f5.sdk_exception import UtilError
 from icontrol.session import iControlUnexpectedHTTPError
 

--- a/f5/bigip/tm/util/test/functional/test_get_dossier.py
+++ b/f5/bigip/tm/util/test/functional/test_get_dossier.py
@@ -15,7 +15,7 @@
 
 import pytest
 
-from f5.bigip.resource import MissingRequiredCommandParameter
+from f5.sdk_exception import MissingRequiredCommandParameter
 from f5.sdk_exception import UtilError
 from icontrol.session import iControlUnexpectedHTTPError
 

--- a/f5/bigip/tm/util/test/functional/test_qkview.py
+++ b/f5/bigip/tm/util/test/functional/test_qkview.py
@@ -15,7 +15,7 @@
 
 import pytest
 
-from f5.bigip.resource import MissingRequiredCommandParameter
+from f5.sdk_exception import MissingRequiredCommandParameter
 from f5.sdk_exception import UtilError
 from icontrol.session import iControlUnexpectedHTTPError
 

--- a/f5/bigip/tm/util/test/functional/test_serverssl_ciphers.py
+++ b/f5/bigip/tm/util/test/functional/test_serverssl_ciphers.py
@@ -16,7 +16,7 @@
 import pytest
 
 from distutils.version import LooseVersion
-from f5.bigip.resource import MissingRequiredCommandParameter
+from f5.sdk_exception import MissingRequiredCommandParameter
 from icontrol.session import iControlUnexpectedHTTPError
 
 

--- a/f5/bigip/tm/util/test/unit/test_clientssl_ciphers.py
+++ b/f5/bigip/tm/util/test/unit/test_clientssl_ciphers.py
@@ -17,8 +17,8 @@ import mock
 import pytest
 
 from f5.bigip import ManagementRoot
-from f5.bigip.resource import MissingRequiredCommandParameter
 from f5.bigip.tm.util.Clientssl_Ciphers import Clientssl_Ciphers
+from f5.sdk_exception import MissingRequiredCommandParameter
 
 
 @pytest.fixture

--- a/f5/bigip/tm/util/test/unit/test_serverssl_ciphers.py
+++ b/f5/bigip/tm/util/test/unit/test_serverssl_ciphers.py
@@ -17,8 +17,8 @@ import mock
 import pytest
 
 from f5.bigip import ManagementRoot
-from f5.bigip.resource import MissingRequiredCommandParameter
 from f5.bigip.tm.util.Serverssl_Ciphers import Serverssl_Ciphers
+from f5.sdk_exception import MissingRequiredCommandParameter
 
 
 @pytest.fixture

--- a/f5/bigiq/tm/sys/software/test/unit/test_update.py
+++ b/f5/bigiq/tm/sys/software/test/unit/test_update.py
@@ -17,8 +17,8 @@ import mock
 import pytest
 
 
-from f5.bigip.mixins import UnsupportedMethod
 from f5.bigip.tm.sys.software.update import Update
+from f5.sdk_exception import UnsupportedMethod
 
 
 @pytest.fixture

--- a/f5/bigiq/tm/sys/test/unit/test_dns.py
+++ b/f5/bigiq/tm/sys/test/unit/test_dns.py
@@ -16,8 +16,8 @@
 import mock
 import pytest
 
-from f5.bigip.mixins import UnsupportedMethod
 from f5.bigip.tm.sys.dns import Dns
+from f5.sdk_exception import UnsupportedMethod
 
 
 @pytest.fixture

--- a/f5/bigiq/tm/sys/test/unit/test_httpd.py
+++ b/f5/bigiq/tm/sys/test/unit/test_httpd.py
@@ -16,8 +16,8 @@
 import mock
 import pytest
 
-from f5.bigip.mixins import UnsupportedMethod
 from f5.bigip.tm.sys.httpd import Httpd
+from f5.sdk_exception import UnsupportedMethod
 
 
 @pytest.fixture

--- a/f5/bigiq/tm/sys/test/unit/test_sshd.py
+++ b/f5/bigiq/tm/sys/test/unit/test_sshd.py
@@ -16,8 +16,8 @@
 import mock
 import pytest
 
-from f5.bigip.mixins import UnsupportedMethod
 from f5.bigip.tm.sys.sshd import Sshd
+from f5.sdk_exception import UnsupportedMethod
 
 
 @pytest.fixture

--- a/f5/iworkflow/shared/identified_devices/config/test/unit/test_device_info.py
+++ b/f5/iworkflow/shared/identified_devices/config/test/unit/test_device_info.py
@@ -16,9 +16,9 @@
 import mock
 import pytest
 
-from f5.bigip.mixins import UnsupportedMethod
 from f5.iworkflow.shared.identified_devices.config.device_info \
     import Device_Info
+from f5.sdk_exception import UnsupportedMethod
 
 
 @pytest.fixture


### PR DESCRIPTION
Problem:
Currently exception classes are scattered all over SDK, this will lead to unecessary duplication and confusion

Analysis:
Corrected UnsupportedMethod imports, removed MissingRequiredCommandParameter from resource and corrected imports whenever needed

Tests:
Flake8