### PR TITLE
Exceptions part8

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 #
 
-from f5.bigip.resource import UnsupportedOperation
+from f5.sdk_exception import UnsupportedOperation
 from f5.utils.testutils.registrytools import register_device
 from icontrol.session import iControlRESTSession
 import logging

--- a/f5/bigip/resource.py
+++ b/f5/bigip/resource.py
@@ -107,36 +107,23 @@ from f5.sdk_exception import AttemptedMutationOfReadOnly
 from f5.sdk_exception import BooleansToReduceHaveSameValue
 from f5.sdk_exception import DeviceProvidesIncompatibleKey
 from f5.sdk_exception import ExclusiveAttributesPresent
-from f5.sdk_exception import F5SDKError
 from f5.sdk_exception import GenerationMismatch
 from f5.sdk_exception import InvalidForceType
 from f5.sdk_exception import InvalidResource
 from f5.sdk_exception import KindTypeMismatch
 from f5.sdk_exception import MissingRequiredCommandParameter
+from f5.sdk_exception import MissingRequiredCreationParameter
 from f5.sdk_exception import MissingRequiredReadParameter
 from f5.sdk_exception import RequestParamKwargCollision
 from f5.sdk_exception import UnregisteredKind
 from f5.sdk_exception import UnsupportedMethod
+from f5.sdk_exception import UnsupportedOperation
+from f5.sdk_exception import URICreationCollision
 from icontrol.exceptions import iControlUnexpectedHTTPError
 from requests.exceptions import HTTPError
 from six import iteritems
 from six import iterkeys
 from six import itervalues
-
-
-class MissingRequiredCreationParameter(F5SDKError):
-    """Various values MUST be provided to create different Resources."""
-    pass
-
-
-class URICreationCollision(F5SDKError):
-    """self._meta_data['uri'] can only be assigned once. In create or load."""
-    pass
-
-
-class UnsupportedOperation(F5SDKError):
-    """Object does not support the method that was called."""
-    pass
 
 
 def _missing_required_parameters(rqset, **kwargs):

--- a/f5/bigip/resource.py
+++ b/f5/bigip/resource.py
@@ -103,6 +103,8 @@ except ImportError:
 
 from f5.bigip.mixins import LazyAttributeMixin
 from f5.bigip.mixins import ToDictMixin
+from f5.sdk_exception import AttemptedMutationOfReadOnly
+from f5.sdk_exception import BooleansToReduceHaveSameValue
 from f5.sdk_exception import DeviceProvidesIncompatibleKey
 from f5.sdk_exception import ExclusiveAttributesPresent
 from f5.sdk_exception import F5SDKError
@@ -134,16 +136,6 @@ class URICreationCollision(F5SDKError):
 
 class UnsupportedOperation(F5SDKError):
     """Object does not support the method that was called."""
-    pass
-
-
-class BooleansToReduceHaveSameValue(F5SDKError):
-    '''Dict contains two keys with same boolean value.'''
-    pass
-
-
-class AttemptedMutationOfReadOnly(F5SDKError):
-    """Read only parameters cannot be set."""
     pass
 
 

--- a/f5/bigip/test/unit/test_resource.py
+++ b/f5/bigip/test/unit/test_resource.py
@@ -23,15 +23,12 @@ import requests
 from f5.bigip.resource import _missing_required_parameters
 from f5.bigip.resource import AsmResource
 from f5.bigip.resource import Collection
-from f5.bigip.resource import MissingRequiredCreationParameter
 from f5.bigip.resource import OrganizingCollection
 from f5.bigip.resource import PathElement
 from f5.bigip.resource import Resource
 from f5.bigip.resource import ResourceBase
 from f5.bigip.resource import Stats
 from f5.bigip.resource import UnnamedResource
-from f5.bigip.resource import UnsupportedOperation
-from f5.bigip.resource import URICreationCollision
 from f5.bigip.tm.asm.signature_sets import Signature_Set
 from f5.bigip.tm.asm.tasks import Check_Signature
 from f5.bigip.tm.cm.sync_status import Sync_Status
@@ -47,10 +44,13 @@ from f5.sdk_exception import InvalidForceType
 from f5.sdk_exception import InvalidResource
 from f5.sdk_exception import KindTypeMismatch
 from f5.sdk_exception import MissingRequiredCommandParameter
+from f5.sdk_exception import MissingRequiredCreationParameter
 from f5.sdk_exception import MissingRequiredReadParameter
 from f5.sdk_exception import RequestParamKwargCollision
 from f5.sdk_exception import UnregisteredKind
 from f5.sdk_exception import UnsupportedMethod
+from f5.sdk_exception import UnsupportedOperation
+from f5.sdk_exception import URICreationCollision
 from icontrol.exceptions import iControlUnexpectedHTTPError
 
 

--- a/f5/bigip/test/unit/test_resource.py
+++ b/f5/bigip/test/unit/test_resource.py
@@ -22,8 +22,6 @@ import requests
 
 from f5.bigip.resource import _missing_required_parameters
 from f5.bigip.resource import AsmResource
-from f5.bigip.resource import AttemptedMutationOfReadOnly
-from f5.bigip.resource import BooleansToReduceHaveSameValue
 from f5.bigip.resource import Collection
 from f5.bigip.resource import MissingRequiredCreationParameter
 from f5.bigip.resource import OrganizingCollection
@@ -40,6 +38,8 @@ from f5.bigip.tm.cm.sync_status import Sync_Status
 from f5.bigip.tm.ltm.virtual import Policies_s
 from f5.bigip.tm.ltm.virtual import Profiles_s
 from f5.bigip.tm.ltm.virtual import Virtual
+from f5.sdk_exception import AttemptedMutationOfReadOnly
+from f5.sdk_exception import BooleansToReduceHaveSameValue
 from f5.sdk_exception import DeviceProvidesIncompatibleKey
 from f5.sdk_exception import ExclusiveAttributesPresent
 from f5.sdk_exception import GenerationMismatch

--- a/f5/bigip/tm/asm/attack_types.py
+++ b/f5/bigip/tm/asm/attack_types.py
@@ -17,7 +17,7 @@
 
 from f5.bigip.resource import AsmResource
 from f5.bigip.resource import Collection
-from f5.bigip.resource import UnsupportedOperation
+from f5.sdk_exception import UnsupportedOperation
 
 
 class Attack_Types_s(Collection):

