### PR TITLE
Adds package management APIs for iAppLX packages

### DIFF
--- a/f5/bigip/resource.py
+++ b/f5/bigip/resource.py
@@ -1337,3 +1337,135 @@ class AsmTaskResource(AsmResource):
         raise UnsupportedOperation(
             "%s does not support the modify method" % self.__class__.__name__
         )
+
+
+class TaskResource(Resource):
+    def __init__(self, container):
+        """Call to create a client side object to represent a service URI.
+
+        Call _create or _load for a Resource to have a self._meta_data['uri']!
+        """
+        super(TaskResource, self).__init__(container)
+        # Asm endpoints require object 'id' which is a hash created by BIGIP
+        # when object is created.
+        self._meta_data['required_load_parameters'] = set(('id',))
+        # No ASM endpoint supports Stats
+        self._meta_data['object_has_stats'] = False
+
+    def _load(self, **kwargs):
+        """wrapped with load, override that in a subclass to customize"""
+        if 'uri' in self._meta_data:
+            error = "There was an attempt to assign a new uri to this " \
+                    "resource, the _meta_data['uri'] is %s and it should" \
+                    " not be changed." % (self._meta_data['uri'])
+            raise URICreationCollision(error)
+        requests_params = self._handle_requests_params(kwargs)
+        self._check_load_parameters(**kwargs)
+        kwargs['uri_as_parts'] = True
+        refresh_session = self._meta_data['bigip']._meta_data['icr_session']
+        uri = self._meta_data['container']._meta_data['uri']
+        endpoint = kwargs.pop('id', '')
+        # Popping name kwarg as it will cause the uri to be invalid. We only
+        # require id parameter
+        kwargs.pop('name', '')
+        base_uri = uri + endpoint + '/'
+        kwargs.update(requests_params)
+        for key1, key2 in self._meta_data['reduction_forcing_pairs']:
+            kwargs = self._reduce_boolean_pair(kwargs, key1, key2)
+        response = refresh_session.get(base_uri, **kwargs)
+        # Make new instance of self
+        return self._produce_instance(response)
+
+    def load(self, **kwargs):
+        """Load an already configured service into this instance.
+
+        This method uses HTTP GET to obtain a resource from the BIG-IP®.
+
+        ..
+            The URI of the target service is constructed from the instance's
+            container and **kwargs.
+            kwargs typically for ASM requires "id" in majority of cases,
+            as object links in ASM are using hash(id) instead of names,
+            this may, or may not, be true for a specific service.
+
+        :param kwargs: typically contains "id"
+        NOTE: If kwargs has a 'requests_params' key the corresponding dict will
+        be passed to the underlying requests.session.get method where it will
+        be handled according to that API. THIS IS HOW TO PASS QUERY-ARGS!
+        :returns: a Resource Instance (with a populated _meta_data['uri'])
+        """
+        return self._load(**kwargs)
+
+    def _delete(self, **kwargs):
+        """wrapped with delete, override that in a subclass to customize """
+        requests_params = self._handle_requests_params(kwargs)
+
+        delete_uri = self._meta_data['uri']
+        session = self._meta_data['bigip']._meta_data['icr_session']
+        response = session.delete(delete_uri, **requests_params)
+        if response.status_code == 200 or 201:
+            self.__dict__ = {'deleted': True}
+
+    def delete(self, **kwargs):
+        """Delete the Task resource on the BIG-IP®.
+
+        Uses HTTP DELETE to delete the Task resource on the BIG-IP®.
+
+        After this method is called, and status_code 200 or 201 response is
+        received ``instance.__dict__`` is replace with ``{'deleted': True}``
+
+        :param kwargs: The only current use is to pass kwargs to the requests
+        API. If kwargs has a 'requests_params' key the corresponding dict will
+        be passed to the underlying requests.session.delete method where it
+        will be handled according to that API. THIS IS HOW TO PASS QUERY-ARGS!
+        """
+        # Need to implement checking for ? here.
+        self._delete(**kwargs)
+        # Need to implement correct teardown here.
+
+    def exists(self, **kwargs):
+        """Check for the existence of the Task object on the BIG-IP
+
+        Sends an HTTP GET to the URI of the ASM object and if it fails with
+        a :exc:~requests.HTTPError` exception it checks the exception for
+        status code of 404 and returns :obj:`False` in that case.
+
+        If the GET is successful it returns :obj:`True`.
+
+        For any other errors are raised as-is.
+
+        :param kwargs: Keyword arguments required to get objects
+        NOTE: If kwargs has a 'requests_params' key the corresponding dict will
+        be passed to the underlying requests.session.get method where it will
+        be handled according to that API. THIS IS HOW TO PASS QUERY-ARGS!
+        :returns: bool -- The objects exists on BIG-IP® or not.
+        :raises: :exc:`requests.HTTPError`, Any HTTP error that was not status
+                 code 404.
+        """
+        requests_params = self._handle_requests_params(kwargs)
+        self._check_load_parameters(**kwargs)
+        kwargs['uri_as_parts'] = True
+        session = self._meta_data['bigip']._meta_data['icr_session']
+        uri = self._meta_data['container']._meta_data['uri']
+        endpoint = kwargs.pop('id', '')
+        # Popping name kwarg as it will cause the uri to be invalid
+        kwargs.pop('name', '')
+        base_uri = uri + endpoint + '/'
+        kwargs.update(requests_params)
+        try:
+            session.get(base_uri, **kwargs)
+        except HTTPError as err:
+            if err.response.status_code == 404:
+                return False
+            else:
+                raise
+        return True
+
+    def update(self, **kwargs):
+        """Update is not supported for ASM Resources
+
+                :raises: UnsupportedOperation
+        """
+        raise UnsupportedOperation(
+            "%s does not support the update method" % self.__class__.__name__
+        )

