### PR TITLE
Fixes #1045

### DIFF
--- a/f5/bigip/tm/security/test/functional/test_dos.py
+++ b/f5/bigip/tm/security/test/functional/test_dos.py
@@ -16,6 +16,7 @@ import copy
 import pytest
 
 from f5.bigip.tm.security.dos import Application
+from f5.bigip.tm.security.dos import Dos_Network
 from f5.bigip.tm.security.dos import Profile
 from f5.sdk_exception import NonExtantApplication
 from requests.exceptions import HTTPError
@@ -24,6 +25,7 @@ from six import iteritems
 from distutils.version import LooseVersion
 
 DESC = 'TESTCHANGEDIT'
+ATCK = [{'name': 'tcp-rst-flood', 'rateLimit': 100, 'rateThreshold': 50}]
 
 
 @pytest.fixture(scope='function')
@@ -116,7 +118,7 @@ class TestDosProfiles(object):
         assert hasattr(r2, 'description')
         assert r1.description == r2.description
 
-    def test_policy_collection(self, dos_profile, mgmt_root):
+    def test_dosprofile_collection(self, dos_profile, mgmt_root):
         r1 = dos_profile
         URI = 'https://localhost/mgmt/tm/security/dos/profile/~Common~fake_dos'
         assert r1.name == 'fake_dos'
@@ -211,8 +213,8 @@ class TestApplication(object):
             dos_profile.applications.application.load(name='fake_app')
 
         except NonExtantApplication as err:
-            msg = 'The application resource named,' \
-                  'fake_app, does not exist on the device.'
+            msg = 'The application resource named, fake_app, does not exist ' \
+                  'on the device.'
 
             assert err.message == msg
 
@@ -227,8 +229,8 @@ class TestApplication(object):
             dos_profile.applications.application.load(name='not_exists')
 
         except NonExtantApplication as err:
-            msg = 'The application resource named,' \
-                  'fake_app, does not exist on the device.'
+            msg = 'The application resource named, not_exists, ' \
+                  'does not exist on the device.'
 
             assert err.message == msg
 
@@ -247,7 +249,7 @@ class TestApplication(object):
         assert r1.selfLink == r2.selfLink
         assert r1.triggerIrule == r2.triggerIrule
 
-    def test_policy_collection(self, dos_profile):
+    def test_app_subcollection(self, dos_profile):
         r1 = dos_profile.applications.application.create(name='fake_app')
         URI = 'https://localhost/mgmt/tm/security/dos/profile/~Common' \
               '~fake_dos/application/fake_app'
@@ -259,3 +261,135 @@ class TestApplication(object):
         assert isinstance(rc, list)
         assert len(rc)
         assert isinstance(rc[0], Application)
