### PR TITLE
Fixes File Transfer Endpoint

### DIFF
--- a/f5/bigip/tm/asm/file_transfer.py
+++ b/f5/bigip/tm/asm/file_transfer.py
@@ -18,15 +18,17 @@
 import os
 
 from f5.bigip.mixins import AsmFileMixin
-from f5.bigip.resource import OrganizingCollection
+from f5.bigip.resource import Collection
 from f5.bigip.resource import PathElement
 from f5.sdk_exception import FileMustNotHaveDotISOExtension
 
 
-class File_Transfer(OrganizingCollection):
-    """BIG-IP® ASM Tasks organizing collection."""
+class File_Transfer(Collection):
+    """BIG-IP® ASM File Transfer collection."""
     def __init__(self, tm):
         super(File_Transfer, self).__init__(tm)
+        self._meta_data['object_has_stats'] = False
+        self._meta_data['minimum_version'] = '11.6.0'
         self._meta_data['allowed_lazy_attributes'] = [
             Uploads,
             Downloads,
@@ -37,6 +39,8 @@ class Uploads(PathElement, AsmFileMixin):
     """A file upload resource."""
     def __init__(self, file_transfer):
         super(Uploads, self).__init__(file_transfer)
+        self._meta_data['object_has_stats'] = False
+        self.file_bound_uri = ''
 
     def upload_file(self, filepathname, **kwargs):
         filename = os.path.basename(filepathname)
@@ -50,6 +54,8 @@ class Downloads(PathElement, AsmFileMixin):
     """A file download resource."""
     def __init__(self, file_transfer):
         super(Downloads, self).__init__(file_transfer)
+        self._meta_data['object_has_stats'] = False
+        self.file_bound_uri = ''
 
     def download_file(self, filepathname):
         filename = os.path.basename(filepathname)

--- a/f5/bigip/tm/asm/test/unit/test_file_transfer.py
+++ b/f5/bigip/tm/asm/test/unit/test_file_transfer.py
@@ -20,10 +20,11 @@ import requests_mock
 import struct
 
 from f5.bigip import ManagementRoot
-from f5.bigip.resource import OrganizingCollection
+from f5.bigip.resource import Collection
 from f5.bigip.tm.asm.file_transfer import Downloads
-from f5.bigip.tm.asm.file_transfer import FileMustNotHaveDotISOExtension
+from f5.bigip.tm.asm.file_transfer import Uploads
 from f5.sdk_exception import EmptyContent
+from f5.sdk_exception import FileMustNotHaveDotISOExtension
 from f5.sdk_exception import MissingHttpHeader
 
 from requests import HTTPError
@@ -44,17 +45,19 @@ def FakeDownload(session):
     fake_filetransfer = mock.MagicMock()
     fake_dwnld = Downloads(fake_filetransfer)
     fake_dwnld._meta_data['icr_session'] = session
+    fake_dwnld._meta_data['bigip'].tmos_version = '11.6.0'
     fake_dwnld._meta_data['uri'] = 'mock://test.com/'
     return fake_dwnld
 
 
-class TestTasksOC(object):
-    def test_OC(self, fakeicontrolsession):
+class TestFileTransferCollection(object):
+    def test_collection(self, fakeicontrolsession):
         b = ManagementRoot('192.168.1.1', 'admin', 'admin')
         c1 = b.tm.asm.file_transfer
-        assert isinstance(c1, OrganizingCollection)
-        assert hasattr(c1, 'downloads')
-        assert hasattr(c1, 'uploads')
+        test_meta = c1._meta_data['allowed_lazy_attributes']
+        assert isinstance(c1, Collection)
+        assert Downloads in test_meta
+        assert Uploads in test_meta
 
 
 def test_asm_file_uploads_70a(tmpdir, fakeicontrolsessionfactory):


### PR DESCRIPTION
Fixes #952, #944

Problem:
File Transfer Endpoint for ASM does not exist pre 11.6.0, also there were few minor changes that were required in the file-transfer class.

Analysis:
Added minimum version to asm file-transfer class, did a minor refactor of the asm file-transfer endpoint

Tests:
Flake8
Unit
Functional