--- a/f5/bigip/shared/__init__.py
+++ b/f5/bigip/shared/__init__.py
@@ -18,6 +18,7 @@
 
 from f5.bigip.resource import OrganizingCollection
 from f5.bigip.shared.file_transfer import File_Transfer
+from f5.bigip.shared.iapp import Iapp
 
 
 class Shared(OrganizingCollection):
@@ -25,5 +26,6 @@ class Shared(OrganizingCollection):
     def __init__(self, mgmt):
         super(Shared, self).__init__(mgmt)
         self._meta_data['allowed_lazy_attributes'] = [
-            File_Transfer
+            File_Transfer,
+            Iapp
         ]

--- a/f5/bigip/shared/iapp.py
+++ b/f5/bigip/shared/iapp.py
@@ -1,0 +1,66 @@
+# coding=utf-8
+#
+# Copyright 2017 F5 Networks Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+from f5.bigip.resource import Collection
+from f5.bigip.resource import OrganizingCollection
+from f5.bigip.resource import TaskResource
+from f5.sdk_exception import UnsupportedOperation
+
+
+class Iapp(OrganizingCollection):
+    def __init__(self, shared):
+        super(Iapp, self).__init__(shared)
+        self._meta_data['allowed_lazy_attributes'] = [
+            Package_Management_Tasks_s
+        ]
+
+
+class Package_Management_Tasks_s(Collection):
+    def __init__(self, iapp):
+        super(Package_Management_Tasks_s, self).__init__(iapp)
+        self._meta_data['object_has_stats'] = False
+        self._meta_data['required_json_kind'] = \
+            'shared:iapp:package-management-tasks:iapppackagemanagementcollectionstate'  # NOQA
+        self._meta_data['allowed_lazy_attributes'] = [Package_Management_Task]
+        self._meta_data['attribute_registry'] = {
+            'shared:iapp:package-management-tasks:iapppackagemanagementtaskstate': Package_Management_Task  # NOQA
+        }
+
+
+class Package_Management_Task(TaskResource):
+    def __init__(self, package_management_tasks):
+        super(Package_Management_Task, self).__init__(package_management_tasks)
+        self._meta_data['required_json_kind'] = \
+            'shared:iapp:package-management-tasks:iapppackagemanagementtaskstate'  # NOQA
+        self._meta_data['required_creation_parameters'] = \
+            set(('operation', 'packageFilePath'))
+
+    def update(self, **kwargs):
+        raise UnsupportedOperation(
+            "%s does not support the update method" % self.__class__.__name__
+        )
+
+    def cancel(self, **kwargs):
+        self._cancel(**kwargs)
+
+    def _cancel(self, **kwargs):
+        params = dict(
+            status='CANCEL_REQUESTED'
+        )
+        self.modify(**params)
+        if self.status == 'CANCEL_REQUESTED':
+            self.__dict__.update({'canceled': True})

