### PR TITLE
Fixes #975 #968 #833

### DIFF
--- a/f5/bigip/mixins.py
+++ b/f5/bigip/mixins.py
@@ -401,3 +401,10 @@ class CheckExistenceMixin(object):
             if item.name == item_name:
                 return True
         return False
+
+    def _return_object(self, container, item_name):
+        """Helper method to retrieve the object"""
+        coll = container.get_collection()
+        for item in coll:
+            if item.name == item_name:
+                return item


### PR DESCRIPTION
Fixes #975 #968 #833

Problem:
There multiple issues with creating/loading with virtual server policies subcollection in 11.5.4 and 12.1.1. Some of the virtual server tests required some refactor and supplementation.

Analysis:
Added custom _create, _load methods to the resources to work around issues in 11.5.4 and 12.1.1. Refactored some of the virtual server functional tests

Tests:
Functional
Flake8