### PR TITLE
Fixes #1029 #1030 #1031 #1032 #1032 #1033 #986 #828

### DIFF
--- a/f5/bigip/tm/asm/policies.py
+++ b/f5/bigip/tm/asm/policies.py
@@ -102,7 +102,8 @@ class Policy(AsmResource):
             'navigation-parametercollectionstate': Navigation_Parameters_s,
             'tm:asm:policies:character-sets:character-setcollectionstate':
             Character_Sets_s,
-            'tm:asm:policies:web-scraping:web-scrapingstate': Web_Scraping
+            'tm:asm:policies:web-scraping:web-scrapingstate': Web_Scraping,
+            'tm:asm:policies:audit-logs:audit-logcollectionstate': Audit_Logs_s
         }
         self._set_attr_reg()
 
@@ -1306,4 +1307,54 @@ class Web_Scraping(UnnamedResource):
         """
         raise UnsupportedOperation(
             "%s does not support the update method" % self.__class__.__name__
+        )
+
+
+class Audit_Logs_s(Collection):
+    """BIG-IP® ASM Audit Logs sub-collection."""
+    def __init__(self, policy):
+        super(Audit_Logs_s, self).__init__(policy)
+        self._meta_data['object_has_stats'] = False
+        self._meta_data['minimum_version'] = '12.0.0'
+        self._meta_data['allowed_lazy_attributes'] = \
+            [Audit_Log]
+        self._meta_data['required_json_kind'] = \
+            'tm:asm:policies:audit-logs:audit-logcollectionstate'
+        self._meta_data['attribute_registry'] = {
+            'tm:asm:policies:audit-logs:audit-logstate':
+                Audit_Log}
+
+
+class Audit_Log(AsmResource):
+    """BIG-IP® ASM Audit Logs Resource."""
+    def __init__(self, audit_logs_s):
+        super(Audit_Log, self).__init__(audit_logs_s)
+        self._meta_data['required_json_kind'] = \
+            'tm:asm:policies:audit-logs:audit-logstate'
+
+    def create(self, **kwargs):
+        """Modify is not supported for Audit Logs resource
+
+        :raises: UnsupportedOperation
+        """
+        raise UnsupportedOperation(
+            "%s does not support the create method" % self.__class__.__name__
+        )
+
+    def modify(self, **kwargs):
+        """Modify is not supported for Audit Logs resource
+
+        :raises: UnsupportedOperation
+        """
+        raise UnsupportedOperation(
+            "%s does not support the modify method" % self.__class__.__name__
+        )
+
+    def delete(self, **kwargs):
+        """Modify is not supported for Audit Logs resource
+
+        :raises: UnsupportedOperation
+        """
+        raise UnsupportedOperation(
+            "%s does not support the delete method" % self.__class__.__name__
         )

--- a/f5/bigip/tm/asm/policies.py
+++ b/f5/bigip/tm/asm/policies.py
@@ -103,7 +103,10 @@ class Policy(AsmResource):
             'tm:asm:policies:character-sets:character-setcollectionstate':
             Character_Sets_s,
             'tm:asm:policies:web-scraping:web-scrapingstate': Web_Scraping,
-            'tm:asm:policies:audit-logs:audit-logcollectionstate': Audit_Logs_s
+            'tm:asm:policies:audit-logs:audit-logcollectionstate':
+                Audit_Logs_s,
+            'tm:asm:policies:suggestions:suggestioncollectionstate':
+                Suggestions_s
         }
         self._set_attr_reg()
 
@@ -1357,4 +1360,36 @@ class Audit_Log(AsmResource):
         """
         raise UnsupportedOperation(
             "%s does not support the delete method" % self.__class__.__name__
+        )
+
+
+class Suggestions_s(Collection):
+    """BIG-IP® ASM Suggestions sub-collection."""
+    def __init__(self, policy):
+        super(Suggestions_s, self).__init__(policy)
+        self._meta_data['object_has_stats'] = False
+        self._meta_data['minimum_version'] = '12.0.0'
+        self._meta_data['allowed_lazy_attributes'] = \
+            [Suggestion]
+        self._meta_data['required_json_kind'] = \
+            'tm:asm:policies:suggestions:suggestioncollectionstate'
+        self._meta_data['attribute_registry'] = {
+            'tm:asm:policies:suggestions:suggestionstate':
+                Suggestion}
+
+
+class Suggestion(AsmResource):
+    """BIG-IP® ASM Suggestions Resource."""
+    def __init__(self, suggestions_s):
+        super(Suggestion, self).__init__(suggestions_s)
+        self._meta_data['required_json_kind'] = \
+            'tm:asm:policies:suggestions:suggestionstate'
+
+    def create(self, **kwargs):
+        """Modify is not supported for Suggestions resource
+
+        :raises: UnsupportedOperation
+        """
+        raise UnsupportedOperation(
+            "%s does not support the create method" % self.__class__.__name__
         )

