### PR TITLE
Fixes LTM node endpoint

### DIFF
--- a/f5/bigip/tm/ltm/test/functional/test_node.py
+++ b/f5/bigip/tm/ltm/test/functional/test_node.py
@@ -84,11 +84,88 @@ class TestNode(object):
         n1, nc1 = setup_node_test(
             request, mgmt_root, 'Common', 'node1', '192.168.100.1')
         assert n1.state == 'unchecked'
-        n1.update(state='unchecked')
+        n1.update(state='user-down')
+        n2 = mgmt_root.tm.ltm.nodes.node.load(
+            name='node1', partition='Common')
+        assert n2.state == 'user-down'
+        assert n2.state == n1.state
+
+    def test_state_update_invalid_value_with_kwargs(self, request, mgmt_root):
+        n1, nc1 = setup_node_test(
+            request, mgmt_root, 'Common', 'node1', '192.168.100.1')
+        assert n1.state == 'unchecked'
+        n1.update(state='down')
         n2 = mgmt_root.tm.ltm.nodes.node.load(
             name='node1', partition='Common')
         assert n2.state == 'unchecked'
         assert n2.state == n1.state
+
+    def test_state_update_invalid_value(self, request, mgmt_root):
+        n1, nc1 = setup_node_test(
+            request, mgmt_root, 'Common', 'node1', '192.168.100.1')
+        assert n1.state == 'unchecked'
+        n1.state = 'down'
+        n1.update()
+        n2 = mgmt_root.tm.ltm.nodes.node.load(name='node1', partition='Common')
+        assert n2.state == 'unchecked'
+        assert n2.state == n1.state
+
+    def test_session_update_with_kwargs(self, request, mgmt_root):
+        n1, nc1 = setup_node_test(
+            request, mgmt_root, 'Common', 'node1', '192.168.100.1')
+        assert n1.session == 'user-enabled'
+        n1.update(session='user-disabled')
+        n2 = mgmt_root.tm.ltm.nodes.node.load(
+            name='node1', partition='Common')
+        assert n2.session == 'user-disabled'
+        assert n2.session == n1.session
+
+    def test_session_update_invalid_value_with_kwargs(self, request,
+                                                      mgmt_root):
+        n1, nc1 = setup_node_test(
+            request, mgmt_root, 'Common', 'node1', '192.168.100.1')
+        assert n1.session == 'user-enabled'
+        n1.update(session='monitor-enabled')
+        n2 = mgmt_root.tm.ltm.nodes.node.load(
+            name='node1', partition='Common')
+        assert n2.session == 'user-enabled'
+        assert n2.session == n1.session
+
+    def test_session_update_invalid_value(self, request, mgmt_root):
+        n1, nc1 = setup_node_test(
+            request, mgmt_root, 'Common', 'node1', '192.168.100.1')
+        assert n1.session == 'user-enabled'
+        n1.session = 'monitor-enabled'
+        n1.update()
+        n2 = mgmt_root.tm.ltm.nodes.node.load(name='node1', partition='Common')
+        assert n2.session == 'user-enabled'
+        assert n2.session == n1.session
+
+    def test_update_session_state(self, request, mgmt_root):
+        n1, nc1 = setup_node_test(
+            request, mgmt_root, 'Common', 'node1', '192.168.100.1')
+        assert n1.session == 'user-enabled'
+        assert n1.state == 'unchecked'
+        n1.session = 'user-disabled'
+        n1.state = 'user-down'
+        n1.update()
+        n2 = mgmt_root.tm.ltm.nodes.node.load(name='node1', partition='Common')
+        n2.session = 'user-disabled'
+        n2.state = 'user-down'
+        n2.session = n1.session
+        n2.state = n1.state
+
+    def test_update_session_state_kwargs(self, request, mgmt_root):
+        n1, nc1 = setup_node_test(
+            request, mgmt_root, 'Common', 'node1', '192.168.100.1')
+        assert n1.session == 'user-enabled'
+        assert n1.state == 'unchecked'
+        n1.update(session='user-disabled', state='user-down')
+        n2 = mgmt_root.tm.ltm.nodes.node.load(name='node1', partition='Common')
+        n2.session = 'user-disabled'
+        n2.state = 'user-down'
+        n2.session = n1.session
+        n2.state = n1.state
 
     def test_state_modify(self, request, mgmt_root):
         n1, nc1 = setup_node_test(
@@ -104,9 +181,22 @@ class TestNode(object):
         n1, nc1 = setup_node_test(
             request, mgmt_root, 'Common', 'node1', '10.10.10.1')
         with pytest.raises(NodeStateModifyUnsupported) as ex:
-            n1.modify(state='unchecked')
-        assert "The node resource does not support a modify with the value " \
-            "of the 'state' attribute as 'unchecked'." == ex.value.message
+            n1.modify(state='down')
+        assert ex.value.message == "The node resource does not support a " \
+                                   "modify with the value of the 'state' " \
+                                   "attribute as down. The accepted values " \
+                                   "are 'user-up' or 'user-down'"
+
+    def test_session_modify_error(self, request, mgmt_root):
+        n1, nc1 = setup_node_test(
+            request, mgmt_root, 'Common', 'node1', '10.10.10.1')
+        with pytest.raises(NodeStateModifyUnsupported) as ex:
+            n1.modify(state='monitor-enabled')
+        assert ex.value.message == "The node resource does not support a " \
+                                   "modify with the value of the 'state' " \
+                                   "attribute as monitor-enabled. " \
+                                   "The accepted values are " \
+                                   "'user-up' or 'user-down'"
 
 
 class TestNodes(object):


### PR DESCRIPTION
Fixes #840

Problem:
Updating or modifying node might fail under certain circumstances.

Analysis:
Added and expanded kwargs and \_\_dict\_\_ checking on update() method calls. Modified exceptions for modify() methods to reflect findings in #840. Added functional tests

Tests:
Flake8
Functional