--- a/f5/bigip/tm/asm/policies.py
+++ b/f5/bigip/tm/asm/policies.py
@@ -19,7 +19,7 @@ from distutils.version import LooseVersion
 from f5.bigip.resource import AsmResource
 from f5.bigip.resource import Collection
 from f5.bigip.resource import UnnamedResource
-from f5.bigip.resource import UnsupportedOperation
+from f5.sdk_exception import UnsupportedOperation
 
 
 class Policies_s(Collection):

--- a/f5/bigip/tm/asm/signature_statuses.py
+++ b/f5/bigip/tm/asm/signature_statuses.py
@@ -17,7 +17,7 @@
 
 from f5.bigip.resource import AsmResource
 from f5.bigip.resource import Collection
-from f5.bigip.resource import UnsupportedOperation
+from f5.sdk_exception import UnsupportedOperation
 
 
 class Signature_Statuses_s(Collection):

--- a/f5/bigip/tm/asm/signature_systems.py
+++ b/f5/bigip/tm/asm/signature_systems.py
@@ -17,7 +17,7 @@
 
 from f5.bigip.resource import AsmResource
 from f5.bigip.resource import Collection
-from f5.bigip.resource import UnsupportedOperation
+from f5.sdk_exception import UnsupportedOperation
 
 
 class Signature_Systems_s(Collection):

--- a/f5/bigip/tm/asm/signature_update.py
+++ b/f5/bigip/tm/asm/signature_update.py
@@ -16,7 +16,7 @@
 #
 
 from f5.bigip.resource import UnnamedResource
-from f5.bigip.resource import UnsupportedOperation
+from f5.sdk_exception import UnsupportedOperation
 
 
 class Signature_Update(UnnamedResource):

--- a/f5/bigip/tm/asm/tasks.py
+++ b/f5/bigip/tm/asm/tasks.py
@@ -31,7 +31,7 @@ from f5.bigip.resource import AsmResource
 from f5.bigip.resource import AsmTaskResource
 from f5.bigip.resource import Collection
 from f5.bigip.resource import OrganizingCollection
-from f5.bigip.resource import UnsupportedOperation
+from f5.sdk_exception import UnsupportedOperation
 
 
 class Tasks(OrganizingCollection):

--- a/f5/bigip/tm/asm/test/functional/test_policies.py
+++ b/f5/bigip/tm/asm/test/functional/test_policies.py
@@ -15,8 +15,6 @@
 
 import copy
 from distutils.version import LooseVersion
-from f5.bigip.resource import UnsupportedMethod
-from f5.bigip.resource import UnsupportedOperation
 from f5.bigip.tm.asm.policies import Blocking_Settings
 from f5.bigip.tm.asm.policies import Cookie
 from f5.bigip.tm.asm.policies import Cookies_s
@@ -58,6 +56,8 @@ from f5.bigip.tm.asm.policies import Whitelist_Ips_s
 from f5.bigip.tm.asm.policies import Xml_Profile
 from f5.bigip.tm.asm.policies import Xml_Profiles_s
 from f5.sdk_exception import AttemptedMutationOfReadOnly
+from f5.sdk_exception import UnsupportedMethod
+from f5.sdk_exception import UnsupportedOperation
 
 import pytest
 from requests.exceptions import HTTPError

--- a/f5/bigip/tm/asm/test/functional/test_policies.py
+++ b/f5/bigip/tm/asm/test/functional/test_policies.py
@@ -15,7 +15,6 @@
 
 import copy
 from distutils.version import LooseVersion
-from f5.bigip.resource import AttemptedMutationOfReadOnly
 from f5.bigip.resource import UnsupportedMethod
 from f5.bigip.resource import UnsupportedOperation
 from f5.bigip.tm.asm.policies import Blocking_Settings
@@ -58,6 +57,7 @@ from f5.bigip.tm.asm.policies import Whitelist_Ip
 from f5.bigip.tm.asm.policies import Whitelist_Ips_s
 from f5.bigip.tm.asm.policies import Xml_Profile
 from f5.bigip.tm.asm.policies import Xml_Profiles_s
+from f5.sdk_exception import AttemptedMutationOfReadOnly
 
 import pytest
 from requests.exceptions import HTTPError

--- a/f5/bigip/tm/asm/test/unit/test_attack_types.py
+++ b/f5/bigip/tm/asm/test/unit/test_attack_types.py
@@ -14,8 +14,8 @@
 #
 
 from f5.bigip import ManagementRoot
-from f5.bigip.resource import UnsupportedOperation
 from f5.bigip.tm.asm.attack_types import Attack_Type
+from f5.sdk_exception import UnsupportedOperation
 
 import mock
 import pytest

--- a/f5/bigip/tm/asm/test/unit/test_policies.py
+++ b/f5/bigip/tm/asm/test/unit/test_policies.py
@@ -14,8 +14,6 @@
 #
 
 from f5.bigip import ManagementRoot
-from f5.bigip.resource import MissingRequiredCreationParameter
-from f5.bigip.resource import UnsupportedOperation
 from f5.bigip.tm.asm import Asm
 from f5.bigip.tm.asm.policies import Evasion
 from f5.bigip.tm.asm.policies import Header
@@ -31,6 +29,8 @@ from f5.bigip.tm.asm.policies import UrlParametersCollection
 from f5.bigip.tm.asm.policies import UrlParametersResource
 from f5.bigip.tm.asm.policies import Violation
 from f5.bigip.tm.asm.policies import Web_Services_Security
+from f5.sdk_exception import MissingRequiredCreationParameter
+from f5.sdk_exception import UnsupportedOperation
 
 
 import mock

--- a/f5/bigip/tm/asm/test/unit/test_signature_sets.py
+++ b/f5/bigip/tm/asm/test/unit/test_signature_sets.py
@@ -14,8 +14,8 @@
 #
 
 from f5.bigip import ManagementRoot
-from f5.bigip.resource import MissingRequiredCreationParameter
 from f5.bigip.tm.asm.signature_sets import Signature_Set
+from f5.sdk_exception import MissingRequiredCreationParameter
 
 import mock
 import pytest

--- a/f5/bigip/tm/asm/test/unit/test_signature_statuses.py
+++ b/f5/bigip/tm/asm/test/unit/test_signature_statuses.py
@@ -14,8 +14,8 @@
 #
 
 from f5.bigip import ManagementRoot
-from f5.bigip.resource import UnsupportedOperation
 from f5.bigip.tm.asm.signature_statuses import Signature_Status
+from f5.sdk_exception import UnsupportedOperation
 
 import mock
 import pytest

