### PR TITLE
Added six and ordereddict deps to sdk's RPM & DEP builds

### DIFF
--- a/f5-sdk-dist/deb_dist/stdeb.cfg
+++ b/f5-sdk-dist/deb_dist/stdeb.cfg
@@ -1,3 +1,4 @@
 [DEFAULT]
 Depends:
-	python-f5-icontrol-rest (=1.3.0-1)
+    python-f5-icontrol-rest (>=1.3.0), python-f5-icontrol-rest (<2),
+    python-six (>=1.10), python-six (<2) 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,3 +1,6 @@
 [bdist_rpm]
 release = 1
-requires = f5-icontrol-rest >= 1.3.0, <2
+requires = f5-icontrol-rest >= 1.3.0
+    f5-icontrol-rest < 2 
+    python-six >= 1.10 
+    python-six < 2 

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,6 @@ setup(
     url='https://github.com/F5Networks/f5-common-python',
     keywords=['F5', 'sdk', 'api', 'icontrol', 'bigip', 'api', 'ltm'],
     install_requires=['f5-icontrol-rest >= 1.3.0, <2',
-                      'ordereddict >= 1.1, <2',
                       'six >= 1.10, <2'],
     packages=find_packages(
         exclude=["*.test", "*.test.*", "test.*", "test_*", "test", "test*"]


### PR DESCRIPTION
Issues:
Fixes #933

Problem:
DEB and RPM build configs missing both the `six` and `ordereddict`
required modules

Analysis:
Added these dependencies, as they appear in the setup.py.

Tests:
Install Testing