### PR TITLE
Exceptions move part6

### DIFF
--- a/f5/bigip/resource.py
+++ b/f5/bigip/resource.py
@@ -106,10 +106,14 @@ from f5.bigip.mixins import ToDictMixin
 from f5.sdk_exception import DeviceProvidesIncompatibleKey
 from f5.sdk_exception import ExclusiveAttributesPresent
 from f5.sdk_exception import F5SDKError
+from f5.sdk_exception import GenerationMismatch
+from f5.sdk_exception import InvalidForceType
 from f5.sdk_exception import InvalidResource
 from f5.sdk_exception import KindTypeMismatch
 from f5.sdk_exception import MissingRequiredCommandParameter
+from f5.sdk_exception import MissingRequiredReadParameter
 from f5.sdk_exception import RequestParamKwargCollision
+from f5.sdk_exception import UnregisteredKind
 from f5.sdk_exception import UnsupportedMethod
 from icontrol.exceptions import iControlUnexpectedHTTPError
 from requests.exceptions import HTTPError
@@ -120,31 +124,6 @@ from six import itervalues
 
 class MissingRequiredCreationParameter(F5SDKError):
     """Various values MUST be provided to create different Resources."""
-    pass
-
-
-class MissingRequiredReadParameter(F5SDKError):
-    """Various values MUST be provided to refresh some Resources."""
-    pass
-
-
-class UnregisteredKind(F5SDKError):
-    """The returned server JSON `kind` key wasn't expected by this Resource."""
-    pass
-
-
-class GenerationMismatch(F5SDKError):
-    """The server reported BIG-IP® is not the expacted value."""
-    pass
-
-
-class InvalidForceType(ValueError):
-    """Must be of type bool."""
-    pass
-
-
-class InvalidName(ValueError):
-    """Raised during creationm when a given resource name is invalid"""
     pass
 
 

--- a/f5/bigip/test/unit/test_resource.py
+++ b/f5/bigip/test/unit/test_resource.py
@@ -25,17 +25,13 @@ from f5.bigip.resource import AsmResource
 from f5.bigip.resource import AttemptedMutationOfReadOnly
 from f5.bigip.resource import BooleansToReduceHaveSameValue
 from f5.bigip.resource import Collection
-from f5.bigip.resource import GenerationMismatch
-from f5.bigip.resource import InvalidForceType
 from f5.bigip.resource import MissingRequiredCreationParameter
-from f5.bigip.resource import MissingRequiredReadParameter
 from f5.bigip.resource import OrganizingCollection
 from f5.bigip.resource import PathElement
 from f5.bigip.resource import Resource
 from f5.bigip.resource import ResourceBase
 from f5.bigip.resource import Stats
 from f5.bigip.resource import UnnamedResource
-from f5.bigip.resource import UnregisteredKind
 from f5.bigip.resource import UnsupportedOperation
 from f5.bigip.resource import URICreationCollision
 from f5.bigip.tm.asm.signature_sets import Signature_Set
@@ -46,10 +42,14 @@ from f5.bigip.tm.ltm.virtual import Profiles_s
 from f5.bigip.tm.ltm.virtual import Virtual
 from f5.sdk_exception import DeviceProvidesIncompatibleKey
 from f5.sdk_exception import ExclusiveAttributesPresent
+from f5.sdk_exception import GenerationMismatch
+from f5.sdk_exception import InvalidForceType
 from f5.sdk_exception import InvalidResource
 from f5.sdk_exception import KindTypeMismatch
 from f5.sdk_exception import MissingRequiredCommandParameter
+from f5.sdk_exception import MissingRequiredReadParameter
 from f5.sdk_exception import RequestParamKwargCollision
+from f5.sdk_exception import UnregisteredKind
 from f5.sdk_exception import UnsupportedMethod
 from icontrol.exceptions import iControlUnexpectedHTTPError
 

--- a/f5/bigip/tm/gtm/test/functional/test_listener.py
+++ b/f5/bigip/tm/gtm/test/functional/test_listener.py
@@ -18,9 +18,9 @@ import pytest
 
 from distutils.version import LooseVersion
 from f5.bigip.resource import MissingRequiredCreationParameter
-from f5.bigip.resource import MissingRequiredReadParameter
 from f5.bigip.resource import UnsupportedOperation
 from f5.bigip.tm.gtm.listener import Listener
+from f5.sdk_exception import MissingRequiredReadParameter
 from pytest import symbols
 from requests.exceptions import HTTPError
 from six import iteritems

