### PR TITLE
deprecate support for py26

### DIFF
--- a/requirements.py26.txt
+++ b/requirements.py26.txt
@@ -1,3 +1,0 @@
--e .
-
-ordereddict>=1.1, <2

--- a/requirements.test.txt
+++ b/requirements.test.txt
@@ -1,6 +1,5 @@
 # Install this directory (will use setup.py and therefore install_requires).
 -e .
--r requirements.py26.txt
 # Test Requirements
 hacking==0.13.0
 mock==2.0.0

--- a/tox.ini
+++ b/tox.ini
@@ -1,21 +1,18 @@
 [tox]
 envlist =
-    py{26,27,35}-bip-v{11.5.4,11.6.0,11.6.1,12.0.0,12.1.0,12.1.1}
-    py{26,27,35}-biq-v{5.1.0}
-    py{26,27,35}-iwf-v{2.1.0}
+    py{27,35}-bip-v{11.5.4,11.6.0,11.6.1,12.0.0,12.1.0,12.1.1}
+    py{27,35}-biq-v{5.1.0}
+    py{27,35}-iwf-v{2.1.0}
     unit
     flake
-    flake26
     coveralls
 
 [testenv]
 basepython =
-    py26: python2.6
     py27: python2.7
     py35: python3.5
     unit: python
     flake: python
-    flake26: python2.6
     coveralls: python
 passenv = COVERALLS_REPO_TOKEN
 deps =
@@ -23,24 +20,23 @@ deps =
 
 commands =
     # BIG-IP tests
-    py{26,27,35}-bip-v11.5.4: py.test --bigip localhost --port 10443 -s -vv --release 11.5.4 {posargs:f5/bigip}
-    py{26,27,35}-bip-v11.6.0: py.test --bigip localhost --port 10443 -s -vv --release 11.6.0 {posargs:f5/bigip}
-    py{26,27,35}-bip-v11.6.1: py.test --bigip localhost --port 10443 -s -vv --release 11.6.1 {posargs:f5/bigip}
-    py{26,27,35}-bip-v12.0.0: py.test --bigip localhost --port 10443 -s -vv --release 12.0.0 {posargs:f5/bigip}
-    py{26,27,35}-bip-v12.1.0: py.test --bigip localhost --port 10443 -s -vv --release 12.1.0 {posargs:f5/bigip}
-    py{26,27,35}-bip-v12.1.1: py.test --bigip localhost --port 10443 -s -vv --release 12.1.1 {posargs:f5/bigip}
-    py{26,27,35}-bip-v12.1.2: py.test --bigip localhost --port 10443 -s -vv --release 12.1.2 {posargs:f5/bigip}
+    py{27,35}-bip-v11.5.4: py.test --bigip localhost --port 10443 -s -vv --release 11.5.4 {posargs:f5/bigip}
+    py{27,35}-bip-v11.6.0: py.test --bigip localhost --port 10443 -s -vv --release 11.6.0 {posargs:f5/bigip}
+    py{27,35}-bip-v11.6.1: py.test --bigip localhost --port 10443 -s -vv --release 11.6.1 {posargs:f5/bigip}
+    py{27,35}-bip-v12.0.0: py.test --bigip localhost --port 10443 -s -vv --release 12.0.0 {posargs:f5/bigip}
+    py{27,35}-bip-v12.1.0: py.test --bigip localhost --port 10443 -s -vv --release 12.1.0 {posargs:f5/bigip}
+    py{27,35}-bip-v12.1.1: py.test --bigip localhost --port 10443 -s -vv --release 12.1.1 {posargs:f5/bigip}
+    py{27,35}-bip-v12.1.2: py.test --bigip localhost --port 10443 -s -vv --release 12.1.2 {posargs:f5/bigip}
 
     # BIG-IQ tests
-    py{26,27,35}-biq-v5.1.0: py.test --bigip localhost --port 10443 -s -vv --release 5.1.0 {posargs:f5/bigiq}
+    py{27,35}-biq-v5.1.0: py.test --bigip localhost --port 10443 -s -vv --release 5.1.0 {posargs:f5/bigiq}
 
     # iWorkflow tests
-    py{26,27,35}-iwf-v2.1.0: py.test --bigip localhost --port 10443 -s -vv --release 2.1.0 {posargs:f5/iworkflow}
+    py{27,35}-iwf-v2.1.0: py.test --bigip localhost --port 10443 -s -vv --release 2.1.0 {posargs:f5/iworkflow}
 
     # Misc tests
     unit: py.test -k "not /functional/" -vv --cov {posargs:.}
     flake: flake8 {posargs:.}
-    flake26: flake8 {posargs:.}
     coveralls: coveralls
 usedevelop = true
 


### PR DESCRIPTION
Issues:
Fixes #1035

Problem: python 2.6 was end of lifed in 2013.
After an extensive community poll, during which
0 people objected to deprecating support I have
decided to deprecate to reduce development
complexity.

Analysis: references to python 2.6 (py26) were
removed from the test configuration code.

Tests: The usual (minus python 2.6!!!) tests must pass
for acceptance.