### PR TITLE
Asm policy part2

### DIFF
--- a/f5/bigip/tm/asm/policies.py
+++ b/f5/bigip/tm/asm/policies.py
@@ -87,7 +87,10 @@ class Policy(AsmResource):
             'tm:asm:policies:login-enforcement:login-enforcementstate':
                 Login_Enforcement,
             'tm:asm:policies:sensitive-parameters:'
-            'sensitive-parametercollectionstate': Sensitive_Parameters_s
+            'sensitive-parametercollectionstate': Sensitive_Parameters_s,
+            'tm:asm:policies:brute-force-attack-preventions:'
+            'brute-force-attack-preventioncollectionstate':
+                Brute_Force_Attack_Preventions_s
         }
         self._set_attr_reg()
 
@@ -1050,3 +1053,32 @@ class Sensitive_Parameter(AsmResource):
         raise UnsupportedOperation(
             "%s does not support the update method" % self.__class__.__name__
         )
+
+
+class Brute_Force_Attack_Preventions_s(Collection):
+    """BIG-IP® ASM Brute Force Attack Preventions sub-collection."""
+    def __init__(self, policy):
+        super(Brute_Force_Attack_Preventions_s, self).__init__(policy)
+        self._meta_data['object_has_stats'] = False
+        self._meta_data['minimum_version'] = '11.6.0'
+        self._meta_data['allowed_lazy_attributes'] = \
+            [Brute_Force_Attack_Prevention]
+        self._meta_data['required_json_kind'] = \
+            'tm:asm:policies:brute-force-attack-preventions:' \
+            'brute-force-attack-preventioncollectionstate'
+        self._meta_data['attribute_registry'] = {
+            'tm:asm:policies:brute-force-attack-preventions:'
+            'brute-force-attack-preventionstate':
+                Brute_Force_Attack_Prevention}
+
+
+class Brute_Force_Attack_Prevention(AsmResource):
+    """BIG-IP® ASM Brute Force Attack Prevention Resource."""
+    def __init__(self, brute_force_attack_preventions_s):
+        super(Brute_Force_Attack_Prevention, self).__init__(
+            brute_force_attack_preventions_s)
+        self._meta_data['required_json_kind'] = \
+            'tm:asm:policies:brute-force-attack-preventions:' \
+            'brute-force-attack-preventionstate'
+        self._meta_data['required_creation_parameters'] = \
+            set(('urlReference',))

--- a/f5/bigip/tm/asm/policies.py
+++ b/f5/bigip/tm/asm/policies.py
@@ -90,7 +90,9 @@ class Policy(AsmResource):
             'sensitive-parametercollectionstate': Sensitive_Parameters_s,
             'tm:asm:policies:brute-force-attack-preventions:'
             'brute-force-attack-preventioncollectionstate':
-                Brute_Force_Attack_Preventions_s
+                Brute_Force_Attack_Preventions_s,
+            'tm:asm:policies:xml-validation-files:'
+            'xml-validation-filecollectionstate': Xml_Validation_Files_s
         }
         self._set_attr_reg()
 
@@ -1080,5 +1082,39 @@ class Brute_Force_Attack_Prevention(AsmResource):
         self._meta_data['required_json_kind'] = \
             'tm:asm:policies:brute-force-attack-preventions:' \
             'brute-force-attack-preventionstate'
-        self._meta_data['required_creation_parameters'] = \
-            set(('urlReference',))
+        self._meta_data['required_creation_parameters'] = {'urlReference'}
+
+
+class Xml_Validation_Files_s(Collection):
+    """BIG-IP® ASM Xml Validation Files sub-collection."""
+    def __init__(self, policy):
+        super(Xml_Validation_Files_s, self).__init__(policy)
+        self._meta_data['object_has_stats'] = False
+        self._meta_data['minimum_version'] = '11.6.0'
+        self._meta_data['allowed_lazy_attributes'] = \
+            [Xml_Validation_File]
+        self._meta_data['required_json_kind'] = \
+            'tm:asm:policies:xml-validation-files:' \
+            'xml-validation-filecollectionstate'
+        self._meta_data['attribute_registry'] = {
+            'tm:asm:policies:xml-validation-files:xml-validation-filestate':
+                Xml_Validation_File}
+
+
+class Xml_Validation_File(AsmResource):
+    """BIG-IP® ASM Xml Validation File Resource."""
+    def __init__(self, xml_validation_files_s):
+        super(Xml_Validation_File, self).__init__(xml_validation_files_s)
+        self._meta_data['required_json_kind'] = \
+            'tm:asm:policies:xml-validation-files:xml-validation-filestate'
+        self._meta_data['required_creation_parameters'] = {'contents',
+                                                           'fileName'}
+
+    def modify(self, **kwargs):
+        """Modify is not supported for Xml Validation File resource
+
+        :raises: UnsupportedOperation
+        """
+        raise UnsupportedOperation(
+            "%s does not support the modify method" % self.__class__.__name__
+        )

--- a/f5/bigip/tm/asm/test/unit/test_policies.py
+++ b/f5/bigip/tm/asm/test/unit/test_policies.py
@@ -19,6 +19,7 @@ from f5.bigip.tm.asm.policies import Brute_Force_Attack_Prevention
 from f5.bigip.tm.asm.policies import Csrf_Protection
 from f5.bigip.tm.asm.policies import Data_Guard
 from f5.bigip.tm.asm.policies import Evasion
+from f5.bigip.tm.asm.policies import Extraction
 from f5.bigip.tm.asm.policies import Geolocation_Enforcement
 from f5.bigip.tm.asm.policies import Header
 from f5.bigip.tm.asm.policies import History_Revision
@@ -55,7 +56,15 @@ from six import iterkeys
 
 
 @pytest.fixture
-def XmlFile():
+def FakeExtract():
+    fake_policy = mock.MagicMock()
+    fake_e = Extraction(fake_policy)
+    fake_e._meta_data['bigip'].tmos_version = '11.6.0'
+    return fake_e
+
+
+@pytest.fixture
+def FakeXmlFile():
     fake_policy = mock.MagicMock()
     fake_file = Xml_Validation_File(fake_policy)
     fake_file._meta_data['bigip'].tmos_version = '11.6.0'
@@ -486,10 +495,20 @@ class TestBruteForce(object):
 
 
 class TestXMLValidationFiles(object):
-    def test_update_raises(self, XmlFile):
+    def test_update_raises(self, FakeXmlFile):
         with pytest.raises(UnsupportedOperation):
-            XmlFile.modify()
+            FakeXmlFile.modify()
 
-    def test_create_no_args(self, XmlFile):
+    def test_create_no_args(self, FakeXmlFile):
         with pytest.raises(MissingRequiredCreationParameter):
-            XmlFile.create()
+            FakeXmlFile.create()
+
+
+class TestExtractions(object):
+    def test_create_no_args(self, FakeExtract):
+        with pytest.raises(MissingRequiredCreationParameter):
+            FakeExtract.create()
+
+    def test_create_missing_additional_arguments(self, FakeExtract):
+        with pytest.raises(MissingRequiredCreationParameter):
+            FakeExtract.create(name='fake', extractFromAllItems=True)

--- a/f5/bigip/tm/asm/test/unit/test_policies.py
+++ b/f5/bigip/tm/asm/test/unit/test_policies.py
@@ -15,6 +15,7 @@
 
 from f5.bigip import ManagementRoot
 from f5.bigip.tm.asm import Asm
+from f5.bigip.tm.asm.policies import Brute_Force_Attack_Prevention
 from f5.bigip.tm.asm.policies import Csrf_Protection
 from f5.bigip.tm.asm.policies import Data_Guard
 from f5.bigip.tm.asm.policies import Evasion
@@ -254,6 +255,14 @@ def FakeLogin():
     return fake_g
 
 
+@pytest.fixture
+def FakeBrute():
+    fake_policy = mock.MagicMock()
+    fake_g = Brute_Force_Attack_Prevention(fake_policy)
+    fake_g._meta_data['bigip'].tmos_version = '11.6.0'
+    return fake_g
+
+
 class TestPolicy(object):
     def test_create_two(self, fakeicontrolsession):
         b = ManagementRoot('192.168.1.1', 'admin', 'admin')
@@ -459,3 +468,9 @@ class TestSensitiveParameters(object):
     def test_modify_raises(self, FakeSens):
         with pytest.raises(UnsupportedOperation):
             FakeSens.modify()
+
+
+class TestBruteForce(object):
+    def test_create_no_args(self, FakeBrute):
+        with pytest.raises(MissingRequiredCreationParameter):
+            FakeBrute.create()

--- a/f5/bigip/tm/asm/test/unit/test_policies.py
+++ b/f5/bigip/tm/asm/test/unit/test_policies.py
@@ -511,4 +511,4 @@ class TestExtractions(object):
 
     def test_create_missing_additional_arguments(self, FakeExtract):
         with pytest.raises(MissingRequiredCreationParameter):
-            FakeExtract.create(name='fake', extractFromAllItems=True)
+            FakeExtract.create(name='fake', extractFromAllItems=False)

--- a/f5/bigip/tm/asm/test/unit/test_policies.py
+++ b/f5/bigip/tm/asm/test/unit/test_policies.py
@@ -44,6 +44,7 @@ from f5.bigip.tm.asm.policies import UrlParametersResource
 from f5.bigip.tm.asm.policies import Violation
 from f5.bigip.tm.asm.policies import Vulnerability_Assessment
 from f5.bigip.tm.asm.policies import Web_Services_Security
+from f5.bigip.tm.asm.policies import Xml_Validation_File
 from f5.sdk_exception import MissingRequiredCreationParameter
 from f5.sdk_exception import UnsupportedOperation
 
@@ -51,6 +52,14 @@ from f5.sdk_exception import UnsupportedOperation
 import mock
 import pytest
 from six import iterkeys
+
+
+@pytest.fixture
+def XmlFile():
+    fake_policy = mock.MagicMock()
+    fake_file = Xml_Validation_File(fake_policy)
+    fake_file._meta_data['bigip'].tmos_version = '11.6.0'
+    return fake_file
 
 
 @pytest.fixture
@@ -474,3 +483,13 @@ class TestBruteForce(object):
     def test_create_no_args(self, FakeBrute):
         with pytest.raises(MissingRequiredCreationParameter):
             FakeBrute.create()
+
+
+class TestXMLValidationFiles(object):
+    def test_update_raises(self, XmlFile):
+        with pytest.raises(UnsupportedOperation):
+            XmlFile.modify()
+
+    def test_create_no_args(self, XmlFile):
+        with pytest.raises(MissingRequiredCreationParameter):
+            XmlFile.create()


### PR DESCRIPTION
Fixes #1015 #1016 #1018

Problem:
Extractions, Xml Validation Files, Brute Force Attack Prevention, endpoint was missing from ASM policies.

Analysis:
Added Extractions, Xml Validation Files, Brute Force Attack Prevention endpoinst to ASM policies

Tests:
Functional
Unit
Flake8