### PR TITLE
Adds support for mgmt interface

### DIFF
--- a/f5/bigip/tm/sys/__init__.py
+++ b/f5/bigip/tm/sys/__init__.py
@@ -38,6 +38,8 @@ from f5.bigip.tm.sys.file import File
 from f5.bigip.tm.sys.folder import Folders
 from f5.bigip.tm.sys.global_settings import Global_Settings
 from f5.bigip.tm.sys.httpd import Httpd
+from f5.bigip.tm.sys.management_ip import Management_Ips
+from f5.bigip.tm.sys.management_route import Management_Routes
 from f5.bigip.tm.sys.ntp import Ntp
 from f5.bigip.tm.sys.performance import Performances
 from f5.bigip.tm.sys.snmp import Snmp
@@ -59,6 +61,8 @@ class Sys(OrganizingCollection):
             Performances,
             Dbs,
             Global_Settings,
+            Management_Ips,
+            Management_Routes,
             Ntp,
             Failover,
             Dns,

--- a/f5/bigip/tm/sys/management_ip.py
+++ b/f5/bigip/tm/sys/management_ip.py
@@ -1,0 +1,62 @@
+# coding=utf-8
+#
+# Copyright 2016 F5 Networks Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+
+"""BIG-IP® system syslog module
+
+REST URI
+    ``http://localhost/mgmt/tm/sys/management-ip``
+
+GUI Path
+    ``System --> Platform``
+
+REST Kind
+    ``tm:sys:management-ip:*``
+"""
+
+from f5.bigip.resource import Collection
+from f5.bigip.resource import Resource
+from f5.sdk_exception import UnsupportedMethod
+
+
+class Management_Ips(Collection):
+    """BIG-IP® management-ip collection"""
+    def __init__(self, sys):
+        super(Management_Ips, self).__init__(sys)
+        self._meta_data['allowed_lazy_attributes'] = [Management_Ip]
+        self._meta_data['attribute_registry'] =\
+            {'tm:sys:management-ip:management-ipstate': Management_Ip}
+
+
+class Management_Ip(Resource):
+    """BIG-IP® management-ip resource"""
+    def __init__(self, Management_Ips):
+        super(Management_Ip, self).__init__(Management_Ips)
+        self._meta_data['required_json_kind'] = \
+            'tm:sys:management-ip:management-ipstate'
+        self._meta_data['required_creation_parameters'].update(('name',))
+
+    def load(self, **kwargs):
+        kwargs['transform_name'] = True
+        return self._load(**kwargs)
+
+    def modify(self, **kwargs):
+        raise UnsupportedMethod(
+            "%s does not support the modify method" % self.__class__.__name__)
+
+    def update(self, **kwargs):
+        raise UnsupportedMethod(
+            "%s does not support the update method" % self.__class__.__name__)

--- a/f5/bigip/tm/sys/management_route.py
+++ b/f5/bigip/tm/sys/management_route.py
@@ -1,0 +1,50 @@
+# coding=utf-8
+#
+# Copyright 2016 F5 Networks Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+
+"""BIG-IP® system syslog module
+
+REST URI
+    ``http://localhost/mgmt/tm/sys/management-route``
+
+GUI Path
+    ``System --> Platform``
+
+REST Kind
+    ``tm:sys:management-route:management-routestate``
+"""
+
+from f5.bigip.resource import Collection
+from f5.bigip.resource import Resource
+
+
+class Management_Routes(Collection):
+    """BIG-IP® management-route collection"""
+    def __init__(self, sys):
+        super(Management_Routes, self).__init__(sys)
+        self._meta_data['allowed_lazy_attributes'] = [Management_Route]
+        self._meta_data['attribute_registry'] =\
+            {'tm:sys:management-route:management-routestate': Management_Route}
+
+
+class Management_Route(Resource):
+    """BIG-IP® system management-route resource"""
+    def __init__(self, Management_Routes):
+        super(Management_Route, self).__init__(Management_Routes)
+        self._meta_data['required_creation_parameters'].update(
+            ('name', 'network', 'gateway'))
+        self._meta_data['required_json_kind'] = \
+            'tm:sys:management-route:management-routestate'

