### PR TITLE
GTM Listener response codes are buggy

### DIFF
--- a/f5/bigip/tm/gtm/listener.py
+++ b/f5/bigip/tm/gtm/listener.py
@@ -30,6 +30,7 @@ REST Kind
 from f5.bigip.resource import Collection
 from f5.bigip.resource import Resource
 from f5.sdk_exception import UnsupportedOperation
+from icontrol.exceptions import iControlUnexpectedHTTPError
 
 
 class Listeners(Collection):
@@ -51,6 +52,19 @@ class Listener(Resource):
             'tm:gtm:listener:profiles:profilescollectionstate':
                 Profiles_s
         }
+
+    def exists(self, **kwargs):
+        # This endpoint does not return status 404 if the GET request
+        # does not find the resource. On one installation it returned
+        # 400, and on another it returned 500
+        try:
+            result = super(Listener, self).exists(**kwargs)
+        except iControlUnexpectedHTTPError as ex:
+            if 'listener does not exist' in str(ex):
+                return False
+            else:
+                raise
+        return result
 
 
 class Profiles_s(Collection):

--- a/f5/bigip/tm/gtm/test/functional/test_listener.py
+++ b/f5/bigip/tm/gtm/test/functional/test_listener.py
@@ -145,6 +145,24 @@ class TestLoad(object):
         assert r2.description == 'NewListener'
 
 
+class TestExists(object):
+    def test_not_exists(self, request, mgmt_root):
+        result = mgmt_root.tm.gtm.listeners.listener.exists(
+            name='my_listener', partition='Common'
+        )
+        assert result is False
+
+    def test_exists(self, request, mgmt_root):
+        r1 = setup_basic_test(
+            request, mgmt_root, 'fake_listener', '10.10.10.10', 'Common'
+        )
+        result = mgmt_root.tm.gtm.listeners.listener.exists(
+            name='fake_listener', partition='Common'
+        )
+        assert r1.name == 'fake_listener'
+        assert result is True
+
+
 class TestUpdate(object):
     def test_update(self, request, mgmt_root):
         r1 = setup_basic_test(request, mgmt_root, 'fake_listener',


### PR DESCRIPTION
Issues:
Fixes #1057

Problem:
It appears that in 11.6.0 the return code for doing a GET on a
non-existing GTM listener would return a 500 error instead of
the expected 404.

Additionally, on 12.1.2, it appears that this problem has gone
through some revisions and the return code changed to 400.

This is still incorrect though. The response code for something
not found should be 404.

Analysis:
This patch checks for the message returned by the API when an
item is not found and returns the correct value if it does
not exist

Tests:
* functional