### PR TITLE
Fixes #1045

### DIFF
--- a/f5/bigip/tm/security/test/functional/test_dos.py
+++ b/f5/bigip/tm/security/test/functional/test_dos.py
@@ -18,6 +18,7 @@ import pytest
 from f5.bigip.tm.security.dos import Application
 from f5.bigip.tm.security.dos import Dos_Network
 from f5.bigip.tm.security.dos import Profile
+from f5.bigip.tm.security.dos import Protocol_Dns
 from f5.sdk_exception import NonExtantApplication
 from requests.exceptions import HTTPError
 from six import iteritems
@@ -393,3 +394,134 @@ class TestDosNetwork(object):
         assert isinstance(rc, list)
         assert len(rc)
         assert isinstance(rc[0], Dos_Network)
+
+
+class TestProtocolDns(object):
+    def test_create_req_arg(self, dos_profile):
+        r1 = dos_profile.protocol_dns_s.protocol_dns.create(name='fake_app')
+        URI = 'https://localhost/mgmt/tm/security/dos/profile/~Common' \
+              '~fake_dos/protocol-dns/fake_app'
+        assert r1.name == 'fake_app'
+        assert r1.selfLink.startswith(URI)
+        assert r1.protErrAttackDetection == 'disabled'
+
+    def test_create_optional_args(self, dos_profile):
+        r1 = dos_profile.protocol_dns_s.protocol_dns.create(
+            name='fake_app', protErrAttackDetection='enabled')
+        URI = 'https://localhost/mgmt/tm/security/dos/profile/~Common' \
+              '~fake_dos/protocol-dns/fake_app'
+        assert r1.name == 'fake_app'
+        assert r1.selfLink.startswith(URI)
+        assert r1.protErrAttackDetection == 'enabled'
+
+    def test_refresh(self, dos_profile):
+        r1 = dos_profile.protocol_dns_s.protocol_dns.create(name='fake_app')
+        r2 = dos_profile.protocol_dns_s.protocol_dns.load(name='fake_app')
+        assert r1.name == r2.name
+        assert r1.selfLink == r2.selfLink
+        assert r1.protErrAttackDetection == r2.protErrAttackDetection
+        r2.protErrAttackDetection = 'enabled'
+        r2.update()
+        assert r1.selfLink == r2.selfLink
+        assert r1.name == r2.name
+        assert r2.protErrAttackDetection == 'enabled'
+        assert r1.protErrAttackDetection != r2.protErrAttackDetection
+        r1.refresh()
+        assert r1.protErrAttackDetection == r2.protErrAttackDetection
+
+    def test_modify(self, dos_profile):
+        r1 = dos_profile.protocol_dns_s.protocol_dns.create(name='fake_app')
+        original_dict = copy.deepcopy(r1.__dict__)
+        itm = 'protErrAttackDetection'
+        r1.modify(protErrAttackDetection='enabled')
+        for k, v in iteritems(original_dict):
+            if k != itm:
+                original_dict[k] = r1.__dict__[k]
+            elif k == itm:
+                assert r1.__dict__[k] == 'enabled'
+
+    @pytest.mark.skipif(
+        LooseVersion(
+            pytest.config.getoption('--release')
+        ) == LooseVersion('11.6.0'),
+        reason='This test will fail on 11.6.0 due to a known bug.'
+    )
+    def test_delete(self, dos_profile):
+        r1 = dos_profile.protocol_dns_s.protocol_dns.create(name='fake_app')
+        r1.delete()
+        with pytest.raises(HTTPError) as err:
+            dos_profile.protocol_dns_s.protocol_dns.load(name='fake_app')
+        assert err.value.response.status_code == 404
+
+    @pytest.mark.skipif(
+        LooseVersion(
+            pytest.config.getoption('--release')
+        ) == LooseVersion('11.6.0'),
+        reason='This test will fail on 11.6.0 due to a known bug.'
+    )
+    def test_load_no_object(self, dos_profile):
+        with pytest.raises(HTTPError) as err:
+            dos_profile.protocol_dns_s.protocol_dns.load(name='not_exist')
+        assert err.value.response.status_code == 404
+
+    @pytest.mark.skipif(
+        LooseVersion(
+            pytest.config.getoption('--release')
+        ) != LooseVersion('11.6.0'),
+        reason='This test is for 11.6.0 TMOS only, due to a known bug.'
+    )
+    def test_delete_11_6_0(self, dos_profile):
+        r1 = dos_profile.protocol_dns_s.protocol_dns.create(name='fake_app')
+        r1.delete()
+        try:
+            dos_profile.protocol_dns_s.protocol_dns.load(name='fake_app')
+
+        except NonExtantApplication as err:
+            msg = 'The application resource named, fake_app, does not exist ' \
+                  'on the device.'
+
+            assert err.message == msg
+
+    @pytest.mark.skipif(
+        LooseVersion(
+            pytest.config.getoption('--release')
+        ) != LooseVersion('11.6.0'),
+        reason='This test is for 11.6.0 TMOS only, due to a known bug.'
+    )
+    def test_load_no_object_11_6_0(self, dos_profile):
+        try:
+            dos_profile.protocol_dns_s.protocol_dns.load(name='not_exists')
+
+        except NonExtantApplication as err:
+            msg = 'The application resource named, not_exists, ' \
+                  'does not exist on the device.'
+
+            assert err.message == msg
+
+    def test_load_and_update(self, dos_profile):
+        r1 = dos_profile.protocol_dns_s.protocol_dns.create(name='fake_app')
+        URI = 'https://localhost/mgmt/tm/security/dos/profile/~Common' \
+              '~fake_dos/protocol-dns/fake_app'
+        assert r1.name == 'fake_app'
+        assert r1.selfLink.startswith(URI)
+        assert r1.protErrAttackDetection == 'disabled'
+        r1.protErrAttackDetection = 'enabled'
+        r1.update()
+        assert r1.protErrAttackDetection == 'enabled'
+        r2 = dos_profile.protocol_dns_s.protocol_dns.load(name='fake_app')
+        assert r1.name == r2.name
+        assert r1.selfLink == r2.selfLink
+        assert r1.protErrAttackDetection == r2.protErrAttackDetection
+
+    def test_app_subcollection(self, dos_profile):
+        r1 = dos_profile.protocol_dns_s.protocol_dns.create(name='fake_app')
+        URI = 'https://localhost/mgmt/tm/security/dos/profile/~Common' \
+              '~fake_dos/protocol-dns/fake_app'
+        assert r1.name == 'fake_app'
+        assert r1.selfLink.startswith(URI)
+        assert r1.protErrAttackDetection == 'disabled'
+
+        rc = dos_profile.protocol_dns_s.get_collection()
+        assert isinstance(rc, list)
+        assert len(rc)
+        assert isinstance(rc[0], Protocol_Dns)

