### PR TITLE
Adds restproxy feature for iworkflow

### DIFF
--- a/f5/iworkflow/__init__.py
+++ b/f5/iworkflow/__init__.py
@@ -16,40 +16,84 @@
 #
 
 
+from f5.bigip import BaseManagement as BigipBaseManagement
 from f5.iworkflow.cm import Cm
 from f5.iworkflow.resource import PathElement
 from f5.iworkflow.shared import Shared
 from f5.iworkflow.tm import Tm
+from f5.sdk_exception import F5SDKError
 from icontrol.session import iControlRESTSession
 
+import copy
+import re
 
-class ManagementRoot(PathElement):
-    """An interface to a single iWorkflow"""
+
+class BaseManagement(object):
     def __init__(self, hostname, username, password, **kwargs):
-        timeout = kwargs.pop('timeout', 30)
-        port = kwargs.pop('port', 443)
-        icontrol_version = kwargs.pop('icontrol_version', '')
-        token = kwargs.pop('token', False)
+        self.args = self.parse_arguments(
+            hostname, username, password, **kwargs
+        )
+        self.icrs = self._get_icr_session(**self.args)
+        self.configure_meta_data(**self.args)
+        self.set_icr_metadata(self.icrs)
+
+    def parse_arguments(self, *args, **kwargs):
+        result = dict(
+            timeout=kwargs.pop('timeout', 30),
+            port=kwargs.pop('port', 443),
+            icontrol_version=kwargs.pop('icontrol_version', ''),
+            token=kwargs.pop('token', False)
+        )
         if kwargs:
             raise TypeError('Unexpected **kwargs: %r' % kwargs)
-        # _meta_data variable values
-        iCRS = iControlRESTSession(username, password, timeout=timeout,
-                                   token=token)
-        # define _meta_data
+        result.update(dict(
+            hostname=args[0],
+            username=args[1],
+            password=args[2]
+        ))
+        return result
+
+    def _get_icr_session(self, *args, **kwargs):
+        return iControlRESTSession(
+            username=kwargs['username'],
+            password=kwargs['password'],
+            timeout=kwargs['timeout'],
+            token=kwargs['token']
+        )
+
+    def configure_meta_data(self, *args, **kwargs):
         self._meta_data = {
-            'allowed_lazy_attributes': [Cm, Shared, Tm],
-            'hostname': hostname,
-            'port': port,
-            'uri': 'https://%s:%s/mgmt/' % (hostname, port),
-            'icr_session': iCRS,
+            'allowed_lazy_attributes': [Tm, Cm, Shared],
+            'hostname': kwargs['hostname'],
+            'port': kwargs['port'],
             'device_name': None,
             'local_ip': None,
             'bigip': self,
-            'icontrol_version': icontrol_version,
-            'username': username,
-            'password': password,
+            'icontrol_version': kwargs['icontrol_version'],
+            'username': kwargs['username'],
+            'password': kwargs['password'],
             'tmos_version': None,
         }
+
+    def set_icr_metadata(self, icrs):
+        self._meta_data['icr_session'] = icrs
+
+
+class ManagementRoot(BaseManagement, PathElement):
+    """An interface to a single BIG-IP"""
+    def __init__(self, hostname, username, password, **kwargs):
+        super(ManagementRoot, self).__init__(
+            hostname, username, password, **kwargs
+        )
+        self.set_metadata_uri(**self.args)
+        self.post_configuration_setup()
+
+    def set_metadata_uri(self, *args, **kwargs):
+        self._meta_data['uri'] = 'https://{0}:{1}/mgmt/'.format(
+            kwargs['hostname'], kwargs['port']
+        )
+
+    def post_configuration_setup(self):
         self._get_os_version()
 
     @property
@@ -71,3 +115,78 @@ class ManagementRoot(PathElement):
         response = connect.get(base_uri)
         version = response.json()['version']
         self._meta_data['tmos_version'] = version
