### PR TITLE
Fixes #1023 #1024

### DIFF
--- a/f5/bigip/resource.py
+++ b/f5/bigip/resource.py
@@ -146,6 +146,28 @@ def _missing_required_parameters(rqset, **kwargs):
         return list(required_minus_received)
 
 
+def _minimum_one_is_missing(rqset, **kwargs):
+    """Helper function to do operation on sets
+
+    Verify if at least one of the elements
+    is present in **kwargs. If no items of rqset
+    are contained in **kwargs  the function
+    raises exception.
+
+    Raises:
+
+         MissingRequiredCreationParameter
+    """
+
+    kwarg_set = set(iterkeys(kwargs))
+
+    if kwarg_set.isdisjoint(rqset):
+        error_message = 'This resource requires at least one of the ' \
+                        'mandatory additional ' \
+                        'parameters to be provided: %s' % rqset
+        raise MissingRequiredCreationParameter(error_message)
+
+
 class PathElement(LazyAttributeMixin):
     """Base class to represent a URI path element that does not contain data.
 

--- a/f5/bigip/tm/asm/file_transfer.py
+++ b/f5/bigip/tm/asm/file_transfer.py
@@ -18,12 +18,12 @@
 import os
 
 from f5.bigip.mixins import AsmFileMixin
-from f5.bigip.resource import Collection
+from f5.bigip.resource import OrganizingCollection
 from f5.bigip.resource import PathElement
 from f5.sdk_exception import FileMustNotHaveDotISOExtension
 
 
-class File_Transfer(Collection):
+class File_Transfer(OrganizingCollection):
     """BIG-IP® ASM File Transfer collection."""
     def __init__(self, tm):
         super(File_Transfer, self).__init__(tm)

--- a/f5/bigip/tm/asm/policies.py
+++ b/f5/bigip/tm/asm/policies.py
@@ -16,12 +16,11 @@
 #
 
 from distutils.version import LooseVersion
+from f5.bigip.resource import _minimum_one_is_missing
 from f5.bigip.resource import AsmResource
 from f5.bigip.resource import Collection
 from f5.bigip.resource import UnnamedResource
-from f5.sdk_exception import MissingRequiredCreationParameter
 from f5.sdk_exception import UnsupportedOperation
-from six import iterkeys
 
 
 class Policies_s(Collection):
@@ -1152,29 +1151,8 @@ class Extraction(AsmResource):
         """Custom create method to accommodate different endpoint behavior."""
         self._check_create_parameters(**kwargs)
         if kwargs['extractFromAllItems'] is False:
-            self._minimum_one_is_missing(**kwargs)
+            req_set = {'extractFromRegularExpression', 'extractUrlReferences',
+                       'extractFiletypeReferences'}
+            _minimum_one_is_missing(req_set, **kwargs)
 
         return self._create(**kwargs)
-
-    def _minimum_one_is_missing(self, **kwargs):
-        """Helper method
-
-        Verify if at least one of the required parameters is present.
-        The required parameters change depending on extractFromAllItems value.
-
-        ::returns bool
-
-        Raises:
-
-             MissingRequiredCreationParameter
-        """
-
-        req_set = {'extractFromRegularExpression', 'extractUrlReferences',
-                   'extractFiletypeReferences'}
-        kwarg_set = set(iterkeys(kwargs))
-
-        if kwarg_set.isdisjoint(req_set):
-            error_message = 'This resource requires at least one of the ' \
-                            'mandatory additional ' \
-                            'parameters to be provided: %s' % req_set
-            raise MissingRequiredCreationParameter(error_message)

--- a/f5/bigip/tm/asm/tasks.py
+++ b/f5/bigip/tm/asm/tasks.py
@@ -26,7 +26,7 @@ GUI Path
 REST Kind
     ``tm:asm:tasks:``
 """
-
+from f5.bigip.resource import _minimum_one_is_missing
 from f5.bigip.resource import AsmResource
 from f5.bigip.resource import AsmTaskResource
 from f5.bigip.resource import Collection
@@ -45,6 +45,7 @@ class Tasks(OrganizingCollection):
             Export_Policy_s,
             Export_Signatures_s,
             Import_Policy_s,
+            Import_Vulnerabilities_s,
             Update_Signatures_s,
             ]
 
@@ -65,8 +66,7 @@ class Apply_Policy(AsmResource):
         super(Apply_Policy, self).__init__(apply_policy_s)
         self._meta_data['required_json_kind'] =\
             'tm:asm:tasks:apply-policy:apply-policy-taskstate'
-        self._meta_data['required_creation_parameters'] = set((
-            'policyReference',))
+        self._meta_data['required_creation_parameters'] = {'policyReference', }
 
     def modify(self, **kwargs):
         """Modify is not supported for Apply Policy resource
@@ -95,8 +95,8 @@ class Export_Policy(AsmResource):
         super(Export_Policy, self).__init__(export_policy_s)
         self._meta_data['required_json_kind'] =\
             'tm:asm:tasks:export-policy:export-policy-taskstate'
-        self._meta_data['required_creation_parameters'] = set((
-            'policyReference', 'filename'))
+        self._meta_data['required_creation_parameters'] = {
+            'policyReference', 'filename'}
 
     def modify(self, **kwargs):
         """Modify is not supported for Apply Policy resource