--- a/f5/bigip/tm/asm/test/unit/test_signature_systems.py
+++ b/f5/bigip/tm/asm/test/unit/test_signature_systems.py
@@ -13,8 +13,8 @@
 # limitations under the License.
 #
 
-from f5.bigip.resource import UnsupportedOperation
 from f5.bigip.tm.asm.signature_systems import Signature_System
+from f5.sdk_exception import UnsupportedOperation
 
 import mock
 import pytest

--- a/f5/bigip/tm/asm/test/unit/test_signature_update.py
+++ b/f5/bigip/tm/asm/test/unit/test_signature_update.py
@@ -13,8 +13,8 @@
 # limitations under the License.
 #
 
-from f5.bigip.resource import UnsupportedOperation
 from f5.bigip.tm.asm.signature_update import Signature_Update
+from f5.sdk_exception import UnsupportedOperation
 
 import mock
 import pytest

--- a/f5/bigip/tm/asm/test/unit/test_signatures.py
+++ b/f5/bigip/tm/asm/test/unit/test_signatures.py
@@ -14,8 +14,8 @@
 #
 
 from f5.bigip import ManagementRoot
-from f5.bigip.resource import MissingRequiredCreationParameter
 from f5.bigip.tm.asm.signatures import Signature
+from f5.sdk_exception import MissingRequiredCreationParameter
 
 import mock
 import pytest

--- a/f5/bigip/tm/asm/test/unit/test_tasks.py
+++ b/f5/bigip/tm/asm/test/unit/test_tasks.py
@@ -14,12 +14,12 @@
 #
 
 from f5.bigip import ManagementRoot
-from f5.bigip.resource import MissingRequiredCreationParameter
 from f5.bigip.resource import OrganizingCollection
-from f5.bigip.resource import UnsupportedOperation
 from f5.bigip.tm.asm.tasks import Check_Signature
 from f5.bigip.tm.asm.tasks import Export_Signature
 from f5.bigip.tm.asm.tasks import Update_Signature
+from f5.sdk_exception import MissingRequiredCreationParameter
+from f5.sdk_exception import UnsupportedOperation
 
 import mock
 import pytest

--- a/f5/bigip/tm/auth/test/functional/test_user.py
+++ b/f5/bigip/tm/auth/test/functional/test_user.py
@@ -16,7 +16,7 @@
 from distutils.version import LooseVersion
 import pytest
 
-from f5.bigip.resource import MissingRequiredCreationParameter
+from f5.sdk_exception import MissingRequiredCreationParameter
 from requests.exceptions import HTTPError
 
 

--- a/f5/bigip/tm/auth/test/unit/test_user.py
+++ b/f5/bigip/tm/auth/test/unit/test_user.py
@@ -17,8 +17,8 @@ import mock
 import pytest
 
 from f5.bigip import ManagementRoot
-from f5.bigip.resource import MissingRequiredCreationParameter
 from f5.bigip.tm.auth.user import User
+from f5.sdk_exception import MissingRequiredCreationParameter
 
 
 @pytest.fixture

--- a/f5/bigip/tm/cm/test/functional/test_trust_domain.py
+++ b/f5/bigip/tm/cm/test/functional/test_trust_domain.py
@@ -14,7 +14,7 @@
 #
 import pytest
 
-from f5.bigip.resource import UnsupportedOperation
+from f5.sdk_exception import UnsupportedOperation
 
 
 # Obtaining device name for tests to work

--- a/f5/bigip/tm/cm/test/unit/test_trustdomain.py
+++ b/f5/bigip/tm/cm/test/unit/test_trustdomain.py
@@ -16,8 +16,8 @@
 import mock
 import pytest
 
-from f5.bigip.resource import UnsupportedOperation
 from f5.bigip.tm.cm.trust_domain import Trust_Domain
+from f5.sdk_exception import UnsupportedOperation
 
 
 @pytest.fixture

--- a/f5/bigip/tm/cm/trust_domain.py
+++ b/f5/bigip/tm/cm/trust_domain.py
@@ -29,7 +29,7 @@ REST Kind
 
 from f5.bigip.resource import Collection
 from f5.bigip.resource import Resource
-from f5.bigip.resource import UnsupportedOperation
+from f5.sdk_exception import UnsupportedOperation
 
 
 class Trust_Domains(Collection):

--- a/f5/bigip/tm/gtm/listener.py
+++ b/f5/bigip/tm/gtm/listener.py
@@ -29,7 +29,7 @@ REST Kind
 
 from f5.bigip.resource import Collection
 from f5.bigip.resource import Resource
-from f5.bigip.resource import UnsupportedOperation
+from f5.sdk_exception import UnsupportedOperation
 
 
 class Listeners(Collection):

--- a/f5/bigip/tm/gtm/pool.py
+++ b/f5/bigip/tm/gtm/pool.py
@@ -32,7 +32,7 @@ from distutils.version import LooseVersion
 from f5.bigip.resource import Collection
 from f5.bigip.resource import OrganizingCollection
 from f5.bigip.resource import Resource
-from f5.bigip.resource import URICreationCollision
+from f5.sdk_exception import URICreationCollision
 from requests.exceptions import HTTPError
 
 

--- a/f5/bigip/tm/gtm/test/functional/test_datacenter.py
+++ b/f5/bigip/tm/gtm/test/functional/test_datacenter.py
@@ -15,8 +15,8 @@
 
 import pytest
 
-from f5.bigip.resource import MissingRequiredCreationParameter
 from f5.bigip.tm.gtm.datacenter import Datacenter
+from f5.sdk_exception import MissingRequiredCreationParameter
 from pytest import symbols
 from requests.exceptions import HTTPError
 

--- a/f5/bigip/tm/gtm/test/functional/test_listener.py
+++ b/f5/bigip/tm/gtm/test/functional/test_listener.py
@@ -17,10 +17,10 @@ import copy
 import pytest
 
 from distutils.version import LooseVersion
-from f5.bigip.resource import MissingRequiredCreationParameter
-from f5.bigip.resource import UnsupportedOperation
 from f5.bigip.tm.gtm.listener import Listener
+from f5.sdk_exception import MissingRequiredCreationParameter
 from f5.sdk_exception import MissingRequiredReadParameter
+from f5.sdk_exception import UnsupportedOperation
 from pytest import symbols
 from requests.exceptions import HTTPError
 from six import iteritems

--- a/f5/bigip/tm/gtm/test/functional/test_pool.py
+++ b/f5/bigip/tm/gtm/test/functional/test_pool.py
@@ -14,7 +14,6 @@
 #
 import copy
 from distutils.version import LooseVersion
