### PR TITLE
Fixes #959

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,6 @@ services:
   - docker
 python:
   - '2.7'
-  - '2.6'
 before_install:
   - git config --global user.email "OpenStack_TravisCI@f5.com"
   - git config --global user.name "Travis F5 Openstack"

--- a/f5/bigip/resource.py
+++ b/f5/bigip/resource.py
@@ -687,12 +687,11 @@ class ResourceBase(PathElement, ToDictMixin):
             config_dict.pop(key2)
         return config_dict
 
-# Commenting this method for now, until we remove python 2.6 from travis
-#    @property
-#    def properties(self):
-#        no_meta_dict = {k: v for k, v in self.__dict__.iteritems()
-#                        if k != '_meta_data'}
-#        return no_meta_dict
+    @property
+    def properties(self):
+        no_meta_dict = {k: v for k, v in self.__dict__.iteritems()
+                        if k != '_meta_data'}
+        return no_meta_dict
 
 
 class OrganizingCollection(ResourceBase):

--- a/f5/bigip/test/unit/test_resource.py
+++ b/f5/bigip/test/unit/test_resource.py
@@ -799,7 +799,6 @@ def test_ResourceBase():
     assert str(delete_EIO.value) == "Only Resources support 'delete'."
 
 
-@pytest.mark.skip(msg='Disabling This test until we enable the method again')
 def test_resource_base_properties():
     MockBigIP = mock.MagicMock(name='MockBigIP')
     MockBigIP._meta_data = {'uri': 'https://TESTDOMAIN/mgmt/tm/',


### PR DESCRIPTION
Problem:
Python 2.6 on Travis is depracated

Analysis:
We drop testing for python 2.6 on Travis with this patch, also previous disabled properties method is enabled

Tests:
Unit
Flake8