--- a/f5/bigip/tm/gtm/test/functional/test_topology.py
+++ b/f5/bigip/tm/gtm/test/functional/test_topology.py
@@ -17,10 +17,10 @@
 import pytest
 
 from distutils.version import LooseVersion
-from f5.bigip.resource import InvalidName
 from f5.bigip.resource import MissingRequiredCreationParameter
 from f5.bigip.resource import UnsupportedOperation
 from f5.bigip.tm.gtm.topology import Topology
+from f5.sdk_exception import InvalidName
 from f5.sdk_exception import UnsupportedTmosVersion
 from pytest import symbols
 from requests.exceptions import HTTPError

--- a/f5/bigip/tm/gtm/test/unit/test_topology.py
+++ b/f5/bigip/tm/gtm/test/unit/test_topology.py
@@ -16,11 +16,11 @@
 import pytest
 
 from f5.bigip import ManagementRoot
-from f5.bigip.resource import InvalidName
 from f5.bigip.resource import MissingRequiredCreationParameter
 from f5.bigip.resource import UnsupportedOperation
 from f5.bigip.tm import Gtm
 from f5.bigip.tm.gtm.topology import Topology
+from f5.sdk_exception import InvalidName
 
 
 @pytest.fixture

--- a/f5/bigip/tm/gtm/topology.py
+++ b/f5/bigip/tm/gtm/topology.py
@@ -28,10 +28,10 @@ REST Kind
 """
 from distutils.version import LooseVersion
 from f5.bigip.resource import Collection
-from f5.bigip.resource import InvalidName
 from f5.bigip.resource import Resource
 from f5.bigip.resource import UnsupportedOperation
 from f5.bigip.resource import URICreationCollision
+from f5.sdk_exception import InvalidName
 from f5.sdk_exception import UnsupportedTmosVersion
 
 

--- a/f5/bigip/tm/ltm/test/functional/test_virtual.py
+++ b/f5/bigip/tm/ltm/test/functional/test_virtual.py
@@ -15,7 +15,7 @@
 
 from distutils.version import LooseVersion
 from f5.bigip.resource import MissingRequiredCreationParameter
-from f5.bigip.resource import MissingRequiredReadParameter
+from f5.sdk_exception import MissingRequiredReadParameter
 from six import iteritems
 
 import copy

--- a/f5/bigip/tm/sys/test/unit/test_application.py
+++ b/f5/bigip/tm/sys/test/unit/test_application.py
@@ -19,13 +19,13 @@ from requests import HTTPError
 
 from f5.bigip import ManagementRoot
 from f5.bigip.resource import MissingRequiredCreationParameter
-from f5.bigip.resource import MissingRequiredReadParameter
 from f5.bigip.resource import URICreationCollision
 from f5.bigip.tm.sys.application import Aplscript
 from f5.bigip.tm.sys.application import Customstat
 from f5.bigip.tm.sys.application import Service
 from f5.bigip.tm.sys.application import Template
 from f5.sdk_exception import KindTypeMismatch
+from f5.sdk_exception import MissingRequiredReadParameter
 
 
 KIND_MISMATCH = {

--- a/f5/bigip/tm/vcmp/test/functional/test_guest.py
+++ b/f5/bigip/tm/vcmp/test/functional/test_guest.py
@@ -14,9 +14,9 @@
 #
 
 from f5.bigip.resource import MissingRequiredCreationParameter
-from f5.bigip.resource import MissingRequiredReadParameter
 from f5.bigip.tm.vcmp.guest import DisallowedCreationParameter
 from f5.bigip.tm.vcmp.guest import DisallowedReadParameter
+from f5.sdk_exception import MissingRequiredReadParameter
 from icontrol.session import iControlUnexpectedHTTPError
 from six import iteritems
 

--- a/f5/sdk_exception.py
+++ b/f5/sdk_exception.py
@@ -86,7 +86,7 @@ class InvalidForceType(ValueError):
 
 
 class InvalidName(ValueError):
-    """Raised during creationm when a given resource name is invalid."""
+    """Raised during creation when a given resource name is invalid."""
     pass
 
 


### PR DESCRIPTION
Problem:
Currently exception classes are scattered all over SDK, this will lead to unecessary duplication and confusion

Analysis:
Removed the following classes from resource.py:

UnregisteredKind
MissingRequiredReadParameter
GenerationMismatch
InvalidForceType
InvalidName

Corrected coresponding import statements

Tests:
Flake8