-from f5.bigip.resource import URICreationCollision
 from f5.bigip.tm.gtm.pool import A
 from f5.bigip.tm.gtm.pool import Aaaa
 from f5.bigip.tm.gtm.pool import Cname
@@ -29,6 +28,7 @@ from f5.bigip.tm.gtm.pool import Mx
 from f5.bigip.tm.gtm.pool import Naptr
 from f5.bigip.tm.gtm.pool import Pool
 from f5.bigip.tm.gtm.pool import Srv
+from f5.sdk_exception import URICreationCollision
 import mock
 import pytest
 

--- a/f5/bigip/tm/gtm/test/functional/test_region.py
+++ b/f5/bigip/tm/gtm/test/functional/test_region.py
@@ -20,8 +20,8 @@ some more work to determine what we need to disable for 12.x"""
 import copy
 import pytest
 
-from f5.bigip.resource import MissingRequiredCreationParameter
 from f5.bigip.tm.gtm.region import Region
+from f5.sdk_exception import MissingRequiredCreationParameter
 from pytest import symbols
 from requests.exceptions import HTTPError
 from six import iteritems

--- a/f5/bigip/tm/gtm/test/functional/test_rule.py
+++ b/f5/bigip/tm/gtm/test/functional/test_rule.py
@@ -15,8 +15,8 @@
 
 import pytest
 
-from f5.bigip.resource import MissingRequiredCreationParameter
 from f5.bigip.tm.gtm.rule import Rule
+from f5.sdk_exception import MissingRequiredCreationParameter
 from pytest import symbols
 from requests.exceptions import HTTPError
 

--- a/f5/bigip/tm/gtm/test/functional/test_topology.py
+++ b/f5/bigip/tm/gtm/test/functional/test_topology.py
@@ -17,10 +17,10 @@
 import pytest
 
 from distutils.version import LooseVersion
-from f5.bigip.resource import MissingRequiredCreationParameter
-from f5.bigip.resource import UnsupportedOperation
 from f5.bigip.tm.gtm.topology import Topology
 from f5.sdk_exception import InvalidName
+from f5.sdk_exception import MissingRequiredCreationParameter
+from f5.sdk_exception import UnsupportedOperation
 from f5.sdk_exception import UnsupportedTmosVersion
 from pytest import symbols
 from requests.exceptions import HTTPError

--- a/f5/bigip/tm/gtm/test/unit/test_datacenter.py
+++ b/f5/bigip/tm/gtm/test/unit/test_datacenter.py
@@ -17,8 +17,8 @@ import mock
 import pytest
 
 from f5.bigip import ManagementRoot
-from f5.bigip.resource import MissingRequiredCreationParameter
 from f5.bigip.tm.gtm.datacenter import Datacenter
+from f5.sdk_exception import MissingRequiredCreationParameter
 
 
 @pytest.fixture

--- a/f5/bigip/tm/gtm/test/unit/test_listener.py
+++ b/f5/bigip/tm/gtm/test/unit/test_listener.py
@@ -17,10 +17,10 @@ import mock
 import pytest
 
 from f5.bigip import ManagementRoot
-from f5.bigip.resource import MissingRequiredCreationParameter
-from f5.bigip.resource import UnsupportedOperation
 from f5.bigip.tm.gtm.listener import Listener
 from f5.bigip.tm.gtm.listener import Profile
+from f5.sdk_exception import MissingRequiredCreationParameter
+from f5.sdk_exception import UnsupportedOperation
 
 
 @pytest.fixture

--- a/f5/bigip/tm/gtm/test/unit/test_pool.py
+++ b/f5/bigip/tm/gtm/test/unit/test_pool.py
@@ -18,9 +18,7 @@ import pytest
 
 from f5.bigip import ManagementRoot
 from f5.bigip.resource import Collection
-from f5.bigip.resource import MissingRequiredCreationParameter
 from f5.bigip.resource import OrganizingCollection
-from f5.bigip.resource import URICreationCollision
 from f5.bigip.tm.gtm.pool import A
 from f5.bigip.tm.gtm.pool import Aaaa
 from f5.bigip.tm.gtm.pool import Cname
@@ -45,6 +43,8 @@ from f5.bigip.tm.gtm.pool import Naptr
 from f5.bigip.tm.gtm.pool import Pool
 from f5.bigip.tm.gtm.pool import PoolCollection
 from f5.bigip.tm.gtm.pool import Srv
+from f5.sdk_exception import MissingRequiredCreationParameter
+from f5.sdk_exception import URICreationCollision
 from requests import HTTPError
 
 from six import iterkeys

--- a/f5/bigip/tm/gtm/test/unit/test_region.py
+++ b/f5/bigip/tm/gtm/test/unit/test_region.py
@@ -17,8 +17,8 @@ import mock
 import pytest
 
 from f5.bigip import ManagementRoot
-from f5.bigip.resource import MissingRequiredCreationParameter
 from f5.bigip.tm.gtm.region import Region
+from f5.sdk_exception import MissingRequiredCreationParameter
 
 
 @pytest.fixture

--- a/f5/bigip/tm/gtm/test/unit/test_rule.py
+++ b/f5/bigip/tm/gtm/test/unit/test_rule.py
@@ -17,8 +17,8 @@ import mock
 import pytest
 
 from f5.bigip import ManagementRoot
-from f5.bigip.resource import MissingRequiredCreationParameter
 from f5.bigip.tm.gtm.rule import Rule
+from f5.sdk_exception import MissingRequiredCreationParameter
 
 
 @pytest.fixture

--- a/f5/bigip/tm/gtm/test/unit/test_server.py
+++ b/f5/bigip/tm/gtm/test/unit/test_server.py
@@ -17,9 +17,9 @@ import mock
 import pytest
 
 from f5.bigip import ManagementRoot
-from f5.bigip.resource import MissingRequiredCreationParameter
 from f5.bigip.tm.gtm.server import Server
 from f5.bigip.tm.gtm.server import Virtual_Server
+from f5.sdk_exception import MissingRequiredCreationParameter
 
 from six import iterkeys
 

--- a/f5/bigip/tm/gtm/test/unit/test_topology.py
+++ b/f5/bigip/tm/gtm/test/unit/test_topology.py
@@ -16,11 +16,11 @@
 import pytest
 
 from f5.bigip import ManagementRoot
-from f5.bigip.resource import MissingRequiredCreationParameter
-from f5.bigip.resource import UnsupportedOperation
 from f5.bigip.tm import Gtm
 from f5.bigip.tm.gtm.topology import Topology
 from f5.sdk_exception import InvalidName
+from f5.sdk_exception import MissingRequiredCreationParameter
+from f5.sdk_exception import UnsupportedOperation
 
 
 @pytest.fixture

--- a/f5/bigip/tm/gtm/test/unit/test_wideip.py
+++ b/f5/bigip/tm/gtm/test/unit/test_wideip.py
@@ -18,7 +18,6 @@ import pytest
 
 from f5.bigip import ManagementRoot
 from f5.bigip.resource import Collection
-from f5.bigip.resource import MissingRequiredCreationParameter
 from f5.bigip.resource import OrganizingCollection
 from f5.bigip.tm.gtm.wideip import A
 from f5.bigip.tm.gtm.wideip import Aaaa
@@ -28,6 +27,7 @@ from f5.bigip.tm.gtm.wideip import Naptr
 from f5.bigip.tm.gtm.wideip import Srv
 from f5.bigip.tm.gtm.wideip import Wideip
 from f5.bigip.tm.gtm.wideip import WideipCollection
+from f5.sdk_exception import MissingRequiredCreationParameter
 
 from six import iterkeys
 

--- a/f5/bigip/tm/gtm/topology.py
+++ b/f5/bigip/tm/gtm/topology.py
@@ -29,10 +29,10 @@ REST Kind
 from distutils.version import LooseVersion
 from f5.bigip.resource import Collection
 from f5.bigip.resource import Resource
-from f5.bigip.resource import UnsupportedOperation
-from f5.bigip.resource import URICreationCollision
 from f5.sdk_exception import InvalidName
+from f5.sdk_exception import UnsupportedOperation
 from f5.sdk_exception import UnsupportedTmosVersion
+from f5.sdk_exception import URICreationCollision
 
 
 from requests import HTTPError

--- a/f5/bigip/tm/ltm/nat.py
+++ b/f5/bigip/tm/ltm/nat.py
@@ -28,8 +28,8 @@ REST Kind
 
 from f5.bigip.mixins import ExclusiveAttributesMixin
 from f5.bigip.resource import Collection
-from f5.bigip.resource import MissingRequiredCreationParameter
 from f5.bigip.resource import Resource
+from f5.sdk_exception import MissingRequiredCreationParameter
 
 
 class Nats(Collection):

--- a/f5/bigip/tm/ltm/policy.py
+++ b/f5/bigip/tm/ltm/policy.py
@@ -29,9 +29,9 @@ REST Kind
 
 from f5.bigip.mixins import CheckExistenceMixin
 from f5.bigip.resource import Collection
-from f5.bigip.resource import MissingRequiredCreationParameter
 from f5.bigip.resource import Resource
 from f5.sdk_exception import F5SDKError
+from f5.sdk_exception import MissingRequiredCreationParameter
 
 from distutils.version import LooseVersion
 

--- a/f5/bigip/tm/ltm/profile.py
+++ b/f5/bigip/tm/ltm/profile.py
@@ -30,8 +30,8 @@ REST Kind
 from f5.bigip.resource import Collection
 from f5.bigip.resource import OrganizingCollection
 from f5.bigip.resource import Resource
-from f5.bigip.resource import UnsupportedOperation
 from f5.sdk_exception import MissingUpdateParameter
+from f5.sdk_exception import UnsupportedOperation
 
 
 class Profile(OrganizingCollection):

--- a/f5/bigip/tm/ltm/snat.py
+++ b/f5/bigip/tm/ltm/snat.py
@@ -28,12 +28,13 @@ REST Kind
 """
 
 from f5.bigip.resource import Collection
-from f5.bigip.resource import MissingRequiredCreationParameter
 from f5.bigip.resource import Resource
+from f5.sdk_exception import MissingRequiredCreationParameter
 
 from six import iterkeys
 
 
+# ToDo This is a prime example of duplication, needs to be removed
 class RequireOneOf(MissingRequiredCreationParameter):
     pass
 

--- a/f5/bigip/tm/ltm/test/functional/test_data_group.py
+++ b/f5/bigip/tm/ltm/test/functional/test_data_group.py
@@ -14,7 +14,7 @@
 #
 
 import copy
-from f5.bigip.resource import MissingRequiredCreationParameter
+from f5.sdk_exception import MissingRequiredCreationParameter
 import pytest
 
 from requests.exceptions import HTTPError

--- a/f5/bigip/tm/ltm/test/functional/test_ifile.py
+++ b/f5/bigip/tm/ltm/test/functional/test_ifile.py
@@ -16,7 +16,7 @@
 import copy
 import pytest
 
-from f5.bigip.resource import MissingRequiredCreationParameter
+from f5.sdk_exception import MissingRequiredCreationParameter
 from requests.exceptions import HTTPError
 from six import iteritems
 

--- a/f5/bigip/tm/ltm/test/functional/test_nat.py
+++ b/f5/bigip/tm/ltm/test/functional/test_nat.py
@@ -15,7 +15,7 @@
 
 import pytest
 
-from f5.bigip.resource import MissingRequiredCreationParameter
+from f5.sdk_exception import MissingRequiredCreationParameter
 from requests.exceptions import HTTPError
 
 

--- a/f5/bigip/tm/ltm/test/functional/test_node.py
+++ b/f5/bigip/tm/ltm/test/functional/test_node.py
@@ -15,7 +15,7 @@
 
 import pytest
 
-from f5.bigip.resource import MissingRequiredCreationParameter
+from f5.sdk_exception import MissingRequiredCreationParameter
 from f5.sdk_exception import NodeStateModifyUnsupported
 
 

--- a/f5/bigip/tm/ltm/test/functional/test_policy.py
+++ b/f5/bigip/tm/ltm/test/functional/test_policy.py
@@ -19,9 +19,9 @@ import json
 import os
 import pytest
 
-from f5.bigip.resource import MissingRequiredCreationParameter
 from f5.bigip.tm.ltm.policy import NonExtantPolicyRule
 from f5.bigip.tm.ltm.policy import OperationNotSupportedOnPublishedPolicy
+from f5.sdk_exception import MissingRequiredCreationParameter
 
 TESTDESCRIPTION = "TESTDESCRIPTION"
 CURDIR = os.path.dirname(os.path.realpath(__file__))

--- a/f5/bigip/tm/ltm/test/functional/test_pool.py
+++ b/f5/bigip/tm/ltm/test/functional/test_pool.py
@@ -18,7 +18,7 @@ import pytest
 from requests.exceptions import HTTPError
 from six import iterkeys
 
