### PR TITLE
Exceptions move part9

### DIFF
--- a/f5/bigip/cm/autodeploy/software_images.py
+++ b/f5/bigip/cm/autodeploy/software_images.py
@@ -20,12 +20,7 @@ import os
 
 from f5.bigip.mixins import FileUploadMixin
 from f5.bigip.resource import PathElement
-from f5.sdk_exception import F5SDKError
-
-
-class ImageFilesMustHaveDotISOExtension(F5SDKError):
-    def __init__(self, filename):
-        super(ImageFilesMustHaveDotISOExtension, self).__init__(filename)
+from f5.sdk_exception import ImageFilesMustHaveDotISOExtension
 
 
 class Software_Image_Uploads(PathElement, FileUploadMixin):

--- a/f5/bigip/contexts.py
+++ b/f5/bigip/contexts.py
@@ -19,11 +19,7 @@
 import copy
 import logging
 
-from f5.sdk_exception import F5SDKError
-
-
-class TransactionSubmitException(F5SDKError):
-    pass
+from f5.sdk_exception import TransactionSubmitException
 
 
 class TransactionContextManager(object):

--- a/f5/bigip/shared/file_transfer.py
+++ b/f5/bigip/shared/file_transfer.py
@@ -24,12 +24,7 @@ except ImportError:
 
 from f5.bigip.mixins import FileUploadMixin
 from f5.bigip.resource import PathElement
-from f5.sdk_exception import F5SDKError
-
-
-class FileMustNotHaveDotISOExtension(F5SDKError):
-    def __init__(self, filename):
-        super(FileMustNotHaveDotISOExtension, self).__init__(filename)
+from f5.sdk_exception import FileMustNotHaveDotISOExtension
 
 
 class File_Transfer(PathElement):

--- a/f5/bigip/tm/asm/file_transfer.py
+++ b/f5/bigip/tm/asm/file_transfer.py
@@ -20,12 +20,7 @@ import os
 from f5.bigip.mixins import AsmFileMixin
 from f5.bigip.resource import OrganizingCollection
 from f5.bigip.resource import PathElement
-from f5.sdk_exception import F5SDKError
-
-
-class FileMustNotHaveDotISOExtension(F5SDKError):
-    def __init__(self, filename):
-        super(FileMustNotHaveDotISOExtension, self).__init__(filename)
+from f5.sdk_exception import FileMustNotHaveDotISOExtension
 
 
 class File_Transfer(OrganizingCollection):

--- a/f5/bigip/tm/ltm/policy.py
+++ b/f5/bigip/tm/ltm/policy.py
@@ -30,20 +30,11 @@ REST Kind
 from f5.bigip.mixins import CheckExistenceMixin
 from f5.bigip.resource import Collection
 from f5.bigip.resource import Resource
-from f5.sdk_exception import F5SDKError
 from f5.sdk_exception import MissingRequiredCreationParameter
+from f5.sdk_exception import NonExtantPolicyRule
+from f5.sdk_exception import OperationNotSupportedOnPublishedPolicy
 
 from distutils.version import LooseVersion
-
-
-class OperationNotSupportedOnPublishedPolicy(F5SDKError):
-    '''Raise if update/modify attempted on published policy'''
-    pass
-
-
-class NonExtantPolicyRule(F5SDKError):
-    '''Raise if a rule does not exist on the device.'''
-    pass
 
 
 class Policys(Collection):

--- a/f5/bigip/tm/ltm/pool.py
+++ b/f5/bigip/tm/ltm/pool.py
@@ -31,11 +31,7 @@ from requests.exceptions import HTTPError
 
 from f5.bigip.resource import Collection
 from f5.bigip.resource import Resource
-from f5.sdk_exception import F5SDKError
-
-
-class MemberStateAlwaysRequiredOnUpdate(F5SDKError):
-    pass
+from f5.sdk_exception import MemberStateAlwaysRequiredOnUpdate
 
 
 class Pools(Collection):

--- a/f5/bigip/tm/ltm/virtual.py
+++ b/f5/bigip/tm/ltm/virtual.py
@@ -30,11 +30,7 @@ REST Kind
 from f5.bigip.mixins import CheckExistenceMixin
 from f5.bigip.resource import Collection
 from f5.bigip.resource import Resource
-from f5.sdk_exception import F5SDKError
-
-
-class NonExtantVirtualPolicy(F5SDKError):
-    pass
+from f5.sdk_exception import NonExtantVirtualPolicy
 
 
 class Virtuals(Collection):

--- a/f5/bigip/tm/vcmp/guest.py
+++ b/f5/bigip/tm/vcmp/guest.py
@@ -29,17 +29,8 @@ REST Kind
 
 from f5.bigip.resource import Collection
 from f5.bigip.resource import Resource
-from f5.sdk_exception import F5SDKError
-
-
-class DisallowedCreationParameter(F5SDKError):
-    """Exception when partition is passed to create for guest resource."""
-    pass
-
-
-class DisallowedReadParameter(F5SDKError):
-    """Exception when partition is passed to load for guest resource."""
-    pass
+from f5.sdk_exception import DisallowedCreationParameter
+from f5.sdk_exception import DisallowedReadParameter
 
 
 class Guests(Collection):


### PR DESCRIPTION
Problem:
Currently exception classes are scattered all over SDK, this will lead to unecessary duplication and confusion

Analysis:
Removed classes from rest of the endpoints, apart from vlan which is a subject to last of the PR
Tests:
Flake8