### PR TITLE
Adds easy_setup api for iworkflow

### DIFF
--- a/f5/iworkflow/shared/system/__init__.py
+++ b/f5/iworkflow/shared/system/__init__.py
@@ -16,13 +16,15 @@
 #
 
 from f5.iworkflow.resource import OrganizingCollection
+from f5.iworkflow.shared.system.easy_setup import Easy_Setup
 from f5.iworkflow.shared.system.setup import Setup
 
 
 class System(OrganizingCollection):
     """An organizing collection for shared resources."""
-    def __init__(self, iworkflow):
-        super(System, self).__init__(iworkflow)
+    def __init__(self, shared):
+        super(System, self).__init__(shared)
         self._meta_data['allowed_lazy_attributes'] = [
+            Easy_Setup,
             Setup
         ]

--- a/f5/iworkflow/shared/system/easy_setup.py
+++ b/f5/iworkflow/shared/system/easy_setup.py
@@ -1,0 +1,33 @@
+# coding=utf-8
+#
+# Copyright 2016 F5 Networks Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+
+"""iWorkflow® system setup API
+
+REST URI
+    ``http://localhost/mgmt/shared/system/easy-setup``
+
+REST Kind
+    none
+"""
+
+from f5.iworkflow.resource import UnnamedResource
+
+
+class Easy_Setup(UnnamedResource):
+    def __init__(self, config):
+        super(Easy_Setup, self).__init__(config)
+        self._meta_data['required_load_parameters'] = set()

--- a/f5/iworkflow/shared/system/test/functional/test_easy_setup.py
+++ b/f5/iworkflow/shared/system/test/functional/test_easy_setup.py
@@ -1,0 +1,49 @@
+# Copyright 2016 F5 Networks Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+
+import pytest
+
+
+@pytest.fixture(scope='function')
+def easy_setup(mgmt_root):
+    easy_setup = mgmt_root.shared.system.easy_setup.load()
+    yield easy_setup
+    easy_setup.update(
+        ntpServerAddresses=[
+            "pool.ntp.org"
+        ],
+        dnsServerAddresses=[
+            "10.0.2.3"
+        ],
+        dnsSearchDomains=[
+            "olympus.f5net.com"
+        ]
+    )
+
+
+class TestEasySetup(object):
+    def test_load(self, easy_setup):
+        assert easy_setup.ntpServerAddresses == ['pool.ntp.org']
+        assert easy_setup.dnsServerAddresses == ['10.0.2.3']
+        assert easy_setup.dnsSearchDomains == ['olympus.f5net.com']
+
+    def test_update(self, easy_setup):
+        easy_setup.update(
+            ntpServerAddresses=['pool1.ntp.org']
+        )
+        assert easy_setup.ntpServerAddresses == ['pool1.ntp.org']
+        easy_setup.refresh()
+        assert easy_setup.ntpServerAddresses == ['pool1.ntp.org']


### PR DESCRIPTION
Issues:
Fixes #946

Problem:
The easy_setup API was not part of the sdk for iworkflow

Analysis:
This patch adds it

Tests:
functional