### PR TITLE
Moving Exceptions Part 5

### DIFF
--- a/f5/bigip/resource.py
+++ b/f5/bigip/resource.py
@@ -103,47 +103,19 @@ except ImportError:
 
 from f5.bigip.mixins import LazyAttributeMixin
 from f5.bigip.mixins import ToDictMixin
+from f5.sdk_exception import DeviceProvidesIncompatibleKey
+from f5.sdk_exception import ExclusiveAttributesPresent
 from f5.sdk_exception import F5SDKError
+from f5.sdk_exception import InvalidResource
+from f5.sdk_exception import KindTypeMismatch
 from f5.sdk_exception import MissingRequiredCommandParameter
+from f5.sdk_exception import RequestParamKwargCollision
 from f5.sdk_exception import UnsupportedMethod
 from icontrol.exceptions import iControlUnexpectedHTTPError
 from requests.exceptions import HTTPError
 from six import iteritems
 from six import iterkeys
 from six import itervalues
-
-
-class ExclusiveAttributesPresent(F5SDKError):
-    """Raises this when exclusive attributes are present."""
-    pass
-
-
-class MissingUpdateParameter(F5SDKError):
-    """Raises this when update requires specific parameters together."""
-    pass
-
-
-class RequestParamKwargCollision(F5SDKError):
-    pass
-
-
-class KindTypeMismatch(F5SDKError):
-    """Raise this when server JSON keys are incorrect for the Resource type."""
-    pass
-
-
-class DeviceProvidesIncompatibleKey(F5SDKError):
-    """Raise this when server JSON keys are incompatible with Python."""
-    pass
-
-
-class InvalidResource(F5SDKError):
-    """Raise this when a caller tries to invoke an unsupported CRUDL op.
-
-    All resources support `refresh` and `raw`.
-    Only `Resource`'s support `load`, `create`, `update`, and `delete`.
-    """
-    pass
 
 
 class MissingRequiredCreationParameter(F5SDKError):

--- a/f5/bigip/test/unit/test_resource.py
+++ b/f5/bigip/test/unit/test_resource.py
@@ -25,17 +25,12 @@ from f5.bigip.resource import AsmResource
 from f5.bigip.resource import AttemptedMutationOfReadOnly
 from f5.bigip.resource import BooleansToReduceHaveSameValue
 from f5.bigip.resource import Collection
-from f5.bigip.resource import DeviceProvidesIncompatibleKey
-from f5.bigip.resource import ExclusiveAttributesPresent
 from f5.bigip.resource import GenerationMismatch
 from f5.bigip.resource import InvalidForceType
-from f5.bigip.resource import InvalidResource
-from f5.bigip.resource import KindTypeMismatch
 from f5.bigip.resource import MissingRequiredCreationParameter
 from f5.bigip.resource import MissingRequiredReadParameter
 from f5.bigip.resource import OrganizingCollection
 from f5.bigip.resource import PathElement
-from f5.bigip.resource import RequestParamKwargCollision
 from f5.bigip.resource import Resource
 from f5.bigip.resource import ResourceBase
 from f5.bigip.resource import Stats
@@ -49,7 +44,12 @@ from f5.bigip.tm.cm.sync_status import Sync_Status
 from f5.bigip.tm.ltm.virtual import Policies_s
 from f5.bigip.tm.ltm.virtual import Profiles_s
 from f5.bigip.tm.ltm.virtual import Virtual
+from f5.sdk_exception import DeviceProvidesIncompatibleKey
+from f5.sdk_exception import ExclusiveAttributesPresent
+from f5.sdk_exception import InvalidResource
+from f5.sdk_exception import KindTypeMismatch
 from f5.sdk_exception import MissingRequiredCommandParameter
+from f5.sdk_exception import RequestParamKwargCollision
 from f5.sdk_exception import UnsupportedMethod
 from icontrol.exceptions import iControlUnexpectedHTTPError
 

--- a/f5/bigip/tm/ltm/profile.py
+++ b/f5/bigip/tm/ltm/profile.py
@@ -28,10 +28,10 @@ REST Kind
 
 
 from f5.bigip.resource import Collection
-from f5.bigip.resource import MissingUpdateParameter
 from f5.bigip.resource import OrganizingCollection
 from f5.bigip.resource import Resource
 from f5.bigip.resource import UnsupportedOperation
+from f5.sdk_exception import MissingUpdateParameter
 
 
 class Profile(OrganizingCollection):

--- a/f5/bigip/tm/ltm/test/unit/test_profile_ocsp.py
+++ b/f5/bigip/tm/ltm/test/unit/test_profile_ocsp.py
@@ -16,8 +16,8 @@
 import mock
 import pytest
 
-from f5.bigip.resource import MissingUpdateParameter
 from f5.bigip.tm.ltm.profile import Ocsp_Stapling_Params
+from f5.sdk_exception import MissingUpdateParameter
 
 
 @pytest.fixture

--- a/f5/bigip/tm/net/vlan.py
+++ b/f5/bigip/tm/net/vlan.py
@@ -29,9 +29,9 @@ REST Kind
 
 from f5.bigip.mixins import ExclusiveAttributesMixin
 from f5.bigip.resource import Collection
-from f5.bigip.resource import MissingUpdateParameter
 from f5.bigip.resource import Resource
 from f5.sdk_exception import F5SDKError
+from f5.sdk_exception import MissingUpdateParameter
 
 from distutils.version import LooseVersion
 

--- a/f5/bigip/tm/sys/test/unit/test_application.py
+++ b/f5/bigip/tm/sys/test/unit/test_application.py
@@ -18,7 +18,6 @@ import pytest
 from requests import HTTPError
 
 from f5.bigip import ManagementRoot
-from f5.bigip.resource import KindTypeMismatch
 from f5.bigip.resource import MissingRequiredCreationParameter
 from f5.bigip.resource import MissingRequiredReadParameter
 from f5.bigip.resource import URICreationCollision
@@ -26,6 +25,7 @@ from f5.bigip.tm.sys.application import Aplscript
 from f5.bigip.tm.sys.application import Customstat
 from f5.bigip.tm.sys.application import Service
 from f5.bigip.tm.sys.application import Template
+from f5.sdk_exception import KindTypeMismatch
 
 
 KIND_MISMATCH = {

--- a/f5/bigip/tm/sys/test/unit/test_failover.py
+++ b/f5/bigip/tm/sys/test/unit/test_failover.py
@@ -13,8 +13,8 @@
 # limitations under the License.
 #
 
-from f5.bigip.resource import ExclusiveAttributesPresent
 from f5.bigip.tm.sys import Failover
+from f5.sdk_exception import ExclusiveAttributesPresent
 
 import mock
 import pytest


### PR DESCRIPTION
Fixes: #922

Problem: Currently exception classes are scattered all over SDK, this will lead to unecessary duplication and confusion. Vlan tests will fail when there was a specified vlan already and if 1.1 interface is in use.

Analysis:
Removed the following exceptions from resource.py:

*ExclusiveAttributesPresent
*MissingUpdateParameter
*RequestParamKwargCollision
*KindTypeMismatch
*DeviceProvidesIncompatibleKey
*InvalidResource

corrected imports whenever needed. Corrected vlan tests to accommodate existence of other vlans.

Tests:
Flake8
Unit
Functional