-from f5.bigip.resource import MissingRequiredCreationParameter
+from f5.sdk_exception import MissingRequiredCreationParameter
 
 TESTDESCRIPTION = 'TESTDESCRIPTION'
 

--- a/f5/bigip/tm/ltm/test/functional/test_rule.py
+++ b/f5/bigip/tm/ltm/test/functional/test_rule.py
@@ -15,8 +15,8 @@
 
 import pytest
 
-from f5.bigip.resource import MissingRequiredCreationParameter
 from f5.bigip.tm.ltm.rule import Rule
+from f5.sdk_exception import MissingRequiredCreationParameter
 from requests.exceptions import HTTPError
 
 

--- a/f5/bigip/tm/ltm/test/functional/test_virtual.py
+++ b/f5/bigip/tm/ltm/test/functional/test_virtual.py
@@ -14,7 +14,7 @@
 #
 
 from distutils.version import LooseVersion
-from f5.bigip.resource import MissingRequiredCreationParameter
+from f5.sdk_exception import MissingRequiredCreationParameter
 from f5.sdk_exception import MissingRequiredReadParameter
 from six import iteritems
 

--- a/f5/bigip/tm/ltm/test/unit/test_auth.py
+++ b/f5/bigip/tm/ltm/test/unit/test_auth.py
@@ -16,7 +16,6 @@
 #
 
 from f5.bigip import ManagementRoot
-from f5.bigip.resource import MissingRequiredCreationParameter
 from f5.bigip.resource import UnsupportedMethod
 from f5.bigip.tm.ltm.auth import Crldp_Server
 from f5.bigip.tm.ltm.auth import Kerberos_Delegation
@@ -29,6 +28,7 @@ from f5.bigip.tm.ltm.auth import Ssl_Cc_Ldap
 from f5.bigip.tm.ltm.auth import Ssl_Crldp
 from f5.bigip.tm.ltm.auth import Ssl_Ocsp
 from f5.bigip.tm.ltm.auth import Tacacs
+from f5.sdk_exception import MissingRequiredCreationParameter
 import mock
 import pytest
 from six import iterkeys

--- a/f5/bigip/tm/ltm/test/unit/test_datagroup.py
+++ b/f5/bigip/tm/ltm/test/unit/test_datagroup.py
@@ -18,9 +18,9 @@ import pytest
 
 
 from f5.bigip import ManagementRoot
-from f5.bigip.resource import MissingRequiredCreationParameter
 from f5.bigip.tm.ltm.data_group import External
 from f5.bigip.tm.ltm.data_group import Internal
+from f5.sdk_exception import MissingRequiredCreationParameter
 
 
 @pytest.fixture

--- a/f5/bigip/tm/ltm/test/unit/test_ifile.py
+++ b/f5/bigip/tm/ltm/test/unit/test_ifile.py
@@ -16,8 +16,8 @@
 import mock
 import pytest
 
-from f5.bigip.resource import MissingRequiredCreationParameter
 from f5.bigip.tm.ltm.ifile import Ifile
+from f5.sdk_exception import MissingRequiredCreationParameter
 
 
 @pytest.fixture

--- a/f5/bigip/tm/ltm/test/unit/test_nat.py
+++ b/f5/bigip/tm/ltm/test/unit/test_nat.py
@@ -17,8 +17,8 @@ import mock
 import pytest
 
 from f5.bigip import ManagementRoot
-from f5.bigip.resource import MissingRequiredCreationParameter
 from f5.bigip.tm.ltm.nat import Nat
+from f5.sdk_exception import MissingRequiredCreationParameter
 
 
 @pytest.fixture

--- a/f5/bigip/tm/ltm/test/unit/test_rule.py
+++ b/f5/bigip/tm/ltm/test/unit/test_rule.py
@@ -17,8 +17,8 @@ import mock
 import pytest
 
 from f5.bigip import ManagementRoot
-from f5.bigip.resource import MissingRequiredCreationParameter
 from f5.bigip.tm.ltm.nat import Nat
+from f5.sdk_exception import MissingRequiredCreationParameter
 
 
 @pytest.fixture

--- a/f5/bigip/tm/ltm/test/unit/test_traffic_class.py
+++ b/f5/bigip/tm/ltm/test/unit/test_traffic_class.py
@@ -17,8 +17,8 @@ import mock
 import pytest
 
 from f5.bigip import ManagementRoot
-from f5.bigip.resource import MissingRequiredCreationParameter
 from f5.bigip.tm.ltm.traffic_class import Traffic_Class
+from f5.sdk_exception import MissingRequiredCreationParameter
 
 
 @pytest.fixture

--- a/f5/bigip/tm/net/interface.py
+++ b/f5/bigip/tm/net/interface.py
@@ -30,7 +30,7 @@ REST Kind
 from f5.bigip.mixins import ExclusiveAttributesMixin
 from f5.bigip.resource import Collection
 from f5.bigip.resource import Resource
-from f5.bigip.resource import UnsupportedOperation
+from f5.sdk_exception import UnsupportedOperation
 
 
 class Interfaces(Collection):

--- a/f5/bigip/tm/net/route.py
+++ b/f5/bigip/tm/net/route.py
@@ -29,8 +29,8 @@ REST Kind
 
 from f5.bigip.mixins import ExclusiveAttributesMixin
 from f5.bigip.resource import Collection
-from f5.bigip.resource import MissingRequiredCreationParameter
 from f5.bigip.resource import Resource
+from f5.sdk_exception import MissingRequiredCreationParameter
 
 from six import iterkeys
 

--- a/f5/bigip/tm/net/test/functional/test_arp.py
+++ b/f5/bigip/tm/net/test/functional/test_arp.py
@@ -15,9 +15,8 @@
 
 import pytest
 
-from f5.bigip.resource import MissingRequiredCreationParameter
+from f5.sdk_exception import MissingRequiredCreationParameter
 from requests.exceptions import HTTPError
-
 
 TEST_IP = '192.168.98.100'
 TEST_MAC = '02:00:00:00:00:01'

--- a/f5/bigip/tm/net/test/functional/test_route.py
+++ b/f5/bigip/tm/net/test/functional/test_route.py
@@ -15,7 +15,7 @@
 
 import pytest
 
-from f5.bigip.resource import MissingRequiredCreationParameter
+from f5.sdk_exception import MissingRequiredCreationParameter
 
 POOL_NAME = "route-pool"
 VLAN_NAME = "route-vlan"