+
+
+class TestDosNetwork(object):
+    def test_create_req_arg(self, dos_profile):
+        r1 = dos_profile.dos_networks.dos_network.create(name='fake_app')
+        URI = 'https://localhost/mgmt/tm/security/dos/profile/~Common' \
+              '~fake_dos/dos-network/fake_app'
+        assert r1.name == 'fake_app'
+        assert r1.selfLink.startswith(URI)
+        assert not hasattr(r1, 'networkAttackVector')
+
+    def test_create_optional_args(self, dos_profile):
+        r1 = dos_profile.dos_networks.dos_network.create(
+            name='fake_app', networkAttackVector=ATCK)
+        URI = 'https://localhost/mgmt/tm/security/dos/profile/~Common' \
+              '~fake_dos/dos-network/fake_app'
+        assert r1.name == 'fake_app'
+        assert r1.selfLink.startswith(URI)
+        assert hasattr(r1, 'networkAttackVector')
+
+    def test_refresh(self, dos_profile):
+        r1 = dos_profile.dos_networks.dos_network.create(name='fake_app')
+        r2 = dos_profile.dos_networks.dos_network.load(name='fake_app')
+        assert r1.name == r2.name
+        assert r1.selfLink == r2.selfLink
+        assert not hasattr(r1, 'networkAttackVector')
+        assert not hasattr(r2, 'networkAttackVector')
+        r2.networkAttackVector = ATCK
+        r2.update()
+        assert r1.selfLink == r2.selfLink
+        assert r1.name == r2.name
+        assert not hasattr(r1, 'networkAttackVector')
+        assert hasattr(r2, 'networkAttackVector')
+        r1.refresh()
+        assert r1.networkAttackVector == r2.networkAttackVector
+
+    def test_modify(self, dos_profile):
+        r1 = dos_profile.dos_networks.dos_network.create(name='fake_app')
+        original_dict = copy.deepcopy(r1.__dict__)
+        itm = 'networkAttackVector'
+        r1.modify(networkAttackVector=ATCK)
+        for k, v in iteritems(original_dict):
+            if k != itm:
+                original_dict[k] = r1.__dict__[k]
+            elif k == itm:
+                assert r1.__dict__[k] == ATCK
+
+    @pytest.mark.skipif(
+        LooseVersion(
+            pytest.config.getoption('--release')
+        ) == LooseVersion('11.6.0'),
+        reason='This test will fail on 11.6.0 due to a known bug.'
+    )
+    def test_delete(self, dos_profile):
+        r1 = dos_profile.dos_networks.dos_network.create(name='fake_app')
+        r1.delete()
+        with pytest.raises(HTTPError) as err:
+            dos_profile.dos_networks.dos_network.load(name='fake_app')
+        assert err.value.response.status_code == 404
+
+    @pytest.mark.skipif(
+        LooseVersion(
+            pytest.config.getoption('--release')
+        ) == LooseVersion('11.6.0'),
+        reason='This test will fail on 11.6.0 due to a known bug.'
+    )
+    def test_load_no_object(self, dos_profile):
+        with pytest.raises(HTTPError) as err:
+            dos_profile.dos_networks.dos_network.load(name='not_exist')
+        assert err.value.response.status_code == 404
+
+    @pytest.mark.skipif(
+        LooseVersion(
+            pytest.config.getoption('--release')
+        ) != LooseVersion('11.6.0'),
+        reason='This test is for 11.6.0 TMOS only, due to a known bug.'
+    )
+    def test_delete_11_6_0(self, dos_profile):
+        r1 = dos_profile.dos_networks.dos_network.create(name='fake_app')
+        r1.delete()
+        try:
+            dos_profile.dos_networks.dos_network.load(name='fake_app')
+
+        except NonExtantApplication as err:
+            msg = 'The application resource named, fake_app, does not exist ' \
+                  'on the device.'
+
+            assert err.message == msg
+
+    @pytest.mark.skipif(
+        LooseVersion(
+            pytest.config.getoption('--release')
+        ) != LooseVersion('11.6.0'),
+        reason='This test is for 11.6.0 TMOS only, due to a known bug.'
+    )
+    def test_load_no_object_11_6_0(self, dos_profile):
+        try:
+            dos_profile.dos_networks.dos_network.load(name='not_exists')
+
+        except NonExtantApplication as err:
+            msg = 'The application resource named, not_exists, does not ' \
+                  'exist on the device.'
+
+            assert err.message == msg
+
+    def test_load_and_update(self, dos_profile):
+        r1 = dos_profile.dos_networks.dos_network.create(name='fake_app')
+        URI = 'https://localhost/mgmt/tm/security/dos/profile/~Common' \
+              '~fake_dos/dos-network/fake_app'
+        assert r1.name == 'fake_app'
+        assert r1.selfLink.startswith(URI)
+        assert not hasattr(r1, 'networkAttackVector')
+        r1.networkAttackVector = ATCK
+        r1.update()
+        assert hasattr(r1, 'networkAttackVector')
+        r2 = dos_profile.dos_networks.dos_network.load(name='fake_app')
+        assert r1.name == r2.name
+        assert r1.selfLink == r2.selfLink
+        assert hasattr(r2, 'networkAttackVector')
+        assert r1.networkAttackVector == r2.networkAttackVector
+
+    def test_dosnet_subcollection(self, dos_profile):
+        r1 = dos_profile.dos_networks.dos_network.create(name='fake_app')
+        URI = 'https://localhost/mgmt/tm/security/dos/profile/~Common' \
+              '~fake_dos/dos-network/fake_app'
+        assert r1.name == 'fake_app'
+        assert r1.selfLink.startswith(URI)
+
+        rc = dos_profile.dos_networks.get_collection()
+        assert isinstance(rc, list)
+        assert len(rc)
+        assert isinstance(rc[0], Dos_Network)

--- a/f5/bigip/tm/security/test/unit/test_dos.py
+++ b/f5/bigip/tm/security/test/unit/test_dos.py
@@ -19,6 +19,8 @@ import pytest
 from f5.bigip import ManagementRoot
 from f5.bigip.tm.security.dos import Application
 from f5.bigip.tm.security.dos import Applications
+from f5.bigip.tm.security.dos import Dos_Network
+from f5.bigip.tm.security.dos import Dos_Networks
 from f5.bigip.tm.security.dos import Profile
 from f5.sdk_exception import MissingRequiredCreationParameter
 
@@ -70,7 +72,30 @@ class TestApplicationSubcollection(object):
         r2 = pc2.application
         assert r1 is not r2
 
-    def test_member_create_no_args_v11(self, fakeicontrolsession):
+    def test_app_create_no_args_v11(self, fakeicontrolsession):
         pc = Applications(Makeprofile(fakeicontrolsession))
         with pytest.raises(MissingRequiredCreationParameter):
             pc.application.create()
+
+
+class TestDosNetworksSubcollection(object):
+    def test_dosnet_subcollection(self, fakeicontrolsession):
+        pc = Dos_Networks(Makeprofile(fakeicontrolsession))
+        kind = 'tm:security:dos:profile:dos-network:dos-networkstate'
+        test_meta = pc._meta_data['attribute_registry']
+        test_meta2 = pc._meta_data['allowed_lazy_attributes']
+        assert isinstance(pc, Dos_Networks)
+        assert kind in list(iterkeys(test_meta))
+        assert Dos_Network in test_meta2
+
+    def test_dosnet_create(self, fakeicontrolsession):
+        pc = Dos_Networks(Makeprofile(fakeicontrolsession))
+        pc2 = Dos_Networks(Makeprofile(fakeicontrolsession))
+        r1 = pc.dos_network
+        r2 = pc2.dos_network
+        assert r1 is not r2
+
+    def test_dosnet_create_no_args_v11(self, fakeicontrolsession):
+        pc = Dos_Networks(Makeprofile(fakeicontrolsession))
+        with pytest.raises(MissingRequiredCreationParameter):
+            pc.dos_network.create()


### PR DESCRIPTION
Problem:
AFM DDoS profiles Dos Network subcollection was missing

Analysis:
This PR adds DOS profiles Dos Network subcollection endpoint.  Custom load and exists method had to be implemented due to a known bug in 11.6.0 where non existing objects would still return when called by a direct link

Tests:
Functional
Unit
Flake8