--- a/f5/bigip/tm/sys/test/functional/test_management_ip.py
+++ b/f5/bigip/tm/sys/test/functional/test_management_ip.py
@@ -1,0 +1,96 @@
+# Copyright 2015-2106 F5 Networks Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import pytest
+
+from f5.bigip.resource import MissingRequiredCreationParameter
+from f5.sdk_exception import UnsupportedMethod
+from icontrol.exceptions import iControlUnexpectedHTTPError
+
+
+def setup_management_ip_test(request, mgmt_root):
+    def teardown():
+        try:
+            mgmt_root.tm.sys.management_ips.management_ip.load(
+                name=mip[0].name)
+        except iControlUnexpectedHTTPError:
+            mgmt_root.tm.sys.management_ips.management_ip.create(
+                name=mip[0].name)
+
+    request.addfinalizer(teardown)
+
+    mip = mgmt_root.tm.sys.management_ips.get_collection()
+    return mip
+
+
+def test_missing_required_params(mgmt_root):
+    with pytest.raises(MissingRequiredCreationParameter) as err:
+        mgmt_root.tm.sys.management_ips.management_ip.create()
+    assert 'Missing required params: [\'name\']' in str(err)
+
+
+def test_missing_mask(request, mgmt_root):
+    name = '172.16.44.15'
+    with pytest.raises(iControlUnexpectedHTTPError) as err:
+        mgmt_root.tm.sys.management_ips.management_ip.create(
+            name=name)
+    assert 'a netmask must be specified' in str(err.value.message)
+
+
+def test_invalid_addr(request, mgmt_root):
+    name = '/24'
+    with pytest.raises(iControlUnexpectedHTTPError) as err:
+        mgmt_root.tm.sys.management_ips.management_ip.create(
+            name=name)
+    assert 'invalid address' in str(err.value.message)
+
+
+def test_create_delete_addr(request, mgmt_root):
+    mip = setup_management_ip_test(request, mgmt_root)
+    assert mip[0].name == '172.16.44.15/24'
+
+    mip1 = mgmt_root.tm.sys.management_ips.management_ip.load(
+        name=mip[0].name)
+    assert mip1.name == mip[0].name
+    mip1.delete()
+
+    with pytest.raises(iControlUnexpectedHTTPError) as err:
+        mgmt_root.tm.sys.management_ips.management_ip.load(
+            name=mip[0].name)
+    assert ') was not found.' in str(err.value.message)
+
+    mip2 = mgmt_root.tm.sys.management_ips.management_ip.create(
+        name='172.16.44.16/24')
+    assert mip2.name == '172.16.44.16/24'
+
+
+def test_modify_addr(request, mgmt_root):
+    mip = setup_management_ip_test(request, mgmt_root)
+    mip1 = mgmt_root.tm.sys.management_ips.management_ip.load(
+        name=mip[0].name)
+    mip1.name = '172.16.44.20/24'
+    with pytest.raises(UnsupportedMethod) as err:
+        mip1.modify()
+    assert 'Management_Ip does not support the modify method' in str(err)
+
+
+def test_update_addr(request, mgmt_root):
+    mip = setup_management_ip_test(request, mgmt_root)
+    mip1 = mgmt_root.tm.sys.management_ips.management_ip.load(
+        name=mip[0].name)
+    mip1.name = '172.16.44.20/24'
+    with pytest.raises(UnsupportedMethod) as err:
+        mip1.update()
+    assert 'Management_Ip does not support the update method' in str(err)

--- a/f5/bigip/tm/sys/test/functional/test_management_route.py
+++ b/f5/bigip/tm/sys/test/functional/test_management_route.py
@@ -1,0 +1,69 @@
+# Copyright 2015-2106 F5 Networks Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import pytest
+
+from f5.bigip.resource import MissingRequiredCreationParameter
+
+
+def setup_management_route_test(request, mgmt_root, name, network, gateway):
+    def teardown():
+        if mgmt_root.tm.sys.management_routes.management_route.exists(
+                name=name):
+            mroute = mgmt_root.tm.sys.management_routes.management_route.load(
+                name=name)
+            mroute.delete()
+    request.addfinalizer(teardown)
+
+    mroute1 = mgmt_root.tm.sys.management_routes.management_route.create(
+        name=name,
+        network=network,
+        gateway=gateway)
+
+    return mroute1
+
+
+class TestMgmtRoute(object):
+    def test_missing_required_params(self, mgmt_root):
+        with pytest.raises(MissingRequiredCreationParameter) as err:
+            mgmt_root.tm.sys.management_routes.management_route.create()
+        assert 'Missing required params:' in str(err)
+
+    def test_CDU(self, request, mgmt_root):
+        mr1 = setup_management_route_test(request,
+                                          mgmt_root,
+                                          'testroute',
+                                          '192.168.15.0/24',
+                                          '192.168.1.1')
+
+        assert mr1.name == 'testroute'
+        assert mr1.network == '192.168.15.0/24'
+        assert mr1.gateway == '192.168.1.1'
+
+        # Change Gateway
+        mr1.gateway = '192.168.1.2'
+        mr1.update()
+        assert mr1.gateway == '192.168.1.2'
+
+        # Add Description
+        assert hasattr(mr1, 'description') is False
+        mr1.description = 'my test route'
+        mr1.update()
+        assert mr1.description == 'my test route'
+
+        # Delete Route
+        mr1.delete()
+        assert mgmt_root.tm.sys.management_routes.management_route.exists(
+            name='testroute') is False