@@ -125,8 +125,8 @@ class Import_Policy(AsmResource):
         super(Import_Policy, self).__init__(import_policy_s)
         self._meta_data['required_json_kind'] =\
             'tm:asm:tasks:import-policy:import-policy-taskstate'
-        self._meta_data['required_creation_parameters'] = set((
-            'name', 'filename'))
+        self._meta_data['required_creation_parameters'] = {
+            'name', 'filename'}
 
     def modify(self, **kwargs):
         """Modify is not supported for Apply Policy resource
@@ -179,7 +179,7 @@ class Export_Signature(AsmResource):
         super(Export_Signature, self).__init__(export_signatures_s)
         self._meta_data['required_json_kind'] =\
             'tm:asm:tasks:export-signatures:export-signatures-taskstate'
-        self._meta_data['required_creation_parameters'] = set(('filename',))
+        self._meta_data['required_creation_parameters'] = {'filename', }
 
     def modify(self, **kwargs):
         """Modify is not supported for Export Signature resource
@@ -205,7 +205,6 @@ class Update_Signatures_s(Collection):
 class Update_Signature(AsmTaskResource):
     """BIG-IP® ASM Tasks Update Signature Resource resource
 
-
         To create this resource on the ASM, one must utilize fetch() method
         from AsmTaskResource class, create() is not supported.
     """
@@ -213,3 +212,41 @@ class Update_Signature(AsmTaskResource):
         super(Update_Signature, self).__init__(update_signatures_s)
         self._meta_data['required_json_kind'] =\
             'tm:asm:tasks:update-signatures:update-signatures-taskstate'
+
+
+class Import_Vulnerabilities_s(Collection):
+    """BIG-IP® ASM Import Vulnerabilities Collection."""
+    def __init__(self, tasks):
+        super(Import_Vulnerabilities_s, self).__init__(tasks)
+        self._meta_data['object_has_stats'] = False
+        self._meta_data['allowed_lazy_attributes'] = [Import_Vulnerabilities]
+        self._meta_data['attribute_registry'] = {
+            'tm:asm:tasks:import-vulnerabilities:'
+            'import-vulnerabilities-taskstate': Import_Vulnerabilities}
+
+
+class Import_Vulnerabilities(AsmResource):
+    """BIG-IP® ASM Import Vulnerabilities Resource."""
+    def __init__(self, import_vulnerabilities_s):
+        super(Import_Vulnerabilities, self).__init__(import_vulnerabilities_s)
+        self._meta_data['required_json_kind'] = \
+            'tm:asm:tasks:import-vulnerabilities:' \
+            'import-vulnerabilities-taskstate'
+        self._meta_data['required_creation_parameters'] = {
+            'policyReference', 'filename'}
+
+    def create(self, **kwargs):
+        """We check if one of the 3 mandatory attributes is present."""
+        rq_set = {'onlyGetDomainNames', 'importAllDomainNames', 'domainNames'}
+        _minimum_one_is_missing(rq_set, **kwargs)
+
+        return self._create(**kwargs)
+
+    def modify(self, **kwargs):
+        """Modify is not supported for Import Vulnerabilities resource
+
+                :raises: UnsupportedOperation
+        """
+        raise UnsupportedOperation(
+            "%s does not support the modify method" % self.__class__.__name__
+        )

--- a/f5/bigip/tm/asm/test/unit/test_file_transfer.py
+++ b/f5/bigip/tm/asm/test/unit/test_file_transfer.py
@@ -20,7 +20,7 @@ import requests_mock
 import struct
 
 from f5.bigip import ManagementRoot
-from f5.bigip.resource import Collection
+from f5.bigip.resource import OrganizingCollection
 from f5.bigip.tm.asm.file_transfer import Downloads
 from f5.bigip.tm.asm.file_transfer import Uploads
 from f5.sdk_exception import EmptyContent
@@ -55,7 +55,7 @@ class TestFileTransferCollection(object):
         b = ManagementRoot('192.168.1.1', 'admin', 'admin')
         c1 = b.tm.asm.file_transfer
         test_meta = c1._meta_data['allowed_lazy_attributes']
-        assert isinstance(c1, Collection)
+        assert isinstance(c1, OrganizingCollection)
         assert Downloads in test_meta
         assert Uploads in test_meta
 


### PR DESCRIPTION
Problem:
ASM Tasks Import Vunlerability endpoint was missing. _minimum_one_is_missing method needed to be available for multiple endpoints

Analysis:
Added ASM Tasks Import Vunlerability endpoint, as this was a blocker for #1017. Moved _minimum_one_is_missing method into resource.py module. Corrected class inheritance in file transfer sub-module.

Tests:
Functional
Unit
Flake8