### PR TITLE
Fixes #1047

### DIFF
--- a/f5/bigip/tm/security/dos.py
+++ b/f5/bigip/tm/security/dos.py
@@ -69,7 +69,9 @@ class Profile(Resource):
              'tm:security:dos:profile:dos-network:dos-networkcollectionstate':
                  Dos_Networks,
              'tm:security:dos:profile:protocol-dns:'
-             'protocol-dnscollectionstate': Protocol_Dns_s}
+             'protocol-dnscollectionstate': Protocol_Dns_s,
+             'tm:security:dos:profile:protocol-sip:protocol'
+             '-sipcollectionstate': Protocol_Sips}
 
 
 class Applications(Collection):
@@ -235,6 +237,63 @@ class Protocol_Dns(Resource, CheckExistenceMixin):
             return self._exists_11_6(**kwargs)
         else:
             return super(Protocol_Dns, self)._load(**kwargs)
+
+    def _exists_11_6(self, **kwargs):
+        """Check rule existence on device."""
+
+        return self._check_existence_by_collection(
+            self._meta_data['container'], kwargs['name'])
+
+
+class Protocol_Sips(Collection):
+    """BIG-IP® AFM Protocol Sip sub-collection"""
+    def __init__(self, profile):
+        super(Protocol_Sips, self).__init__(profile)
+        self._meta_data['required_json_kind'] = \
+            'tm:security:dos:profile:protocol-sip:protocol-sipcollectionstate'
+        self._meta_data['allowed_lazy_attributes'] = [Protocol_Sip]
+        self._meta_data['attribute_registry'] = \
+            {'tm:security:dos:profile:protocol-sip:protocol-sipstate':
+                Protocol_Sip}
+
+
+class Protocol_Sip(Resource, CheckExistenceMixin):
+    """BIG-IP® AFM Protocol Sip resource"""
+    def __init__(self, protocol_sips):
+        super(Protocol_Sip, self).__init__(protocol_sips)
+        self._meta_data['required_json_kind'] = \
+            'tm:security:dos:profile:protocol-sip:protocol-sipstate'
+        self.tmos_ver = self._meta_data['bigip']._meta_data['tmos_version']
+
+    def load(self, **kwargs):
+        """Custom load method to address issue in 11.6.0 Final,
+
+        where non existing objects would be True.
+        """
+        if LooseVersion(self.tmos_ver) == LooseVersion('11.6.0'):
+            return self._load_11_6(**kwargs)
+        else:
+            return super(Protocol_Sip, self)._load(**kwargs)
+
+    def _load_11_6(self, **kwargs):
+        """Must check if rule actually exists before proceeding with load."""
+        if self._check_existence_by_collection(self._meta_data['container'],
+                                               kwargs['name']):
+            return super(Protocol_Sip, self)._load(**kwargs)
+        msg = 'The application resource named, {}, does not exist on the ' \
+              'device.'.format(kwargs['name'])
+        raise NonExtantApplication(msg)
+
+    def exists(self, **kwargs):
+        """Some objects when deleted still return when called by their
+
+        direct URI, this is a known issue in 11.6.0.
+        """
+
+        if LooseVersion(self.tmos_ver) == LooseVersion('11.6.0'):
+            return self._exists_11_6(**kwargs)
+        else:
+            return super(Protocol_Sip, self)._load(**kwargs)
 
     def _exists_11_6(self, **kwargs):
         """Check rule existence on device."""

--- a/f5/bigip/tm/security/test/unit/test_dos.py
+++ b/f5/bigip/tm/security/test/unit/test_dos.py
@@ -24,6 +24,8 @@ from f5.bigip.tm.security.dos import Dos_Networks
 from f5.bigip.tm.security.dos import Profile
 from f5.bigip.tm.security.dos import Protocol_Dns
 from f5.bigip.tm.security.dos import Protocol_Dns_s
+from f5.bigip.tm.security.dos import Protocol_Sip
+from f5.bigip.tm.security.dos import Protocol_Sips
 
 from f5.sdk_exception import MissingRequiredCreationParameter
 
@@ -125,3 +127,26 @@ class TestProtocolDnsSubcollection(object):
         pc = Protocol_Dns_s(Makeprofile(fakeicontrolsession))
         with pytest.raises(MissingRequiredCreationParameter):
             pc.protocol_dns.create()
+
+
+class TestProtocolSipSubcollection(object):
+    def test_sip_subcollection(self, fakeicontrolsession):
+        pc = Protocol_Sips(Makeprofile(fakeicontrolsession))
+        kind = 'tm:security:dos:profile:protocol-sip:protocol-sipstate'
+        test_meta = pc._meta_data['attribute_registry']
+        test_meta2 = pc._meta_data['allowed_lazy_attributes']
+        assert isinstance(pc, Protocol_Sips)
+        assert kind in list(iterkeys(test_meta))
+        assert Protocol_Sip in test_meta2
+
+    def test_sip_create(self, fakeicontrolsession):
+        pc = Protocol_Sips(Makeprofile(fakeicontrolsession))
+        pc2 = Protocol_Sips(Makeprofile(fakeicontrolsession))
+        r1 = pc.protocol_sip
+        r2 = pc2.protocol_sip
+        assert r1 is not r2
+
+    def test_sip_create_no_args_v11(self, fakeicontrolsession):
+        pc = Protocol_Sips(Makeprofile(fakeicontrolsession))
+        with pytest.raises(MissingRequiredCreationParameter):
+            pc.protocol_sip.create()


### PR DESCRIPTION
Problem:
AFM DDoS profiles Protocol Sip subcollection was missing

Analysis:
This PR adds DOS profiles Protocol Sip subcollection endpoint.  Custom load and exists method had to be implemented due to a known bug in 11.6.0 where non existing objects would still return when called by a direct link

Tests:
Functional
Unit
Flake8