--- a/f5/bigip/tm/net/test/functional/test_self.py
+++ b/f5/bigip/tm/net/test/functional/test_self.py
@@ -15,7 +15,7 @@
 
 import pytest
 
-from f5.bigip.resource import MissingRequiredCreationParameter
+from f5.sdk_exception import MissingRequiredCreationParameter
 TESTDESCRIPTION = "TESTDESCRIPTION"
 
 

--- a/f5/bigip/tm/net/test/functional/test_vlan.py
+++ b/f5/bigip/tm/net/test/functional/test_vlan.py
@@ -45,7 +45,7 @@ def setup_basic_test(request, bigip, name, partition):
     return v
 
 
-def setup_interfaces_test(request, bigip, name, partition, iname='1.1'):
+def setup_interfaces_test(request, bigip, name, partition, iname='1.3'):
     v = setup_basic_test(request, bigip, name, partition)
     i = v.interfaces_s.interfaces.create(name=iname)
     return i, v
@@ -73,11 +73,11 @@ class TestVLANInterfacesCollection(object):
     def test_get_collection(self, request, bigip):
         # Setup will create a VLAN and one interfaces
         v1 = setup_basic_test(request, bigip, 'v1', 'Common')
-        v1.interfaces_s.interfaces.create(name='1.1')
+        v1.interfaces_s.interfaces.create(name='1.3')
         ifcs = v1.interfaces_s.get_collection()
         i2 = ifcs[0]
         assert len(ifcs) is 1
-        assert ifcs[0].name == '1.1'
+        assert ifcs[0].name == '1.3'
         i2.delete()
         ifcs = v1.interfaces_s.get_collection()
         assert len(ifcs) is 0
@@ -86,7 +86,7 @@ class TestVLANInterfacesCollection(object):
 class TestVLANInterfaces(object):
     def test_create_interfaces(self, request, bigip):
         i, _ = setup_interfaces_test(request, bigip, 'v1', 'Common')
-        assert i.name == '1.1'
+        assert i.name == '1.3'
 
     @pytest.mark.skipif(
         LooseVersion(
@@ -216,7 +216,7 @@ class TestVLANInterfaces(object):
 
     def test_load(self, request, bigip):
         i1, v = setup_interfaces_test(request, bigip, 'v1', 'Common')
-        i2 = v.interfaces_s.interfaces.load(name='1.1')
+        i2 = v.interfaces_s.interfaces.load(name='1.3')
         assert i1.name == i2.name
         assert i1.generation == i2.generation
 
@@ -251,13 +251,13 @@ class TestVLAN(object):
         # Create a VLAN and verify some of the attributes
         v1 = bigip.net.vlans.vlan.create(name='v1', partition='Common')
         v1.interfaces_s.interfaces.create(
-            name='1.1', tagged=True, tagMode='service')
+            name='1.3', tagged=True, tagMode='service')
         v1_ifcs = v1.interfaces_s.get_collection()
         gen1 = v1.generation
         assert v1.name == 'v1'
         assert hasattr(v1, 'generation') and isinstance(v1.generation, int)
         assert len(v1_ifcs) == 1
-        assert v1_ifcs[0].name == '1.1'
+        assert v1_ifcs[0].name == '1.3'
 
         # Update it
         v1.description = DESCRIPTION
@@ -294,7 +294,7 @@ class TestVLAN(object):
         v1 = bigip.net.vlans.vlan.create(name='v1', partition='Common')
         with pytest.raises(TagModeDisallowedForTMOSVersion) as ex:
             v1.interfaces_s.interfaces.create(
-                name='1.1', tagged=True, tagMode='service')
+                name='1.3', tagged=True, tagMode='service')
         assert "'tagMode', is not allowed against the following version of " \
             'TMOS: 11.5.4' in ex.value.message
 

--- a/f5/bigip/tm/net/test/functional/test_vlan.py
+++ b/f5/bigip/tm/net/test/functional/test_vlan.py
@@ -16,8 +16,8 @@
 from distutils.version import LooseVersion
 import pytest
 
-from f5.bigip.resource import MissingRequiredCreationParameter
 from f5.bigip.tm.net.vlan import TagModeDisallowedForTMOSVersion
+from f5.sdk_exception import MissingRequiredCreationParameter
 from f5.sdk_exception import MissingUpdateParameter
 from icontrol.session import iControlUnexpectedHTTPError
 from requests.exceptions import HTTPError

--- a/f5/bigip/tm/net/test/unit/test_interface.py
+++ b/f5/bigip/tm/net/test/unit/test_interface.py
@@ -16,8 +16,8 @@
 import mock
 import pytest
 
-from f5.bigip.resource import UnsupportedOperation
 from f5.bigip.tm.net.interface import Interface
+from f5.sdk_exception import UnsupportedOperation
 
 
 @pytest.fixture

--- a/f5/bigip/tm/sys/db.py
+++ b/f5/bigip/tm/sys/db.py
@@ -29,7 +29,7 @@ REST Kind
 
 from f5.bigip.resource import Collection
 from f5.bigip.resource import Resource
-from f5.bigip.resource import UnsupportedOperation
+from f5.sdk_exception import UnsupportedOperation
 
 
 class Dbs(Collection):

--- a/f5/bigip/tm/sys/performance.py
+++ b/f5/bigip/tm/sys/performance.py
@@ -29,7 +29,7 @@ REST Kind
 
 from f5.bigip.resource import Collection
 from f5.bigip.resource import UnnamedResource
-from f5.bigip.resource import UnsupportedOperation
+from f5.sdk_exception import UnsupportedOperation
 
 
 class Performances(Collection):

--- a/f5/bigip/tm/sys/snmp.py
+++ b/f5/bigip/tm/sys/snmp.py
@@ -30,7 +30,7 @@ from distutils.version import LooseVersion
 from f5.bigip.resource import Collection
 from f5.bigip.resource import Resource
 from f5.bigip.resource import UnnamedResource
-from f5.bigip.resource import UnsupportedOperation
+from f5.sdk_exception import UnsupportedOperation
 
 
 class Snmp(UnnamedResource):

--- a/f5/bigip/tm/sys/test/functional/test_failover.py
+++ b/f5/bigip/tm/sys/test/functional/test_failover.py
@@ -13,9 +13,9 @@
 # limitations under the License.
 #
 
-from f5.bigip.resource import BooleansToReduceHaveSameValue
 from f5.multi_device.utils import get_device_info
 from f5.multi_device.utils import pollster
+from f5.sdk_exception import BooleansToReduceHaveSameValue
 
 import pytest
 