+
+
+class ManagementProxy(object):
+    def __new__(cls, *args, **kwargs):
+        device_group = kwargs.pop('device_group', 'cm-cloud-managed-devices')
+        hostname = kwargs.pop('hostname', None)
+        uuid = kwargs.pop('uuid', None)
+        rest_proxy = kwargs.pop('rest_proxy', None)
+        if not uuid and not hostname:
+            raise F5SDKError(
+                "One of either 'uuid' or 'hostname must be specified."
+            )
+        elif uuid is not None and hostname is not None:
+            raise F5SDKError(
+                "The 'uuid' and 'hostname' parameters are mutually exclusive. "
+                "You may specify one or the other, but not both."
+            )
+        if not rest_proxy:
+            raise F5SDKError(
+                "You must provide a device to proxy REST requests through"
+            )
+        proxy = copy.deepcopy(rest_proxy)
+        uuid = cls._get_identifier(proxy, hostname=hostname, uuid=uuid)
+        if uuid is None:
+            raise F5SDKError(
+                "The specified device was missing a UUID. "
+                "This should not happen!"
+            )
+        bigip = BigipBaseManagement(
+            proxy.args['hostname'],
+            proxy.args['username'],
+            proxy.args['password'],
+            port=proxy.args['port']
+        )
+        bigip.icrs = proxy.icrs
+        uri = ''.join([
+            'https://{0}:{1}/mgmt/shared/resolver/device-groups/',
+            '{2}/devices/{3}/rest-proxy/mgmt/'
+        ])
+        bigip._meta_data['uri'] = uri.format(
+            proxy.args['hostname'],
+            proxy.args['port'],
+            device_group,
+            uuid
+        )
+        bigip.post_configuration_setup()
+        return bigip
+
+    @staticmethod
+    def _get_identifier(proxy, hostname=None, uuid=None):
+        if uuid is not None:
+            if re.search(r'([0-9-a-z]+\-){4}[0-9-a-z]+', uuid, re.I):
+                return uuid
+        return ManagementProxy._get_device_uuid(proxy, hostname)
+
+    @staticmethod
+    def _get_device_uuid(proxy, name):
+        dg = proxy.shared.resolver.device_groups
+        collection = dg.cm_cloud_managed_devices.devices_s.get_collection(
+            requests_params=dict(
+                params="$filter=hostname+eq+'{0}'&$select=uuid".format(name)
+            )
+        )
+        if len(collection) > 1:
+            raise F5SDKError(
+                "More that one managed device was found with this hostname. "
+                "Proxied devices must be unique."
+            )
+        elif len(collection) == 0:
+            raise F5SDKError(
+                "No device was found with that hostname"
+            )
+        else:
+            resource = collection.pop()
+            return resource.pop('uuid', None)

--- a/f5/iworkflow/test/unit/test___init__.py
+++ b/f5/iworkflow/test/unit/test___init__.py
@@ -1,0 +1,67 @@
+# Copyright 2014 F5 Networks Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import mock
+import pytest
+try:
+    import urlparse
+except ImportError:
+    from urllib import parse as urlparse
+
+from f5.iworkflow import ManagementRoot
+
+from f5.iworkflow.cm import Cm
+from f5.iworkflow.shared import Shared
+from f5.iworkflow.tm import Tm
+
+
+@pytest.fixture
+def FakeIWorkflow(fakeiwficontrolsession):
+    mo = ManagementRoot('FakeHostName', 'admin', 'admin')
+    mo.icontrol = mock.MagicMock()
+    return mo
+
+
+@pytest.fixture
+def FakeIWorkflowWithPort(fakeiwficontrolsession):
+    mo = ManagementRoot('FakeHostName', 'admin', 'admin', port='10443')
+    mo.icontrol = mock.MagicMock()
+    return mo
+
+
+def test___get__attr(FakeIWorkflow):
+    bigip_dot_cm = FakeIWorkflow.cm
+    assert isinstance(bigip_dot_cm, Cm)
+    bigip_dot_shared = FakeIWorkflow.shared
+    assert isinstance(bigip_dot_shared, Shared)
+    bigip_dot_sys = FakeIWorkflow.tm
+    assert isinstance(bigip_dot_sys, Tm)
+    with pytest.raises(AttributeError):
+        FakeIWorkflow.tm.this_is_not_a_real_attribute
+    assert FakeIWorkflow.hostname == 'FakeHostName'
+
+
+def test_invalid_args():
+    with pytest.raises(TypeError) as err:
+        ManagementRoot('FakeHostName', 'admin', 'admin', badArgs='foobar')
+    assert 'Unexpected **kwargs' in str(err.value)
+
+
+def test_icontrol_version(FakeIWorkflowWithPort):
+    assert hasattr(FakeIWorkflowWithPort, 'icontrol_version')
+
+
+def test_non_default_port_number(FakeIWorkflowWithPort):
+    uri = urlparse.urlsplit(FakeIWorkflowWithPort._meta_data['uri'])
+    assert uri.port == 10443

--- a/requirements.test.txt
+++ b/requirements.test.txt
@@ -7,5 +7,5 @@ pytest==3.0.5
 pytest-cov>=2.2.1
 git+https://github.com/F5Networks/pytest-symbols.git
 python-coveralls==2.7.0
-pyOpenSSL==16.0.0
+pyOpenSSL==16.2.0
 requests-mock==1.2.0


### PR DESCRIPTION
Issues:
Fixes #1049

Problem:
the SDK was missing the ability to use iWorkflow's RestProxy feature

Analysis:
This patch adds it. Additionally, it refactors the bigip's init files
so that the necessary functionality can be made to exist for the iwf
rest proxy

Tests: