### PR TITLE
Makes the name parameter a required load parameter for the user object

### DIFF
--- a/f5/iworkflow/shared/authz/user.py
+++ b/f5/iworkflow/shared/authz/user.py
@@ -42,6 +42,7 @@ class Users_s(Collection):
 class User(Resource):
     def __init__(self, users_s):
         super(User, self).__init__(users_s)
+        self._meta_data['required_load_parameters'] = set(('name',))
         # There's a confirmation password parameter here (password2) but it is
         # not needed by the API. The web UI, however, requires it.
         self._meta_data['required_creation_parameters'] = \


### PR DESCRIPTION
Issues:

Problem:
User module did not have correct required_load_parameter specified

Analysis:
this fixes it

Tests: