### PR TITLE
Exceptions move part7

### DIFF
--- a/f5/bigip/resource.py
+++ b/f5/bigip/resource.py
@@ -103,6 +103,8 @@ except ImportError:
 
 from f5.bigip.mixins import LazyAttributeMixin
 from f5.bigip.mixins import ToDictMixin
+from f5.sdk_exception import AttemptedMutationOfReadOnly
+from f5.sdk_exception import BooleansToReduceHaveSameValue
 from f5.sdk_exception import DeviceProvidesIncompatibleKey
 from f5.sdk_exception import ExclusiveAttributesPresent
 from f5.sdk_exception import F5SDKError
@@ -134,16 +136,6 @@ class URICreationCollision(F5SDKError):
 
 class UnsupportedOperation(F5SDKError):
     """Object does not support the method that was called."""
-    pass
-
-
-class BooleansToReduceHaveSameValue(F5SDKError):
-    '''Dict contains two keys with same boolean value.'''
-    pass
-
-
-class AttemptedMutationOfReadOnly(F5SDKError):
-    """Read only parameters cannot be set."""
     pass
 
 

--- a/f5/bigip/test/unit/test_resource.py
+++ b/f5/bigip/test/unit/test_resource.py
@@ -22,8 +22,6 @@ import requests
 
 from f5.bigip.resource import _missing_required_parameters
 from f5.bigip.resource import AsmResource
-from f5.bigip.resource import AttemptedMutationOfReadOnly
-from f5.bigip.resource import BooleansToReduceHaveSameValue
 from f5.bigip.resource import Collection
 from f5.bigip.resource import MissingRequiredCreationParameter
 from f5.bigip.resource import OrganizingCollection
@@ -40,6 +38,8 @@ from f5.bigip.tm.cm.sync_status import Sync_Status
 from f5.bigip.tm.ltm.virtual import Policies_s
 from f5.bigip.tm.ltm.virtual import Profiles_s
 from f5.bigip.tm.ltm.virtual import Virtual
+from f5.sdk_exception import AttemptedMutationOfReadOnly
+from f5.sdk_exception import BooleansToReduceHaveSameValue
 from f5.sdk_exception import DeviceProvidesIncompatibleKey
 from f5.sdk_exception import ExclusiveAttributesPresent
 from f5.sdk_exception import GenerationMismatch

--- a/f5/bigip/tm/asm/test/functional/test_policies.py
+++ b/f5/bigip/tm/asm/test/functional/test_policies.py
@@ -15,7 +15,6 @@
 
 import copy
 from distutils.version import LooseVersion
-from f5.bigip.resource import AttemptedMutationOfReadOnly
 from f5.bigip.resource import UnsupportedMethod
 from f5.bigip.resource import UnsupportedOperation
 from f5.bigip.tm.asm.policies import Blocking_Settings
@@ -58,6 +57,7 @@ from f5.bigip.tm.asm.policies import Whitelist_Ip
 from f5.bigip.tm.asm.policies import Whitelist_Ips_s
 from f5.bigip.tm.asm.policies import Xml_Profile
 from f5.bigip.tm.asm.policies import Xml_Profiles_s
+from f5.sdk_exception import AttemptedMutationOfReadOnly
 
 import pytest
 from requests.exceptions import HTTPError

--- a/f5/bigip/tm/sys/test/functional/test_failover.py
+++ b/f5/bigip/tm/sys/test/functional/test_failover.py
@@ -13,9 +13,9 @@
 # limitations under the License.
 #
 
-from f5.bigip.resource import BooleansToReduceHaveSameValue
 from f5.multi_device.utils import get_device_info
 from f5.multi_device.utils import pollster
+from f5.sdk_exception import BooleansToReduceHaveSameValue
 
 import pytest
 


### PR DESCRIPTION
Problem:
Currently exception classes are scattered all over SDK, this will lead to unecessary duplication and confusion

Analysis:
Removed the following classes from resource.py:

AttemptedMutationOfReadOnly
BooleansToReduceHaveSameValue

Corrected coresponding import statements

Tests:
Flake8