--- a/f5/bigip/tm/sys/test/unit/test_management_ip.py
+++ b/f5/bigip/tm/sys/test/unit/test_management_ip.py
@@ -1,0 +1,41 @@
+# Copyright 2016 F5 Networks Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import mock
+import pytest
+
+
+from f5.bigip.tm.sys.management_ip import Management_Ip
+from f5.sdk_exception import UnsupportedMethod
+
+
+@pytest.fixture
+def FakeMgmtIp():
+    fake_sys = mock.MagicMock()
+    return Management_Ip(fake_sys)
+
+
+def test_update_raises(FakeMgmtIp):
+    with pytest.raises(UnsupportedMethod) as EIO:
+        FakeMgmtIp.update()
+    assert EIO.value.message == "Management_Ip does not support the update " \
+                                "method"
+
+
+def test_modify_raises(FakeMgmtIp):
+    with pytest.raises(UnsupportedMethod) as EIO:
+        FakeMgmtIp.modify()
+    assert EIO.value.message == "Management_Ip does not support the modify " \
+                                "method"

--- a/f5/bigip/tm/sys/test/unit/test_management_route.py
+++ b/f5/bigip/tm/sys/test/unit/test_management_route.py
@@ -1,0 +1,52 @@
+# Copyright 2016 F5 Networks Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import mock
+import pytest
+
+
+from f5.bigip.tm.sys.management_route import Management_Route
+from f5.sdk_exception import MissingRequiredCreationParameter
+
+
+@pytest.fixture
+def FakeMgmtRoute():
+    fake_sys = mock.MagicMock()
+    return Management_Route(fake_sys)
+
+
+def test_create_no_args(FakeMgmtRoute):
+    with pytest.raises(MissingRequiredCreationParameter) as EIO:
+        FakeMgmtRoute.create()
+    assert EIO.value.message == "Missing required params: ['network', " \
+                                "'gateway', 'name']"
+
+
+def test_create_missing_name(FakeMgmtRoute):
+    with pytest.raises(MissingRequiredCreationParameter) as EIO:
+        FakeMgmtRoute.create(gateway='192.168.1.1', network='172.16.15.0/24')
+    assert EIO.value.message == "Missing required params: ['name']"
+
+
+def test_create_missing_network(FakeMgmtRoute):
+    with pytest.raises(MissingRequiredCreationParameter) as EIO:
+        FakeMgmtRoute.create(name='testnet', gateway='192.168.1.1')
+    assert EIO.value.message == "Missing required params: ['network']"
+
+
+def test_create_missing_gateway(FakeMgmtRoute):
+    with pytest.raises(MissingRequiredCreationParameter) as EIO:
+        FakeMgmtRoute.create(name='testnet', network='172.16.15.0/24')
+    assert EIO.value.message == "Missing required params: ['gateway']"


### PR DESCRIPTION
Fixes #865

Files In Update:
Added:
f5/bigip/tm/sys/test/functional/test_management_ip.py
f5/bigip/tm/sys/test/functional/test_management_route.py
f5/bigip/tm/sys/test/functional/test_management_ip.py
f5/bigip/tm/sys/test/functional/test_management_route.py
f5/bigip/tm/sys/management_ip.py
f5/bigip/tm/sys/management_route.py

Changed:
f5/bigip/tm/sys/__init__.py

Tests:
Unit and Functional Tests (though management-ip tests will fail until test environment can be modified)