### PR TITLE
Fixes the kind for cm/cloud/connectors/local

### DIFF
--- a/f5/iworkflow/cm/cloud/connectors/local.py
+++ b/f5/iworkflow/cm/cloud/connectors/local.py
@@ -36,7 +36,7 @@ class Locals(Collection):
         super(Locals, self).__init__(connectors)
         self._meta_data['allowed_lazy_attributes'] = [Local]
         self._meta_data['attribute_registry'] = {
-            'cm:cloud:connectors:genericconnectorcollectionworkerstate': Local
+            'cm:cloud:connectors:cloudconnectorstate': Local
         }
 
 


### PR DESCRIPTION
Issues:
Fixes #928

Problem:
The kind was incorrect

Analysis:
This patch fixes it.

Tests: