### PR TITLE
Asm policies 1160 1of2

### DIFF
--- a/f5/bigip/tm/asm/policies.py
+++ b/f5/bigip/tm/asm/policies.py
@@ -81,7 +81,9 @@ class Policy(AsmResource):
             'tm:asm:policies:ip-intelligence:ip-intelligencestate':
                 Ip_Intelligence,
             'tm:asm:policies:csrf-protection:csrf-protectionstate':
-                Csrf_Protection
+                Csrf_Protection,
+            'tm:asm:policies:redirection-protection:'
+            'redirection-protectionstate': Redirection_Protection
         }
         self._set_attr_reg()
 
@@ -964,6 +966,27 @@ class Csrf_Protection(UnnamedResource):
 
     def update(self, **kwargs):
         """Update is not supported for Csrf Protection resource
+
+        :raises: UnsupportedOperation
+        """
+        raise UnsupportedOperation(
+            "%s does not support the update method" % self.__class__.__name__
+        )
+
+
+class Redirection_Protection(UnnamedResource):
+    """BIG-IP® ASM Redirection Protection resource."""
+    def __init__(self, policy):
+        super(Redirection_Protection, self).__init__(policy)
+        self._meta_data['required_json_kind'] = \
+            'tm:asm:policies:redirection-protection:' \
+            'redirection-protectionstate'
+        self._meta_data['required_load_parameters'] = set()
+        self._meta_data['object_has_stats'] = False
+        self._meta_data['minimum_version'] = '11.6.0'
+
+    def update(self, **kwargs):
+        """Update is not supported for Redirection Protection resource
 
         :raises: UnsupportedOperation
         """

--- a/f5/bigip/tm/asm/policies.py
+++ b/f5/bigip/tm/asm/policies.py
@@ -83,7 +83,9 @@ class Policy(AsmResource):
             'tm:asm:policies:csrf-protection:csrf-protectionstate':
                 Csrf_Protection,
             'tm:asm:policies:redirection-protection:'
-            'redirection-protectionstate': Redirection_Protection
+            'redirection-protectionstate': Redirection_Protection,
+            'tm:asm:policies:login-enforcement:login-enforcementstate':
+                Login_Enforcement
         }
         self._set_attr_reg()
 
@@ -987,6 +989,26 @@ class Redirection_Protection(UnnamedResource):
 
     def update(self, **kwargs):
         """Update is not supported for Redirection Protection resource
+
+        :raises: UnsupportedOperation
+        """
+        raise UnsupportedOperation(
+            "%s does not support the update method" % self.__class__.__name__
+        )
+
+
+class Login_Enforcement(UnnamedResource):
+    """BIG-IP® ASM Login Enforcement resource."""
+    def __init__(self, policy):
+        super(Login_Enforcement, self).__init__(policy)
+        self._meta_data['required_json_kind'] = \
+            'tm:asm:policies:login-enforcement:login-enforcementstate"'
+        self._meta_data['required_load_parameters'] = set()
+        self._meta_data['object_has_stats'] = False
+        self._meta_data['minimum_version'] = '11.6.0'
+
+    def update(self, **kwargs):
+        """Update is not supported for Login Enforcement resource
 
         :raises: UnsupportedOperation
         """

--- a/f5/bigip/tm/asm/policies.py
+++ b/f5/bigip/tm/asm/policies.py
@@ -79,7 +79,9 @@ class Policy(AsmResource):
             'tm:asm:policies:login-pages:login-pagecollectionstate':
                 Login_Pages_s,
             'tm:asm:policies:ip-intelligence:ip-intelligencestate':
-                Ip_Intelligence
+                Ip_Intelligence,
+            'tm:asm:policies:csrf-protection:csrf-protectionstate':
+                Csrf_Protection
         }
         self._set_attr_reg()
 
@@ -942,6 +944,26 @@ class Ip_Intelligence(UnnamedResource):
 
     def update(self, **kwargs):
         """Update is not supported for IP Intelligence resource
+
+        :raises: UnsupportedOperation
+        """
+        raise UnsupportedOperation(
+            "%s does not support the update method" % self.__class__.__name__
+        )
+
+
+class Csrf_Protection(UnnamedResource):
+    """BIG-IP® ASM Csrf Protection resource."""
+    def __init__(self, policy):
+        super(Csrf_Protection, self).__init__(policy)
+        self._meta_data['required_json_kind'] = \
+            'tm:asm:policies:csrf-protection:csrf-protectionstate'
+        self._meta_data['required_load_parameters'] = set()
+        self._meta_data['object_has_stats'] = False
+        self._meta_data['minimum_version'] = '11.6.0'
+
+    def update(self, **kwargs):
+        """Update is not supported for Csrf Protection resource
 
         :raises: UnsupportedOperation
         """

--- a/f5/bigip/tm/asm/policies.py
+++ b/f5/bigip/tm/asm/policies.py
@@ -75,7 +75,9 @@ class Policy(AsmResource):
             '-settingsstate': Session_Tracking,
             'tm:asm:policies:session-tracking-'
             'statuses:session-tracking-statuscollectionstate':
-                Session_Tracking_Statuses_s
+                Session_Tracking_Statuses_s,
+            'tm:asm:policies:login-pages:login-pagecollectionstate':
+                Login_Pages_s
         }
         self._set_attr_reg()
 
@@ -900,3 +902,27 @@ class Session_Tracking_Status(AsmResource):
         raise UnsupportedOperation(
             "%s does not support the modify method" % self.__class__.__name__
         )
+
+
+class Login_Pages_s(Collection):
+    """BIG-IP® ASM Login Pages sub-collection."""
+    def __init__(self, policy):
+        super(Login_Pages_s, self).__init__(policy)
+        self._meta_data['object_has_stats'] = False
+        self._meta_data['minimum_version'] = '11.6.0'
+        self._meta_data['allowed_lazy_attributes'] = [Login_Page]
+        self._meta_data['required_json_kind'] = \
+            'tm:asm:policies:login-pages:login-pagecollectionstate'
+        self._meta_data['attribute_registry'] = {
+            'tm:asm:policies:login-pages:login-pagestate':
+                Login_Page}
+
+
+class Login_Page(AsmResource):
+    """BIG-IP® ASM Login Page Resource."""
+    def __init__(self, host_names_s):
+        super(Login_Page, self).__init__(host_names_s)
+        self._meta_data['required_json_kind'] = \
+            'tm:asm:policies:login-pages:login-pagestate'
+        self._meta_data['required_creation_parameters'] = \
+            set(('accessValidation', 'urlReference',))

--- a/f5/bigip/tm/asm/policies.py
+++ b/f5/bigip/tm/asm/policies.py
@@ -85,7 +85,9 @@ class Policy(AsmResource):
             'tm:asm:policies:redirection-protection:'
             'redirection-protectionstate': Redirection_Protection,
             'tm:asm:policies:login-enforcement:login-enforcementstate':
-                Login_Enforcement
+                Login_Enforcement,
+            'tm:asm:policies:sensitive-parameters:'
+            'sensitive-parametercollectionstate': Sensitive_Parameters_s
         }
         self._set_attr_reg()
 
@@ -761,8 +763,8 @@ class History_Revisions_s(Collection):
 
 class History_Revision(AsmResource):
     """BIG-IP® ASM History Revision resource."""
-    def __init__(self, response_pages_s):
-        super(History_Revision, self).__init__(response_pages_s)
+    def __init__(self, history_revisions_s):
+        super(History_Revision, self).__init__(history_revisions_s)
         self._meta_data['required_json_kind'] = \
             'tm:asm:policies:history-revisions:history-revisionstate'
 
@@ -894,8 +896,9 @@ class Session_Tracking_Statuses_s(Collection):
 
 class Session_Tracking_Status(AsmResource):
     """BIG-IP® ASM Session TrackingStatus resource."""
-    def __init__(self, response_pages_s):
-        super(Session_Tracking_Status, self).__init__(response_pages_s)
+    def __init__(self, session_tracking_statuses_s):
+        super(Session_Tracking_Status, self).__init__(
+            session_tracking_statuses_s)
         self._meta_data['required_json_kind'] = \
             'tm:asm:policies:session-tracking-statuses:' \
             'session-tracking-statusstate'
@@ -928,8 +931,8 @@ class Login_Pages_s(Collection):
 
 class Login_Page(AsmResource):
     """BIG-IP® ASM Login Page Resource."""
-    def __init__(self, host_names_s):
-        super(Login_Page, self).__init__(host_names_s)
+    def __init__(self, login_pages_s):
+        super(Login_Page, self).__init__(login_pages_s)
         self._meta_data['required_json_kind'] = \
             'tm:asm:policies:login-pages:login-pagestate'
         self._meta_data['required_creation_parameters'] = \
@@ -1009,6 +1012,38 @@ class Login_Enforcement(UnnamedResource):
 
     def update(self, **kwargs):
         """Update is not supported for Login Enforcement resource
+
+        :raises: UnsupportedOperation
+        """
+        raise UnsupportedOperation(
+            "%s does not support the update method" % self.__class__.__name__
+        )
+
+
+class Sensitive_Parameters_s(Collection):
+    """BIG-IP® ASM Sensitive Parameters sub-collection."""
+    def __init__(self, policy):
+        super(Sensitive_Parameters_s, self).__init__(policy)
+        self._meta_data['object_has_stats'] = False
+        self._meta_data['minimum_version'] = '11.6.0'
+        self._meta_data['allowed_lazy_attributes'] = [Sensitive_Parameter]
+        self._meta_data['required_json_kind'] = \
+            'tm:asm:policies:sensitive-parameters:' \
+            'sensitive-parametercollectionstate'
+        self._meta_data['attribute_registry'] = {
+            'tm:asm:policies:sensitive-parameters:sensitive-parameterstate':
+                Sensitive_Parameter}
+
+
+class Sensitive_Parameter(AsmResource):
+    """BIG-IP® ASM Sensitive Parameters Resource."""
+    def __init__(self, sensitive_parameters_s):
+        super(Sensitive_Parameter, self).__init__(sensitive_parameters_s)
+        self._meta_data['required_json_kind'] = \
+            'tm:asm:policies:sensitive-parameters:sensitive-parameterstate'
+
+    def modify(self, **kwargs):
+        """Modify is not supported for Sensitive Parameters resource
 
         :raises: UnsupportedOperation
         """

--- a/f5/bigip/tm/asm/policies.py
+++ b/f5/bigip/tm/asm/policies.py
@@ -77,7 +77,9 @@ class Policy(AsmResource):
             'statuses:session-tracking-statuscollectionstate':
                 Session_Tracking_Statuses_s,
             'tm:asm:policies:login-pages:login-pagecollectionstate':
-                Login_Pages_s
+                Login_Pages_s,
+            'tm:asm:policies:ip-intelligence:ip-intelligencestate':
+                Ip_Intelligence
         }
         self._set_attr_reg()
 
@@ -926,3 +928,23 @@ class Login_Page(AsmResource):
             'tm:asm:policies:login-pages:login-pagestate'
         self._meta_data['required_creation_parameters'] = \
             set(('accessValidation', 'urlReference',))
+
+
+class Ip_Intelligence(UnnamedResource):
+    """BIG-IP® ASM IP Intelligence resource."""
+    def __init__(self, policy):
+        super(Ip_Intelligence, self).__init__(policy)
+        self._meta_data['required_json_kind'] = \
+            'tm:asm:policies:ip-intelligence:ip-intelligencestate'
+        self._meta_data['required_load_parameters'] = set()
+        self._meta_data['object_has_stats'] = False
+        self._meta_data['minimum_version'] = '11.6.0'
+
+    def update(self, **kwargs):
+        """Update is not supported for IP Intelligence resource
+
+        :raises: UnsupportedOperation
+        """
+        raise UnsupportedOperation(
+            "%s does not support the update method" % self.__class__.__name__
+        )

--- a/f5/bigip/tm/asm/test/functional/test_policies.py
+++ b/f5/bigip/tm/asm/test/functional/test_policies.py
@@ -2314,3 +2314,54 @@ class TestIPIntelligence(object):
         r1.refresh()
         assert r1.enabled is True
         assert hasattr(r1, 'ipIntelligenceCategories')
+
+
+@pytest.mark.skipif(
+    LooseVersion(pytest.config.getoption('--release')) < LooseVersion(
+        '11.6.0'),
+    reason='This collection is fully implemented on 11.6.0 or greater.'
+)
+class TestCsrfProtection(object):
+    def test_update_raises(self, policy):
+        with pytest.raises(UnsupportedOperation):
+            policy.csrf_protection.update()
+
+    def test_modify(self, policy):
+        r1 = policy.csrf_protection.load()
+        original_dict = copy.copy(r1.__dict__)
+        itm = 'enabled'
+        r1.modify(enabled=True)
+        for k, v in iteritems(original_dict):
+            if k != itm:
+                original_dict[k] = r1.__dict__[k]
+            elif k == itm:
+                assert r1.__dict__[k] is True
+
+    def test_load(self, policy):
+        r1 = policy.csrf_protection.load()
+        assert r1.kind == \
+            'tm:asm:policies:csrf-protection:csrf-protectionstate'
+        assert r1.enabled is True
+        assert hasattr(r1, 'expirationTimeInSeconds')
+        r1.modify(enabled=False)
+        assert r1.enabled is False
+        assert not hasattr(r1, 'expirationTimeInSeconds')
+        r2 = policy.csrf_protection.load()
+        assert r1.kind == r2.kind
+        assert r1.enabled == r2.enabled
+
+    def test_refresh(self, policy):
+        r1 = policy.csrf_protection.load()
+        assert r1.kind == \
+            'tm:asm:policies:csrf-protection:csrf-protectionstate'
+        assert r1.enabled is False
+        assert not hasattr(r1, 'expirationTimeInSeconds')
+        r2 = policy.csrf_protection.load()
+        assert r1.kind == r2.kind
+        assert r1.enabled == r2.enabled
+        r2.modify(enabled=True)
+        assert r2.enabled is True
+        assert hasattr(r2, 'expirationTimeInSeconds')
+        r1.refresh()
+        assert r1.enabled is True
+        assert hasattr(r1, 'expirationTimeInSeconds')

--- a/f5/bigip/tm/asm/test/functional/test_policies.py
+++ b/f5/bigip/tm/asm/test/functional/test_policies.py
@@ -2263,3 +2263,54 @@ class TestLoginPages(object):
         assert isinstance(cc, list)
         assert len(cc)
         assert isinstance(cc[0], Login_Page)
+
+
+@pytest.mark.skipif(
+    LooseVersion(pytest.config.getoption('--release')) < LooseVersion(
+        '11.6.0'),
+    reason='This collection is fully implemented on 11.6.0 or greater.'
+)
+class TestIPIntelligence(object):
+    def test_update_raises(self, policy):
+        with pytest.raises(UnsupportedOperation):
+            policy.ip_intelligence.update()
+
+    def test_modify(self, policy):
+        r1 = policy.ip_intelligence.load()
+        original_dict = copy.copy(r1.__dict__)
+        itm = 'enabled'
+        r1.modify(enabled=True)
+        for k, v in iteritems(original_dict):
+            if k != itm:
+                original_dict[k] = r1.__dict__[k]
+            elif k == itm:
+                assert r1.__dict__[k] is True
+
+    def test_load(self, policy):
+        r1 = policy.ip_intelligence.load()
+        assert r1.kind == \
+            'tm:asm:policies:ip-intelligence:ip-intelligencestate'
+        assert r1.enabled is True
+        assert hasattr(r1, 'ipIntelligenceCategories')
+        r1.modify(enabled=False)
+        assert r1.enabled is False
+        assert not hasattr(r1, 'ipIntelligenceCategories')
+        r2 = policy.ip_intelligence.load()
+        assert r1.kind == r2.kind
+        assert r1.enabled == r2.enabled
+
+    def test_refresh(self, policy):
+        r1 = policy.ip_intelligence.load()
+        assert r1.kind == \
+            'tm:asm:policies:ip-intelligence:ip-intelligencestate'
+        assert r1.enabled is False
+        assert not hasattr(r1, 'ipIntelligenceCategories')
+        r2 = policy.ip_intelligence.load()
+        assert r1.kind == r2.kind
+        assert r1.enabled == r2.enabled
+        r2.modify(enabled=True)
+        assert r2.enabled is True
+        assert hasattr(r2, 'ipIntelligenceCategories')
+        r1.refresh()
+        assert r1.enabled is True
+        assert hasattr(r1, 'ipIntelligenceCategories')

--- a/f5/bigip/tm/asm/test/unit/test_policies.py
+++ b/f5/bigip/tm/asm/test/unit/test_policies.py
@@ -33,6 +33,7 @@ from f5.bigip.tm.asm.policies import Policy
 from f5.bigip.tm.asm.policies import Policy_Builder
 from f5.bigip.tm.asm.policies import Redirection_Protection
 from f5.bigip.tm.asm.policies import Response_Page
+from f5.bigip.tm.asm.policies import Sensitive_Parameter
 from f5.bigip.tm.asm.policies import Session_Tracking
 from f5.bigip.tm.asm.policies import Session_Tracking_Status
 from f5.bigip.tm.asm.policies import Signature
@@ -49,6 +50,14 @@ from f5.sdk_exception import UnsupportedOperation
 import mock
 import pytest
 from six import iterkeys
+
+
+@pytest.fixture
+def FakeSens():
+    fake_policy = mock.MagicMock()
+    fake_resp = Sensitive_Parameter(fake_policy)
+    fake_resp._meta_data['bigip'].tmos_version = '11.6.0'
+    return fake_resp
 
 
 @pytest.fixture
@@ -444,3 +453,9 @@ class TestLoginEnforcement(object):
     def test_update_raises(self, FakeLog):
         with pytest.raises(UnsupportedOperation):
             FakeLog.update()
+
+
+class TestSensitiveParameters(object):
+    def test_modify_raises(self, FakeSens):
+        with pytest.raises(UnsupportedOperation):
+            FakeSens.modify()

--- a/f5/bigip/tm/asm/test/unit/test_policies.py
+++ b/f5/bigip/tm/asm/test/unit/test_policies.py
@@ -15,6 +15,7 @@
 
 from f5.bigip import ManagementRoot
 from f5.bigip.tm.asm import Asm
+from f5.bigip.tm.asm.policies import Csrf_Protection
 from f5.bigip.tm.asm.policies import Data_Guard
 from f5.bigip.tm.asm.policies import Evasion
 from f5.bigip.tm.asm.policies import Geolocation_Enforcement
@@ -46,6 +47,14 @@ from f5.sdk_exception import UnsupportedOperation
 import mock
 import pytest
 from six import iterkeys
+
+
+@pytest.fixture
+def FakeCsrf():
+    fake_policy = mock.MagicMock()
+    fake_resp = Csrf_Protection(fake_policy)
+    fake_resp._meta_data['bigip'].tmos_version = '11.6.0'
+    return fake_resp
 
 
 @pytest.fixture
@@ -399,3 +408,9 @@ class TestIPIntelligence(object):
     def test_update_raises(self, FakeIP):
         with pytest.raises(UnsupportedOperation):
             FakeIP.update()
+
+
+class TestCrfProtection(object):
+    def test_update_raises(self, FakeCsrf):
+        with pytest.raises(UnsupportedOperation):
+            FakeCsrf.update()

--- a/f5/bigip/tm/asm/test/unit/test_policies.py
+++ b/f5/bigip/tm/asm/test/unit/test_policies.py
@@ -21,6 +21,7 @@ from f5.bigip.tm.asm.policies import Geolocation_Enforcement
 from f5.bigip.tm.asm.policies import Header
 from f5.bigip.tm.asm.policies import History_Revision
 from f5.bigip.tm.asm.policies import Http_Protocol
+from f5.bigip.tm.asm.policies import Login_Page
 from f5.bigip.tm.asm.policies import Parameter
 from f5.bigip.tm.asm.policies import Parameters_s
 from f5.bigip.tm.asm.policies import ParametersCollection
@@ -200,6 +201,14 @@ def FakeSess():
     return fake_g
 
 
+@pytest.fixture
+def FakeLogin():
+    fake_policy = mock.MagicMock()
+    fake_g = Login_Page(fake_policy)
+    fake_g._meta_data['bigip'].tmos_version = '11.6.0'
+    return fake_g
+
+
 class TestPolicy(object):
     def test_create_two(self, fakeicontrolsession):
         b = ManagementRoot('192.168.1.1', 'admin', 'admin')
@@ -369,3 +378,9 @@ class TestSessionTrackingStatuses(object):
     def test_update_raises(self, FakeSess):
         with pytest.raises(UnsupportedOperation):
             FakeSess.modify()
+
+
+class TestLoginPages(object):
+    def test_create_no_args(self, FakeLogin):
+        with pytest.raises(MissingRequiredCreationParameter):
+            FakeLogin.create()

--- a/f5/bigip/tm/asm/test/unit/test_policies.py
+++ b/f5/bigip/tm/asm/test/unit/test_policies.py
@@ -23,6 +23,7 @@ from f5.bigip.tm.asm.policies import Header
 from f5.bigip.tm.asm.policies import History_Revision
 from f5.bigip.tm.asm.policies import Http_Protocol
 from f5.bigip.tm.asm.policies import Ip_Intelligence
+from f5.bigip.tm.asm.policies import Login_Enforcement
 from f5.bigip.tm.asm.policies import Login_Page
 from f5.bigip.tm.asm.policies import Parameter
 from f5.bigip.tm.asm.policies import Parameters_s
@@ -48,6 +49,14 @@ from f5.sdk_exception import UnsupportedOperation
 import mock
 import pytest
 from six import iterkeys
+
+
+@pytest.fixture
+def FakeLog():
+    fake_policy = mock.MagicMock()
+    fake_resp = Login_Enforcement(fake_policy)
+    fake_resp._meta_data['bigip'].tmos_version = '11.6.0'
+    return fake_resp
 
 
 @pytest.fixture
@@ -429,3 +438,9 @@ class TestRedirectionProtection(object):
     def test_update_raises(self, FakeRedir):
         with pytest.raises(UnsupportedOperation):
             FakeRedir.update()
+
+
+class TestLoginEnforcement(object):
+    def test_update_raises(self, FakeLog):
+        with pytest.raises(UnsupportedOperation):
+            FakeLog.update()

--- a/f5/bigip/tm/asm/test/unit/test_policies.py
+++ b/f5/bigip/tm/asm/test/unit/test_policies.py
@@ -30,6 +30,7 @@ from f5.bigip.tm.asm.policies import ParametersCollection
 from f5.bigip.tm.asm.policies import ParametersResource
 from f5.bigip.tm.asm.policies import Policy
 from f5.bigip.tm.asm.policies import Policy_Builder
+from f5.bigip.tm.asm.policies import Redirection_Protection
 from f5.bigip.tm.asm.policies import Response_Page
 from f5.bigip.tm.asm.policies import Session_Tracking
 from f5.bigip.tm.asm.policies import Session_Tracking_Status
@@ -47,6 +48,14 @@ from f5.sdk_exception import UnsupportedOperation
 import mock
 import pytest
 from six import iterkeys
+
+
+@pytest.fixture
+def FakeRedir():
+    fake_policy = mock.MagicMock()
+    fake_resp = Redirection_Protection(fake_policy)
+    fake_resp._meta_data['bigip'].tmos_version = '11.6.0'
+    return fake_resp
 
 
 @pytest.fixture
@@ -414,3 +423,9 @@ class TestCrfProtection(object):
     def test_update_raises(self, FakeCsrf):
         with pytest.raises(UnsupportedOperation):
             FakeCsrf.update()
+
+
+class TestRedirectionProtection(object):
+    def test_update_raises(self, FakeRedir):
+        with pytest.raises(UnsupportedOperation):
+            FakeRedir.update()

--- a/f5/bigip/tm/asm/test/unit/test_policies.py
+++ b/f5/bigip/tm/asm/test/unit/test_policies.py
@@ -21,6 +21,7 @@ from f5.bigip.tm.asm.policies import Geolocation_Enforcement
 from f5.bigip.tm.asm.policies import Header
 from f5.bigip.tm.asm.policies import History_Revision
 from f5.bigip.tm.asm.policies import Http_Protocol
+from f5.bigip.tm.asm.policies import Ip_Intelligence
 from f5.bigip.tm.asm.policies import Login_Page
 from f5.bigip.tm.asm.policies import Parameter
 from f5.bigip.tm.asm.policies import Parameters_s
@@ -45,6 +46,14 @@ from f5.sdk_exception import UnsupportedOperation
 import mock
 import pytest
 from six import iterkeys
+
+
+@pytest.fixture
+def FakeIP():
+    fake_policy = mock.MagicMock()
+    fake_resp = Ip_Intelligence(fake_policy)
+    fake_resp._meta_data['bigip'].tmos_version = '11.6.0'
+    return fake_resp
 
 
 @pytest.fixture
@@ -384,3 +393,9 @@ class TestLoginPages(object):
     def test_create_no_args(self, FakeLogin):
         with pytest.raises(MissingRequiredCreationParameter):
             FakeLogin.create()
+
+
+class TestIPIntelligence(object):
+    def test_update_raises(self, FakeIP):
+        with pytest.raises(UnsupportedOperation):
+            FakeIP.update()


### PR DESCRIPTION
Fixes #1007 #1008 #1009 #1010 #1011 #1012

Problem:
Multiple endpoints missing from ASM policies for version 11.6.0 and up

Analysis:
Multiple endpoints were added to ASM policies in 11.6.0, this is the one of 2 patches to address the remainder missing endpoints

Tests:
Functional
Unit
Flake8