### PR TITLE
Handle possible unavailability of orderreddict

### DIFF
--- a/f5/bigip/mixins.py
+++ b/f5/bigip/mixins.py
@@ -20,7 +20,12 @@
 try:
     from collections import OrderedDict
 except ImportError:
-    from ordereddict import OrderedDict
+    try:
+        from ordereddict import OrderedDict
+    except ImportError as exc:
+        message = ("Maybe you're using Python < 2.7 and do not have the "
+                   "orderreddict external dependency installed.")
+        raise exc(message)
 
 from distutils.version import LooseVersion
 from six import iteritems

--- a/f5/bigip/resource.py
+++ b/f5/bigip/resource.py
@@ -91,7 +91,12 @@ Available Classes:
 try:
     from collections import OrderedDict
 except ImportError:
-    from ordereddict import OrderedDict
+    try:
+        from ordereddict import OrderedDict
+    except ImportError as exc:
+        message = ("Maybe you're using Python < 2.7 and do not have the "
+                   "orderreddict external dependency installed.")
+        raise exc(message)
 import copy
 import keyword
 import re

--- a/f5/bigip/test/unit/test_resource.py
+++ b/f5/bigip/test/unit/test_resource.py
@@ -13,9 +13,14 @@
 #   limitations under the License.
 #
 try:
-        from collections import OrderedDict
-except ImportError:
+    from collections import OrderedDict
+except ImportError as exc:
+    try:
         from ordereddict import OrderedDict
+    except ImportError as exc:
+        message = ("Maybe you're using Python < 2.7 and do not have the "
+                   "orderreddict external dependency installed.")
+        raise exc(message)
 import mock
 import pytest
 import requests

--- a/requirements.py26.txt
+++ b/requirements.py26.txt
@@ -1,0 +1,3 @@
+-e .
+
+ordereddict>=1.1, <2

--- a/requirements.test.txt
+++ b/requirements.test.txt
@@ -1,6 +1,6 @@
 # Install this directory (will use setup.py and therefore install_requires).
 -e .
-
+-r requirements.py26.txt
 # Test Requirements
 hacking==0.13.0
 mock==2.0.0


### PR DESCRIPTION
@ssorenso 
Fixes: #935
Before Python 2.7 orderreddict had to be pip installed

After 2.7 it comes from collections.  We
use a nested try-except to handle all cases.