### PR TITLE
Fixes #1044

### DIFF
--- a/f5/bigip/tm/asm/policies.py
+++ b/f5/bigip/tm/asm/policies.py
@@ -1214,7 +1214,7 @@ class Vulnerabilities(AsmResource):
         )
 
     def delete(self, **kwargs):
-        """Modify is not supported for Vulnerabilities resource
+        """Delete is not supported for Vulnerabilities resource
 
         :raises: UnsupportedOperation
         """
@@ -1288,7 +1288,7 @@ class Character_Sets(AsmResource):
         )
 
     def delete(self, **kwargs):
-        """Modify is not supported for Character Sets resource
+        """Delete is not supported for Character Sets resource
 
         :raises: UnsupportedOperation
         """
@@ -1358,7 +1358,7 @@ class Audit_Log(AsmResource):
         )
 
     def delete(self, **kwargs):
-        """Modify is not supported for Audit Logs resource
+        """Delete is not supported for Audit Logs resource
 
         :raises: UnsupportedOperation
         """

--- a/f5/sdk_exception.py
+++ b/f5/sdk_exception.py
@@ -149,6 +149,14 @@ class NonExtantVirtualPolicy(F5SDKError):
     pass
 
 
+class NonExtantApplication(F5SDKError):
+    """Raise if the dos profile application sub-collection
+
+    resource does not exist on the device.
+    """
+    pass
+
+
 class NonExtantPolicyRule(F5SDKError):
     """Raise if a rule does not exist on the device."""
     pass


### PR DESCRIPTION
Problem:
AFM DDoS profiles Application subcollection was missing

Analysis:
This PR adds DOS profiles Application subcollection endpoint.  Custom load and exists method had to be implemented due to a known bug in 11.6.0 where non existing objects would still return when called by a direct link

Tests:
Functional
Unit
Flake8