--- a/f5/bigip/tm/asm/policies.py
+++ b/f5/bigip/tm/asm/policies.py
@@ -106,7 +106,9 @@ class Policy(AsmResource):
             'tm:asm:policies:audit-logs:audit-logcollectionstate':
                 Audit_Logs_s,
             'tm:asm:policies:suggestions:suggestioncollectionstate':
-                Suggestions_s
+                Suggestions_s,
+            'tm:asm:policies:plain-text-profiles:'
+            'plain-text-profilecollectionstate': Plain_Text_Profiles_s
         }
         self._set_attr_reg()
 
@@ -1393,3 +1395,27 @@ class Suggestion(AsmResource):
         raise UnsupportedOperation(
             "%s does not support the create method" % self.__class__.__name__
         )
+
+
+class Plain_Text_Profiles_s(Collection):
+    """BIG-IP® ASM Plain Text Profiles sub-collection."""
+    def __init__(self, policy):
+        super(Plain_Text_Profiles_s, self).__init__(policy)
+        self._meta_data['object_has_stats'] = False
+        self._meta_data['minimum_version'] = '12.1.0'
+        self._meta_data['allowed_lazy_attributes'] = \
+            [Plain_Text_Profile]
+        self._meta_data['required_json_kind'] = \
+            'tm:asm:policies:plain-text-profiles:' \
+            'plain-text-profilecollectionstate'
+        self._meta_data['attribute_registry'] = {
+            'tm:asm:policies:plain-text-profiles:plain-text-profilestate':
+                Plain_Text_Profile}
+
+
+class Plain_Text_Profile(AsmResource):
+    """BIG-IP® ASM Plain Text Profile Resource."""
+    def __init__(self, plain_text_profiles_s):
+        super(Plain_Text_Profile, self).__init__(plain_text_profiles_s)
+        self._meta_data['required_json_kind'] = \
+            'tm:asm:policies:plain-text-profiles:plain-text-profilestate'

--- a/f5/bigip/tm/asm/policies.py
+++ b/f5/bigip/tm/asm/policies.py
@@ -101,7 +101,8 @@ class Policy(AsmResource):
             'tm:asm:policies:navigation-parameters:'
             'navigation-parametercollectionstate': Navigation_Parameters_s,
             'tm:asm:policies:character-sets:character-setcollectionstate':
-            Character_Sets_s
+            Character_Sets_s,
+            'tm:asm:policies:web-scraping:web-scrapingstate': Web_Scraping
         }
         self._set_attr_reg()
 
@@ -1019,7 +1020,7 @@ class Login_Enforcement(UnnamedResource):
     def __init__(self, policy):
         super(Login_Enforcement, self).__init__(policy)
         self._meta_data['required_json_kind'] = \
-            'tm:asm:policies:login-enforcement:login-enforcementstate"'
+            'tm:asm:policies:login-enforcement:login-enforcementstate'
         self._meta_data['required_load_parameters'] = set()
         self._meta_data['object_has_stats'] = False
         self._meta_data['minimum_version'] = '11.6.0'