--- a/f5/bigip/tm/sys/test/unit/test_application.py
+++ b/f5/bigip/tm/sys/test/unit/test_application.py
@@ -18,14 +18,14 @@ import pytest
 from requests import HTTPError
 
 from f5.bigip import ManagementRoot
-from f5.bigip.resource import MissingRequiredCreationParameter
-from f5.bigip.resource import URICreationCollision
 from f5.bigip.tm.sys.application import Aplscript
 from f5.bigip.tm.sys.application import Customstat
 from f5.bigip.tm.sys.application import Service
 from f5.bigip.tm.sys.application import Template
 from f5.sdk_exception import KindTypeMismatch
+from f5.sdk_exception import MissingRequiredCreationParameter
 from f5.sdk_exception import MissingRequiredReadParameter
+from f5.sdk_exception import URICreationCollision
 
 
 KIND_MISMATCH = {

--- a/f5/bigip/tm/sys/test/unit/test_db.py
+++ b/f5/bigip/tm/sys/test/unit/test_db.py
@@ -13,8 +13,8 @@
 # limitations under the License.
 #
 
-from f5.bigip.resource import UnsupportedOperation
 from f5.bigip.tm.sys import Dbs
+from f5.sdk_exception import UnsupportedOperation
 import mock
 import pytest
 

--- a/f5/bigip/tm/sys/test/unit/test_file.py
+++ b/f5/bigip/tm/sys/test/unit/test_file.py
@@ -16,13 +16,13 @@
 import mock
 import pytest
 
-from f5.bigip.resource import MissingRequiredCreationParameter
 from f5.bigip.tm.sys.file import Data_Group
 from f5.bigip.tm.sys.file import Ifile
 from f5.bigip.tm.sys.file import Ssl_Cert
 from f5.bigip.tm.sys.file import Ssl_Crl
 from f5.bigip.tm.sys.file import Ssl_Csr
 from f5.bigip.tm.sys.file import Ssl_Key
+from f5.sdk_exception import MissingRequiredCreationParameter
 from f5.sdk_exception import UnsupportedMethod
 
 

--- a/f5/bigip/tm/sys/test/unit/test_folder.py
+++ b/f5/bigip/tm/sys/test/unit/test_folder.py
@@ -16,8 +16,8 @@
 import mock
 import pytest
 
-from f5.bigip.resource import MissingRequiredCreationParameter
 from f5.bigip.tm.sys.folder import Folders
+from f5.sdk_exception import MissingRequiredCreationParameter
 
 
 @pytest.fixture

--- a/f5/bigip/tm/sys/test/unit/test_performance.py
+++ b/f5/bigip/tm/sys/test/unit/test_performance.py
@@ -16,9 +16,9 @@
 import mock
 import pytest
 
-from f5.bigip.resource import UnsupportedOperation
 from f5.bigip.tm.sys.performance import Performances
 from f5.sdk_exception import UnsupportedMethod
+from f5.sdk_exception import UnsupportedOperation
 
 
 @pytest.fixture

--- a/f5/bigip/tm/sys/test/unit/test_snmp.py
+++ b/f5/bigip/tm/sys/test/unit/test_snmp.py
@@ -16,11 +16,11 @@
 import mock
 import pytest
 
-from f5.bigip.resource import UnsupportedOperation
 from f5.bigip.tm.sys.snmp import Snmp
 from f5.bigip.tm.sys.snmp import Trap
 from f5.bigip.tm.sys.snmp import User
 from f5.sdk_exception import UnsupportedMethod
+from f5.sdk_exception import UnsupportedOperation
 
 
 @pytest.fixture

--- a/f5/bigip/tm/vcmp/test/functional/test_guest.py
+++ b/f5/bigip/tm/vcmp/test/functional/test_guest.py
@@ -13,9 +13,9 @@
 # limitations under the License.
 #
 
-from f5.bigip.resource import MissingRequiredCreationParameter
 from f5.bigip.tm.vcmp.guest import DisallowedCreationParameter
 from f5.bigip.tm.vcmp.guest import DisallowedReadParameter
+from f5.sdk_exception import MissingRequiredCreationParameter
 from f5.sdk_exception import MissingRequiredReadParameter
 from icontrol.session import iControlUnexpectedHTTPError
 from six import iteritems

--- a/f5/bigip/tm/vcmp/test/unit/test_guest.py
+++ b/f5/bigip/tm/vcmp/test/unit/test_guest.py
@@ -16,10 +16,10 @@
 import mock
 import pytest
 
-from f5.bigip.resource import MissingRequiredCreationParameter
 from f5.bigip.tm.vcmp.guest import DisallowedCreationParameter
 from f5.bigip.tm.vcmp.guest import DisallowedReadParameter
 from f5.bigip.tm.vcmp.guest import Guest
+from f5.sdk_exception import MissingRequiredCreationParameter
 
 
 @pytest.fixture

--- a/f5/bigiq/resource.py
+++ b/f5/bigiq/resource.py
@@ -22,8 +22,8 @@ from f5.bigip.resource import PathElement as BigIpPathElement
 from f5.bigip.resource import Resource as BigIpResource
 from f5.bigip.resource import ResourceBase as BigIpResourceBase
 from f5.bigip.resource import UnnamedResource as BigIpUnnamedResource
-from f5.bigip.resource import UnsupportedOperation
-from f5.bigip.resource import URICreationCollision
+from f5.sdk_exception import UnsupportedOperation
+from f5.sdk_exception import URICreationCollision
 
 
 class PathElement(BigIpPathElement):

--- a/f5/sdk_exception.py
+++ b/f5/sdk_exception.py
@@ -119,13 +119,13 @@ class MissingHttpHeader(F5SDKError):
     pass
 
 
-class MissingRequiredCommandParameter(F5SDKError):
-    """Various values MUST be provided to execute a command."""
+class MissingRequiredCreationParameter(F5SDKError):
+    """Various values MUST be provided to create different Resources."""
     pass
 
 
-class MissingRequiredCreationParameter(F5SDKError):
-    """Various values MUST be provided to create different Resources."""
+class MissingRequiredCommandParameter(F5SDKError):
+    """Various values MUST be provided to execute a command."""
     pass
 
 


### PR DESCRIPTION
Problem:
Currently exception classes are scattered all over SDK, this will lead to unnecessary duplication and confusion

Analysis:
Removed the following classes from resource.py:

UnsupportedOperation
URICreationCollision
MissingRequiredCreationParameter

Corrected corresponding import statements

Tests:
Flake8