--- a/f5/bigip/shared/test/functional/test_iapp.py
+++ b/f5/bigip/shared/test/functional/test_iapp.py
@@ -1,0 +1,90 @@
+# Copyright 2015 F5 Networks Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+
+import pytest
+
+try:
+    from StringIO import StringIO
+except ImportError:
+    from io import StringIO
+
+from requests.exceptions import HTTPError
+
+
+@pytest.fixture(scope='function')
+def iapp_lx(mgmt_root):
+    fake_iapp_name = 'foo-iapp.rpm'
+    sio = StringIO(80*'a')
+    ftu = mgmt_root.shared.file_transfer.uploads
+    ftu.upload_stringio(sio, fake_iapp_name, chunk_size=20)
+    yield fake_iapp_name
+    tpath_name = '/var/config/rest/downloads/{0}'.format(fake_iapp_name)
+    mgmt_root.tm.util.unix_rm.exec_cmd('run', utilCmdArgs=tpath_name)
+
+
+@pytest.fixture(scope='function')
+def pkg_task(mgmt_root, iapp_lx):
+    collection = mgmt_root.shared.iapp.package_management_tasks_s
+    task = collection.package_management_task.create(
+        operation='INSTALL',
+        packageFilePath='/var/config/rest/downloads/foo-iapp.rpm'
+    )
+    yield task
+
+
+class TestPackageManagementTasks(object):
+    def test_create_task(self, pkg_task):
+        assert pkg_task.operation == "INSTALL"
+        assert pkg_task.kind == \
+            'shared:iapp:package-management-tasks:iapppackagemanagementtaskstate'  # NOQA
+
+    def test_load_no_task(self, mgmt_root):
+        with pytest.raises(HTTPError) as err:
+            collection = mgmt_root.shared.iapp.package_management_tasks_s
+            collection.package_management_task.load(
+                id='asdasdasd'
+            )
+        assert err.value.response.status_code == 404
+
+    def test_load(self, mgmt_root, pkg_task):
+        collection = mgmt_root.shared.iapp.package_management_tasks_s
+        resource = collection.package_management_task.load(id=pkg_task.id)
+        assert pkg_task.id == resource.id
+        assert pkg_task.selfLink == resource.selfLink
+
+    def test_exists(self, mgmt_root, pkg_task):
+        pid = str(pkg_task.id)
+        collection = mgmt_root.shared.iapp.package_management_tasks_s
+        exists = collection.package_management_task.exists(id=pid)
+        assert exists is True
+
+    def test_cancel(self, pkg_task):
+        pkg_task.cancel()
+        assert pkg_task.__dict__['canceled']
+
+    def test_delete(self, pkg_task):
+        pkg_task.cancel()
+        while True:
+            pkg_task.refresh()
+            if pkg_task.status in ['CANCELED', 'FAILED', 'FINISHED']:
+                pkg_task.delete()
+                break
+        assert pkg_task.__dict__['deleted']
+
+    def test_package_mgmt_tasks_collection(self, mgmt_root, iapp_lx):
+        col = mgmt_root.shared.iapp.package_management_tasks_s.get_collection()
+        assert isinstance(col, list)
+        assert len(col) > 0

--- a/f5/bigip/shared/test/unit/test_iapp.py
+++ b/f5/bigip/shared/test/unit/test_iapp.py
@@ -1,0 +1,56 @@
+# Copyright 2017 F5 Networks Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+from f5.bigip import ManagementRoot
+from f5.bigip.shared.iapp import Package_Management_Task
+from f5.sdk_exception import MissingRequiredCreationParameter
+from f5.sdk_exception import UnsupportedOperation
+
+import mock
+import pytest
+from six import iterkeys
+
+
+@pytest.fixture
+def FakeIapp():
+    mo = mock.MagicMock()
+    fake_iapp = Package_Management_Task(mo)
+    return fake_iapp
+
+
+class TestIapp(object):
+    def test_update_raises(self, FakeIapp):
+        with pytest.raises(UnsupportedOperation):
+            FakeIapp.update()
+
+    def test_create_two(self, fakeicontrolsession):
+        b = ManagementRoot('192.168.1.1', 'admin', 'admin')
+        t1 = b.shared.iapp.package_management_tasks_s.package_management_task
+        t2 = b.shared.iapp.package_management_tasks_s.package_management_task
+        assert t1 is t2
+
+    def test_create_no_args(self, FakeIapp):
+        with pytest.raises(MissingRequiredCreationParameter):
+            FakeIapp.create()
+
+    def test_collection(self, fakeicontrolsession):
+        b = ManagementRoot('192.168.1.1', 'admin', 'admin')
+        t = b.shared.iapp.package_management_tasks_s
+        test_meta = t._meta_data['attribute_registry']
+        test_meta2 = t._meta_data['allowed_lazy_attributes']
+        kind = 'shared:iapp:package-management-tasks:iapppackagemanagementtaskstate'  # NOQA
+        assert kind in list(iterkeys(test_meta))
+        assert Package_Management_Task in test_meta2
+        assert t._meta_data['object_has_stats'] is False


### PR DESCRIPTION
Issues:
Fixes #760

Problem:
APIs for package management tasks were not in the SDK

Analysis:
This patch adds them

Tests:
* functional
* unit