--- a/f5/bigip/tm/security/test/unit/test_dos.py
+++ b/f5/bigip/tm/security/test/unit/test_dos.py
@@ -22,6 +22,9 @@ from f5.bigip.tm.security.dos import Applications
 from f5.bigip.tm.security.dos import Dos_Network
 from f5.bigip.tm.security.dos import Dos_Networks
 from f5.bigip.tm.security.dos import Profile
+from f5.bigip.tm.security.dos import Protocol_Dns
+from f5.bigip.tm.security.dos import Protocol_Dns_s
+
 from f5.sdk_exception import MissingRequiredCreationParameter
 
 from six import iterkeys
@@ -99,3 +102,26 @@ class TestDosNetworksSubcollection(object):
         pc = Dos_Networks(Makeprofile(fakeicontrolsession))
         with pytest.raises(MissingRequiredCreationParameter):
             pc.dos_network.create()
+
+
+class TestProtocolDnsSubcollection(object):
+    def test_dns_subcollection(self, fakeicontrolsession):
+        pc = Protocol_Dns_s(Makeprofile(fakeicontrolsession))
+        kind = 'tm:security:dos:profile:protocol-dns:protocol-dnsstate'
+        test_meta = pc._meta_data['attribute_registry']
+        test_meta2 = pc._meta_data['allowed_lazy_attributes']
+        assert isinstance(pc, Protocol_Dns_s)
+        assert kind in list(iterkeys(test_meta))
+        assert Protocol_Dns in test_meta2
+
+    def test_dns_create(self, fakeicontrolsession):
+        pc = Protocol_Dns_s(Makeprofile(fakeicontrolsession))
+        pc2 = Protocol_Dns_s(Makeprofile(fakeicontrolsession))
+        r1 = pc.protocol_dns
+        r2 = pc2.protocol_dns
+        assert r1 is not r2
+
+    def test_dns_create_no_args_v11(self, fakeicontrolsession):
+        pc = Protocol_Dns_s(Makeprofile(fakeicontrolsession))
+        with pytest.raises(MissingRequiredCreationParameter):
+            pc.protocol_dns.create()


### PR DESCRIPTION
Problem:
AFM DDoS profiles Protocol DNS subcollection was missing

Analysis:
This PR adds DOS profiles Protocol DNS subcollection endpoint.  Custom load and exists method had to be implemented due to a known bug in 11.6.0 where non existing objects would still return when called by a direct link

Tests:
Functional
Unit
Flake8