### PR TITLE
Exceptions move final

### DIFF
--- a/f5/bigip/tm/net/vlan.py
+++ b/f5/bigip/tm/net/vlan.py
@@ -30,14 +30,10 @@ REST Kind
 from f5.bigip.mixins import ExclusiveAttributesMixin
 from f5.bigip.resource import Collection
 from f5.bigip.resource import Resource
-from f5.sdk_exception import F5SDKError
 from f5.sdk_exception import MissingUpdateParameter
+from f5.sdk_exception import TagModeDisallowedForTMOSVersion
 
 from distutils.version import LooseVersion
-
-
-class TagModeDisallowedForTMOSVersion(F5SDKError):
-    pass
 
 
 class Vlans(Collection):


### PR DESCRIPTION
Problem:
Currently exception classes are scattered all over SDK, this will lead to unecessary duplication and confusion

Analysis:
Final Exceptions Move PR

Tests:
Flake8