### PR TITLE
Adds roles api for iworkflo

### DIFF
--- a/f5/iworkflow/shared/authz/__init__.py
+++ b/f5/iworkflow/shared/authz/__init__.py
@@ -21,6 +21,7 @@ REST URI
 """
 
 from f5.iworkflow.resource import OrganizingCollection
+from f5.iworkflow.shared.authz.role import Roles_s
 from f5.iworkflow.shared.authz.user import Users_s
 
 
@@ -28,5 +29,6 @@ class Authz(OrganizingCollection):
     def __init__(self, shared):
         super(Authz, self).__init__(shared)
         self._meta_data['allowed_lazy_attributes'] = [
+            Roles_s,
             Users_s
         ]

--- a/f5/iworkflow/shared/authz/role.py
+++ b/f5/iworkflow/shared/authz/role.py
@@ -1,0 +1,48 @@
+# coding=utf-8
+#
+#  Copyright 2014-2016 F5 Networks Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+
+REST URI
+    ``http://localhost/mgmt/cm/shared/authz/roles``
+
+REST Kind
+    ``shared:authz:roles:*``
+"""
+
+from f5.iworkflow.resource import Collection
+from f5.iworkflow.resource import Resource
+
+
+class Roles_s(Collection):
+    def __init__(self, authz):
+        super(Roles_s, self).__init__(authz)
+        self._meta_data['required_json_kind'] = \
+            'shared:authz:roles:rolescollectionstate'
+        self._meta_data['allowed_lazy_attributes'] = [Role]
+        self._meta_data['attribute_registry'] = {
+            'shared:authz:roles:rolesworkerstate': Role
+        }
+
+
+class Role(Resource):
+    def __init__(self, roles_s):
+        super(Role, self).__init__(roles_s)
+        self._meta_data['required_load_parameters'] = set(('name',))
+        self._meta_data['required_creation_parameters'] = set(('name',))
+        self._meta_data['required_json_kind'] = \
+            'shared:authz:roles:rolesworkerstate'

--- a/f5/iworkflow/shared/authz/test/functional/test_role.py
+++ b/f5/iworkflow/shared/authz/test/functional/test_role.py
@@ -1,0 +1,41 @@
+# Copyright 2015-2106 F5 Networks Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import pytest
+
+
+@pytest.fixture(scope="module")
+def role(mgmt_root):
+    role = mgmt_root.shared.authz.roles_s.role.create(
+        name="foo-role",
+        description="Foo role"
+    )
+    yield role
+    role.delete()
+
+
+@pytest.fixture
+def roles(mgmt_root):
+    roles = mgmt_root.shared.authz.roles_s.get_collection()
+    return roles
+
+
+class TestRole(object):
+    def test_roles_collection(self, roles):
+        assert len(roles) >= 1
+
+    def test_create_role(self, role):
+        assert role.name == 'foo-role'
+        assert role.description == "Foo role"

--- a/f5/iworkflow/shared/authz/test/functional/test_user.py
+++ b/f5/iworkflow/shared/authz/test/functional/test_user.py
@@ -35,7 +35,7 @@ def users(mgmt_root):
 
 
 class TestUser(object):
-    def test_users_collect(self, users):
+    def test_users_collection(self, users):
         # There may be 2 users (like when running in vagrant)
         # or only 1 user (like if running in openstack)
         assert len(users) >= 1


### PR DESCRIPTION
Issues:
Fixes #962

Problem:
The iworkflow api for roles did not exist in the sdk

Analysis:
This patch adds it

Tests:
functional