@@ -1285,4 +1286,24 @@ class Character_Sets(AsmResource):
         """
         raise UnsupportedOperation(
             "%s does not support the delete method" % self.__class__.__name__
+        )
+
+
+class Web_Scraping(UnnamedResource):
+    """BIG-IP® ASM Web Scraping resource."""
+    def __init__(self, policy):
+        super(Web_Scraping, self).__init__(policy)
+        self._meta_data['required_json_kind'] = \
+            'tm:asm:policies:web-scraping:web-scrapingstate'
+        self._meta_data['required_load_parameters'] = set()
+        self._meta_data['object_has_stats'] = False
+        self._meta_data['minimum_version'] = '12.0.0'
+
+    def update(self, **kwargs):
+        """Update is not supported for Login Enforcement resource
+
+        :raises: UnsupportedOperation
+        """
+        raise UnsupportedOperation(
+            "%s does not support the update method" % self.__class__.__name__
         )

--- a/f5/bigip/tm/asm/test/functional/test_policies.py
+++ b/f5/bigip/tm/asm/test/functional/test_policies.py
@@ -43,6 +43,7 @@ from f5.bigip.tm.asm.policies import Sensitive_Parameter
 from f5.bigip.tm.asm.policies import Session_Tracking_Status
 from f5.bigip.tm.asm.policies import Signature
 from f5.bigip.tm.asm.policies import Signature_Set
+from f5.bigip.tm.asm.policies import Suggestion
 from f5.bigip.tm.asm.policies import Url
 from f5.bigip.tm.asm.policies import UrlParametersCollection
 from f5.bigip.tm.asm.policies import UrlParametersResource
@@ -604,7 +605,7 @@ class TestHostNames(object):
         assert host1.includeSubdomains == host2.includeSubdomains
         host1.delete()
 
-    def test_cookies_subcollection(self, policy):
+    def test_hostnames_subcollection(self, policy):
         host1 = policy.host_names_s.host_name.create(name='fake-domain.com')
         assert host1.kind == 'tm:asm:policies:host-names:host-namestate'
         assert host1.name == 'fake-domain.com'
@@ -769,7 +770,7 @@ class TestViolations(object):
         assert isinstance(coll[0], Violation)
 
 
-class TestHTTPProtoccols(object):
+class TestHTTPProtocols(object):
     def test_create_raises(self, policy):
         with pytest.raises(UnsupportedOperation):
             policy.blocking_settings.http_protocols_s.http_protocol.create()
@@ -1780,7 +1781,7 @@ class TestHeaders(object):
         assert h1.base64Decoding == h2.base64Decoding
         h1.delete()
 
-    def test_method_subcollection(self, policy):
+    def test_headers_subcollection(self, policy):
         mc = policy.headers_s.get_collection()
         assert isinstance(mc, list)
         assert len(mc)
@@ -1906,7 +1907,7 @@ class TestResponsePages(object):
         assert r1.responsePageType == r2.responsePageType
         assert r1.responseRedirectUrl == r2.responseRedirectUrl
 
-    def test_method_subcollection(self, policy):
+    def test_responsepages_subcollection(self, policy):
         mc = policy.response_pages_s.get_collection()
         assert isinstance(mc, list)
         assert len(mc)
@@ -1961,7 +1962,7 @@ class TestHistoryRevisions(object):
         assert r1.kind == r2.kind
         assert r1.selfLink == r2.selfLink
 
-    def test_method_subcollection(self, policy):
+    def test_historyrevisions_subcollection(self, policy):
         mc = policy.history_revisions_s.get_collection()
         assert isinstance(mc, list)
         assert len(mc)
@@ -2942,7 +2943,7 @@ class TestVulnerabilities(object):
         assert r1.kind == r2.kind
         assert r1.selfLink == r2.selfLink
 
-    def test_method_subcollection(self, policy):
+    def test_vulnerabilities_subcollection(self, policy):
         mc = policy.vulnerabilities_s.get_collection()
         assert isinstance(mc, list)
         assert len(mc)
@@ -3080,7 +3081,7 @@ class TestCharacterSets(object):
         assert char1.kind == char2.kind
         assert char1.characterSet == char2.characterSet
 
-    def test_evasions_subcollection(self, policy):
+    def test_charactersets_subcollection(self, policy):
         coll = policy.character_sets_s.get_collection()
         assert isinstance(coll, list)
         assert len(coll)
@@ -3175,9 +3176,31 @@ class TestAuditLogs(object):
         assert r1.kind == r2.kind
         assert r1.selfLink == r2.selfLink
 
-    def test_method_subcollection(self, policy):
+    def test_auditlog_subcollection(self, policy):
         mc = policy.audit_logs_s.get_collection(
             requests_params={'params': '$top=2'})
         assert isinstance(mc, list)
         assert len(mc)
         assert isinstance(mc[0], Audit_Log)
+
+
+@pytest.mark.skipif(
+    LooseVersion(pytest.config.getoption('--release')) < LooseVersion(
+        '12.0.0'),
+    reason='This collection is fully implemented on 12.0.0 or greater.'
+)
+class TestSuggestions(object):
+    def test_create_raises(self, policy):
+        with pytest.raises(UnsupportedOperation):
+            policy.suggestions_s.suggestion.create()
+
+    def test_suggestions_subcollection(self, policy):
+        mc = policy.suggestions_s.get_collection(
+            requests_params={'params': '$top=2'})
+        m = policy.suggestions_s
+        # Same situation where the BIGIP will return 500 entries by default.
+        # This list is populated when policy is in learning mode. Very
+        # limited testing can be performed
+        assert Suggestion in m._meta_data['allowed_lazy_attributes']
+        assert isinstance(mc, list)
+        assert not len(mc)

--- a/f5/bigip/tm/asm/test/functional/test_policies.py
+++ b/f5/bigip/tm/asm/test/functional/test_policies.py
@@ -3073,3 +3073,49 @@ class TestCharacterSets(object):
         assert isinstance(coll, list)
         assert len(coll)
         assert isinstance(coll[0], Character_Sets)
+
+
+@pytest.mark.skipif(
+    LooseVersion(pytest.config.getoption('--release')) < LooseVersion(
+        '12.0.0'),
+    reason='This collection is fully implemented on 12.0.0 or greater.'
+)
+class TestWebScraping(object):
+    def test_update_raises(self, policy):
+        with pytest.raises(UnsupportedOperation):
+            policy.web_scraping.update()
+
+    def test_modify(self, policy):
+        r1 = policy.web_scraping.load()
+        original_dict = copy.copy(r1.__dict__)
+        itm = 'enableFingerprinting'
+        r1.modify(enableFingerprinting=True)
+        for k, v in iteritems(original_dict):
+            if k != itm:
+                original_dict[k] = r1.__dict__[k]
+            elif k == itm:
+                assert r1.__dict__[k] is True
+
+    def test_load(self, policy):
+        r1 = policy.web_scraping.load()
+        assert r1.kind == \
+            'tm:asm:policies:web-scraping:web-scrapingstate'
+        assert r1.enableFingerprinting is True
+        r1.modify(enableFingerprinting=False)
+        assert r1.enableFingerprinting is False
+        r2 = policy.web_scraping.load()
+        assert r1.kind == r2.kind
+        assert r1.enableFingerprinting == r2.enableFingerprinting
+
+    def test_refresh(self, policy):
+        r1 = policy.web_scraping.load()
+        assert r1.kind == \
+            'tm:asm:policies:web-scraping:web-scrapingstate'
+        assert r1.enableFingerprinting is False
+        r2 = policy.web_scraping.load()
+        assert r1.kind == r2.kind
+        assert r1.enableFingerprinting == r2.enableFingerprinting
+        r2.modify(enableFingerprinting=True)
+        assert r2.enableFingerprinting is True
+        r1.refresh()
+        assert r1.enableFingerprinting is True

--- a/f5/bigip/tm/asm/test/functional/test_policies.py
+++ b/f5/bigip/tm/asm/test/functional/test_policies.py
@@ -15,6 +15,7 @@
 
 import copy
 from distutils.version import LooseVersion
+from f5.bigip.tm.asm.policies import Audit_Log
 from f5.bigip.tm.asm.policies import Brute_Force_Attack_Prevention
 from f5.bigip.tm.asm.policies import Character_Sets
 from f5.bigip.tm.asm.policies import Cookie
@@ -214,6 +215,17 @@ def set_vulnerability(mgmt_root, policy):
     hashid = str(col[0].id)
     yield hashid
     delete_import_vuln_task(mgmt_root)
+
+
+@pytest.fixture(scope='class')
+def set_audit_logs(policy):
+    # Audit logs fill up quickly, doing a get_collection() would return
+    # first 500 entries by default (as this is how BIGIP returns it),
+    # it faster to have it limited to 2
+    rc = policy.audit_logs_s.get_collection(
+        requests_params={'params': '$top=2'})
+    hashid = str(rc[0].id)
+    yield hashid
 
 
 class TestPolicy(object):
@@ -3119,3 +3131,53 @@ class TestWebScraping(object):
         assert r2.enableFingerprinting is True
         r1.refresh()
         assert r1.enableFingerprinting is True
+
+
+@pytest.mark.skipif(
+    LooseVersion(pytest.config.getoption('--release')) < LooseVersion(
+        '12.0.0'),
+    reason='This collection is fully implemented on 12.0.0 or greater.'
+)
+class TestAuditLogs(object):
+    def test_create_raises(self, policy):
+        with pytest.raises(UnsupportedOperation):
+            policy.audit_logs_s.audit_log.create()
+
+    def test_delete_raises(self, policy):
+        with pytest.raises(UnsupportedOperation):
+            policy.audit_logs_s.audit_log.delete()
+
+    def test_modify_raises(self, policy):
+        with pytest.raises(UnsupportedOperation):
+            policy.audit_logs_s.audit_log.create()
+
+    def test_refresh(self, policy, set_audit_logs):
+        hashid = set_audit_logs
+        r1 = policy.audit_logs_s.audit_log.load(id=hashid)
+        assert r1.kind == 'tm:asm:policies:audit-logs:audit-logstate'
+        r2 = policy.audit_logs_s.audit_log.load(id=hashid)
+        assert r1.kind == r2.kind
+        assert r1.selfLink == r2.selfLink
+        r1.refresh()
+        assert r1.kind == r2.kind
+        assert r1.selfLink == r2.selfLink
+
+    def test_load_no_object(self, policy):
+        with pytest.raises(HTTPError) as err:
+            policy.audit_logs_s.audit_log.load(id='Lx3553-321')
+        assert err.value.response.status_code == 404
+
+    def test_load(self, policy, set_audit_logs):
+        hashid = set_audit_logs
+        r1 = policy.audit_logs_s.audit_log.load(id=hashid)
+        assert r1.kind == 'tm:asm:policies:audit-logs:audit-logstate'
+        r2 = policy.audit_logs_s.audit_log.load(id=hashid)
+        assert r1.kind == r2.kind
+        assert r1.selfLink == r2.selfLink
+
+    def test_method_subcollection(self, policy):
+        mc = policy.audit_logs_s.get_collection(
+            requests_params={'params': '$top=2'})
+        assert isinstance(mc, list)
+        assert len(mc)
+        assert isinstance(mc[0], Audit_Log)

--- a/f5/bigip/tm/asm/test/functional/test_policies.py
+++ b/f5/bigip/tm/asm/test/functional/test_policies.py
@@ -37,6 +37,7 @@ from f5.bigip.tm.asm.policies import Parameter
 from f5.bigip.tm.asm.policies import Parameters_s
 from f5.bigip.tm.asm.policies import ParametersCollection
 from f5.bigip.tm.asm.policies import ParametersResource
+from f5.bigip.tm.asm.policies import Plain_Text_Profile
 from f5.bigip.tm.asm.policies import Policy
 from f5.bigip.tm.asm.policies import Response_Page
 from f5.bigip.tm.asm.policies import Sensitive_Parameter
@@ -227,6 +228,14 @@ def set_audit_logs(policy):
         requests_params={'params': '$top=2'})
     hashid = str(rc[0].id)
     yield hashid
+
+
+@pytest.fixture(scope='function')
+def set_plaintext(policy):
+    r1 = policy.plain_text_profiles_s.plain_text_profile.create(
+        name='fake_txt')
+    yield r1
+    r1.delete()
 
 
 class TestPolicy(object):
@@ -3204,3 +3213,84 @@ class TestSuggestions(object):
         assert Suggestion in m._meta_data['allowed_lazy_attributes']
         assert isinstance(mc, list)
         assert not len(mc)
+
+
+@pytest.mark.skipif(
+    LooseVersion(pytest.config.getoption('--release')) < LooseVersion(
+        '12.1.0'),
+    reason='This collection is fully implemented on 12.1.0 or greater.'
+)
+class TestPlainTextProfiles(object):
+    def test_create_req_arg(self, set_plaintext):
+        r1 = set_plaintext
+        assert r1.kind == \
+            'tm:asm:policies:plain-text-profiles:plain-text-profilestate'
+        assert r1.name == 'fake_txt'
+        assert r1.description == ''
+
+    def test_create_optional_args(self, policy):
+        r1 = policy.plain_text_profiles_s.plain_text_profile.create(
+            name='fake_txt', description='fake_profile_text')
+        assert r1.kind == \
+            'tm:asm:policies:plain-text-profiles:plain-text-profilestate'
+        assert r1.name == 'fake_txt'
+        assert r1.description == 'fake_profile_text'
+        r1.delete()
+
+    def test_refresh(self, set_plaintext, policy):
+        r1 = set_plaintext
+        r2 = policy.plain_text_profiles_s.plain_text_profile.load(id=r1.id)
+        assert r1.kind == r2.kind
+        assert r1.selfLink == r1.selfLink
+        assert r1.description == r2.description
+        r2.modify(description='changed_this')
+        assert r1.description == ''
+        assert r2.description == 'changed_this'
+        r1.refresh()
+        assert r1.kind == r2.kind
+        assert r1.selfLink == r2.selfLink
+        assert r1.description == 'changed_this'
+
+    def test_modify(self, set_plaintext):
+        r1 = set_plaintext
+        original_dict = copy.copy(r1.__dict__)
+        itm = 'description'
+        r1.modify(description='modified_this')
+        for k, v in iteritems(original_dict):
+            if k != itm:
+                original_dict[k] = r1.__dict__[k]
+            elif k == itm:
+                assert r1.__dict__[k] == 'modified_this'
+
+    def test_delete(self, policy):
+        r1 = policy.plain_text_profiles_s.plain_text_profile.create(
+            name='fake_txt')
+        idhash = r1.id
+        r1.delete()
+        with pytest.raises(HTTPError) as err:
+            policy.plain_text_profiles_s.plain_text_profile.load(id=idhash)
+        assert err.value.response.status_code == 404
+
+    def test_load_no_object(self, policy):
+        with pytest.raises(HTTPError) as err:
+            policy.plain_text_profiles_s.plain_text_profile.load(
+                id='Lx3553-321')
+        assert err.value.response.status_code == 404
+
+    def test_load(self, set_plaintext, policy):
+        r1 = set_plaintext
+        assert r1.kind == 'tm:asm:policies:plain-text-profiles:' \
+                          'plain-text-profilestate'
+        assert r1.description == ''
+        r1.modify(description='load_this')
+        assert r1.description == 'load_this'
+        r2 = policy.plain_text_profiles_s.plain_text_profile.load(id=r1.id)
+        assert r1.kind == r2.kind
+        assert r1.selfLink == r2.selfLink
+        assert r1.description == r2.description
+
+    def test_plaintextprofiles_subcollection(self, policy):
+        cc = policy.plain_text_profiles_s.get_collection()
+        assert isinstance(cc, list)
+        assert len(cc)
+        assert isinstance(cc[0], Plain_Text_Profile)

--- a/f5/bigip/tm/asm/test/unit/test_policies.py
+++ b/f5/bigip/tm/asm/test/unit/test_policies.py
@@ -42,6 +42,7 @@ from f5.bigip.tm.asm.policies import Sensitive_Parameter
 from f5.bigip.tm.asm.policies import Session_Tracking
 from f5.bigip.tm.asm.policies import Session_Tracking_Status
 from f5.bigip.tm.asm.policies import Signature
+from f5.bigip.tm.asm.policies import Suggestion
 from f5.bigip.tm.asm.policies import Url
 from f5.bigip.tm.asm.policies import UrlParametersCollection
 from f5.bigip.tm.asm.policies import UrlParametersResource
@@ -58,6 +59,14 @@ from f5.sdk_exception import UnsupportedOperation
 import mock
 import pytest
 from six import iterkeys
+
+
+@pytest.fixture
+def FakeSugg():
+    fake_policy = mock.MagicMock()
+    fake_e = Suggestion(fake_policy)
+    fake_e._meta_data['bigip'].tmos_version = '12.0.0'
+    return fake_e
 
 
 @pytest.fixture
@@ -607,3 +616,9 @@ class TestAuditLogs(object):
     def test_modify_raises(self, FakeAudit):
         with pytest.raises(UnsupportedOperation):
             FakeAudit.modify()
+
+
+class TestSuggestions(object):
+    def test_create_raises(self, FakeSugg):
+        with pytest.raises(UnsupportedOperation):
+            FakeSugg.create()

--- a/f5/bigip/tm/asm/test/unit/test_policies.py
+++ b/f5/bigip/tm/asm/test/unit/test_policies.py
@@ -52,6 +52,7 @@ from f5.bigip.tm.asm.policies import Vulnerabilities
 from f5.bigip.tm.asm.policies import Vulnerability_Assessment
 from f5.bigip.tm.asm.policies import Web_Scraping
 from f5.bigip.tm.asm.policies import Web_Services_Security
+from f5.bigip.tm.asm.policies import Websocket_Url
 from f5.bigip.tm.asm.policies import Xml_Validation_File
 from f5.sdk_exception import MissingRequiredCreationParameter
 from f5.sdk_exception import UnsupportedOperation
@@ -60,6 +61,14 @@ from f5.sdk_exception import UnsupportedOperation
 import mock
 import pytest
 from six import iterkeys
+
+
+@pytest.fixture
+def FakeWebsock():
+    fake_policy = mock.MagicMock()
+    fake_e = Websocket_Url(fake_policy)
+    fake_e._meta_data['bigip'].tmos_version = '12.1.0'
+    return fake_e
 
 
 @pytest.fixture
@@ -637,3 +646,18 @@ class TestPlainTextProfiles(object):
     def test_create_no_args(self, FakePlain):
         with pytest.raises(MissingRequiredCreationParameter):
             FakePlain.create()
+
+
+class TestWebSocketUrls(object):
+    def test_create_no_args(self, FakeWebsock):
+        with pytest.raises(MissingRequiredCreationParameter):
+            FakeWebsock.create()
+
+    def test_create_missing_additional_arguments(self, FakeWebsock):
+        with pytest.raises(MissingRequiredCreationParameter):
+            FakeWebsock.create(name='fake', checkPayload=True)
+
+    def test_create_additional_arguments_missing_profiles(self, FakeWebsock):
+        with pytest.raises(MissingRequiredCreationParameter):
+            FakeWebsock.create(name='fake', checkPayload=True,
+                               allowTextMessage=True, allowJsonMessage=True)

--- a/f5/bigip/tm/asm/test/unit/test_policies.py
+++ b/f5/bigip/tm/asm/test/unit/test_policies.py
@@ -15,6 +15,7 @@
 
 from f5.bigip import ManagementRoot
 from f5.bigip.tm.asm import Asm
+from f5.bigip.tm.asm.policies import Audit_Log
 from f5.bigip.tm.asm.policies import Brute_Force_Attack_Prevention
 from f5.bigip.tm.asm.policies import Character_Sets
 from f5.bigip.tm.asm.policies import Csrf_Protection
@@ -63,6 +64,14 @@ from six import iterkeys
 def FakeWebscrape():
     fake_policy = mock.MagicMock()
     fake_e = Web_Scraping(fake_policy)
+    fake_e._meta_data['bigip'].tmos_version = '12.0.0'
+    return fake_e
+
+
+@pytest.fixture
+def FakeAudit():
+    fake_policy = mock.MagicMock()
+    fake_e = Audit_Log(fake_policy)
     fake_e._meta_data['bigip'].tmos_version = '12.0.0'
     return fake_e
 
@@ -584,3 +593,17 @@ class TestWebScraping(object):
     def test_update_raises(self, FakeWebscrape):
         with pytest.raises(UnsupportedOperation):
             FakeWebscrape.update()
+
+
+class TestAuditLogs(object):
+    def test_create_raises(self, FakeAudit):
+        with pytest.raises(UnsupportedOperation):
+            FakeAudit.create()
+
+    def test_delete_raises(self, FakeAudit):
+        with pytest.raises(UnsupportedOperation):
+            FakeAudit.delete()
+
+    def test_modify_raises(self, FakeAudit):
+        with pytest.raises(UnsupportedOperation):
+            FakeAudit.modify()

--- a/f5/bigip/tm/asm/test/unit/test_policies.py
+++ b/f5/bigip/tm/asm/test/unit/test_policies.py
@@ -34,6 +34,7 @@ from f5.bigip.tm.asm.policies import Parameter
 from f5.bigip.tm.asm.policies import Parameters_s
 from f5.bigip.tm.asm.policies import ParametersCollection
 from f5.bigip.tm.asm.policies import ParametersResource
+from f5.bigip.tm.asm.policies import Plain_Text_Profile
 from f5.bigip.tm.asm.policies import Policy
 from f5.bigip.tm.asm.policies import Policy_Builder
 from f5.bigip.tm.asm.policies import Redirection_Protection
@@ -59,6 +60,14 @@ from f5.sdk_exception import UnsupportedOperation
 import mock
 import pytest
 from six import iterkeys
+
+
+@pytest.fixture
+def FakePlain():
+    fake_policy = mock.MagicMock()
+    fake_e = Plain_Text_Profile(fake_policy)
+    fake_e._meta_data['bigip'].tmos_version = '12.1.0'
+    return fake_e
 
 
 @pytest.fixture
@@ -622,3 +631,9 @@ class TestSuggestions(object):
     def test_create_raises(self, FakeSugg):
         with pytest.raises(UnsupportedOperation):
             FakeSugg.create()
+
+
+class TestPlainTextProfiles(object):
+    def test_create_no_args(self, FakePlain):
+        with pytest.raises(MissingRequiredCreationParameter):
+            FakePlain.create()

--- a/f5/bigip/tm/asm/test/unit/test_policies.py
+++ b/f5/bigip/tm/asm/test/unit/test_policies.py
@@ -47,6 +47,7 @@ from f5.bigip.tm.asm.policies import UrlParametersResource
 from f5.bigip.tm.asm.policies import Violation
 from f5.bigip.tm.asm.policies import Vulnerabilities
 from f5.bigip.tm.asm.policies import Vulnerability_Assessment
+from f5.bigip.tm.asm.policies import Web_Scraping
 from f5.bigip.tm.asm.policies import Web_Services_Security
 from f5.bigip.tm.asm.policies import Xml_Validation_File
 from f5.sdk_exception import MissingRequiredCreationParameter
@@ -56,6 +57,14 @@ from f5.sdk_exception import UnsupportedOperation
 import mock
 import pytest
 from six import iterkeys
+
+
+@pytest.fixture
+def FakeWebscrape():
+    fake_policy = mock.MagicMock()
+    fake_e = Web_Scraping(fake_policy)
+    fake_e._meta_data['bigip'].tmos_version = '12.0.0'
+    return fake_e
 
 
 @pytest.fixture
@@ -474,7 +483,7 @@ class TestSessionTracking(object):
 
 
 class TestSessionTrackingStatuses(object):
-    def test_update_raises(self, FakeSess):
+    def test_modify_raises(self, FakeSess):
         with pytest.raises(UnsupportedOperation):
             FakeSess.modify()
 
@@ -522,7 +531,7 @@ class TestBruteForce(object):
 
 
 class TestXMLValidationFiles(object):
-    def test_update_raises(self, FakeXmlFile):
+    def test_modify_raises(self, FakeXmlFile):
         with pytest.raises(UnsupportedOperation):
             FakeXmlFile.modify()
 
@@ -569,3 +578,9 @@ class TestCharacterSets(object):
     def test_delete_raises(self, FakeChar):
         with pytest.raises(UnsupportedOperation):
             FakeChar.delete()
+
+
+class TestWebScraping(object):
+    def test_update_raises(self, FakeWebscrape):
+        with pytest.raises(UnsupportedOperation):
+            FakeWebscrape.update()


### PR DESCRIPTION
Problem:
Asm Policies were missing multiple endpoints from version 11.6.0

Analysis:
Asm Policies are now complete with all its endpoints and sub-collections up to version 12.1.0. This is last of the series of PRs.

Tests:
Functional
Unit
Flake8