### PR TITLE
Fixes #987

### DIFF
--- a/f5/bigip/tm/security/firewall.py
+++ b/f5/bigip/tm/security/firewall.py
@@ -41,7 +41,8 @@ class Firewall(OrganizingCollection):
         super(Firewall, self).__init__(security)
         self._meta_data['allowed_lazy_attributes'] = [
             Address_Lists,
-            Port_Lists]
+            Port_Lists,
+            Rule_Lists]
 
 
 class Address_Lists(Collection):
@@ -101,3 +102,47 @@ class Port_List(Resource):
 
         _minimum_one_is_missing(req_set, **kwargs)
         return self._create(**kwargs)
+
+
+class Rule_Lists(Collection):
+    """BIG-IP® AFM® Rule List collection"""
+    def __init__(self, firewall):
+        super(Rule_Lists, self).__init__(firewall)
+        self._meta_data['allowed_lazy_attributes'] = [Rule_List]
+        self._meta_data['attribute_registry'] = \
+            {'tm:security:firewall:rule-list:rule-liststate':
+                Rule_List}
+
+
+class Rule_List(Resource):
+    """BIG-IP® Rule List resource"""
+    def __init__(self, rule_lists):
+        super(Rule_List, self).__init__(rule_lists)
+        self._meta_data['required_json_kind'] = \
+            'tm:security:firewall:rule-list:rule-liststate'
+        self._meta_data['required_creation_parameters'].update(('partition',))
+        self._meta_data['required_load_parameters'].update(('partition',))
+        self._meta_data['allowed_lazy_attributes'] = [Rules_s]
+        self._meta_data['attribute_registry'] = \
+            {'tm:security:firewall:rule-list:rules:rulescollectionstate':
+                Rules_s}
+
+
+class Rules_s(Collection):
+    """BIG-IP® AFM® Rules sub-collection"""
+    def __init__(self, rule_list):
+        super(Rules_s, self).__init__(rule_list)
+        self._meta_data['required_json_kind'] = \
+            'tm:security:firewall:rule-list:rules:rulescollectionstate'
+        self._meta_data['allowed_lazy_attributes'] = [Rule]
+        self._meta_data['attribute_registry'] = \
+            {'tm:security:firewall:rule-list:rules:rulesstate':
+                Rule}
+
+
+class Rule(Resource):
+    """BIG-IP® AFM® Rule resource"""
+    def __init__(self, rules_s):
+        super(Rule, self).__init__(rules_s)
+        self._meta_data['required_json_kind'] = \
+            'tm:security:firewall:rule-list:rules:rulesstate'

--- a/f5/bigip/tm/security/firewall.py
+++ b/f5/bigip/tm/security/firewall.py
@@ -26,10 +26,12 @@ GUI Path
 REST Kind
     ``tm:security:firewall:*``
 """
+from f5.bigip.mixins import CheckExistenceMixin
 from f5.bigip.resource import _minimum_one_is_missing
 from f5.bigip.resource import Collection
 from f5.bigip.resource import OrganizingCollection
 from f5.bigip.resource import Resource
+from f5.sdk_exception import NonExtantFirewallRule
 
 from distutils.version import LooseVersion
 
@@ -129,7 +131,7 @@ class Rule_List(Resource):
 
 
 class Rules_s(Collection):
-    """BIG-IP® AFM® Rules sub-collection"""
+    """BIG-IP® AFM® Rules sub-collection."""
     def __init__(self, rule_list):
         super(Rules_s, self).__init__(rule_list)
         self._meta_data['required_json_kind'] = \
@@ -140,9 +142,85 @@ class Rules_s(Collection):
                 Rule}
 
 
-class Rule(Resource):
-    """BIG-IP® AFM® Rule resource"""
+class Rule(Resource, CheckExistenceMixin):
+    """BIG-IP® AFM® Rule resource.
+
+
+    NOTE:: The 'place-before' and 'place-after' attribute are
+        mandatory but cannot be present with one another. Those attributes
+        will not be visible when the class is created, they exist for the
+        sole purpose of rule ordering in the BIGIP. The ordering of the
+        rules corresponds to the index in the 'items' of the Rules_s
+        sub-collection.
+    """
     def __init__(self, rules_s):
         super(Rule, self).__init__(rules_s)
         self._meta_data['required_json_kind'] = \
             'tm:security:firewall:rule-list:rules:rulesstate'
+        self._meta_data['required_creation_parameters'].update(('action',))
+        self._meta_data['exclusive_attributes'].append(
+            ('place-after', 'place-before'))
+        self.tmos_ver = self._meta_data['bigip']._meta_data['tmos_version']
+
+    def create(self, **kwargs):
+        """Custom create method to accommodate different endpoint behavior.
+
+        WARNING: Some parameters are hyphenated therefore the function
+                 will need to utilize variable keyword argument syntax.
+                 eg.
+
+                 param_set ={'name': 'rule', 'place-before': 'first',
+                 'action': 'reject'}
+
+                 rule_lst.rules_s.rule.create(**param_set)
+        """
+        self._check_create_parameters(**kwargs)
+        req_set = {'place-before', 'place-after'}
+        _minimum_one_is_missing(req_set, **kwargs)
+        return self._create(**kwargs)
+
+    def update(self, **kwargs):
+        """We need to implement the custom exclusive parameter check."""
+        self._check_exclusive_parameters(**kwargs)
+        return super(Rule, self)._update(**kwargs)
+
+    def modify(self, **kwargs):
+        """We need to implement the custom exclusive parameter check."""
+        self._check_exclusive_parameters(**kwargs)
+        return super(Rule, self)._modify(**kwargs)
+
+    def load(self, **kwargs):
+        """Custom load method to address issue in 11.6.0 Final,
+
+        where non existing objects would be True.
+        """
+        if LooseVersion(self.tmos_ver) == LooseVersion('11.6.0'):
+            return self._load_11_6(**kwargs)
+        else:
+            return super(Rule, self)._load(**kwargs)
+
+    def _load_11_6(self, **kwargs):
+        """Must check if rule actually exists before proceeding with load."""
+        if self._check_existence_by_collection(self._meta_data['container'],
+                                               kwargs['name']):
+            return super(Rule, self)._load(**kwargs)
+        msg = 'The application resource named, {}, does not exist on the ' \
+              'device.'.format(kwargs['name'])
+        raise NonExtantFirewallRule(msg)
+
+    def exists(self, **kwargs):
+        """Some objects when deleted still return when called by their
+
+        direct URI, this is a known issue in 11.6.0.
+        """
+
+        if LooseVersion(self.tmos_ver) == LooseVersion('11.6.0'):
+            return self._exists_11_6(**kwargs)
+        else:
+            return super(Rule, self)._load(**kwargs)
+
+    def _exists_11_6(self, **kwargs):
+        """Check rule existence on device."""
+
+        return self._check_existence_by_collection(
+            self._meta_data['container'], kwargs['name'])

--- a/f5/bigip/tm/security/test/functional/test_firewall.py
+++ b/f5/bigip/tm/security/test/functional/test_firewall.py
@@ -18,8 +18,10 @@ import pytest
 from f5.bigip.resource import MissingRequiredCreationParameter
 from f5.bigip.tm.security.firewall import Address_List
 from f5.bigip.tm.security.firewall import Port_List
+from f5.bigip.tm.security.firewall import Rule
 from f5.bigip.tm.security.firewall import Rule_List
-from f5.bigip.tm.security.firewall import Rules
+from f5.sdk_exception import ExclusiveAttributesPresent
+from f5.sdk_exception import NonExtantFirewallRule
 
 from requests.exceptions import HTTPError
 from six import iteritems
@@ -50,6 +52,15 @@ def portlst(mgmt_root):
 def rulelst(mgmt_root):
     r1 = mgmt_root.tm.security.firewall.rule_lists.rule_list.create(
         name='fake_rule_list', partition='Common')
+    yield r1
+    r1.delete()
+
+
+@pytest.fixture(scope='function')
+def rule(rulelst):
+    param_set = {'name': 'fake_rule', 'place-after': 'first',
+                 'action': 'reject'}
+    r1 = rulelst.rules_s.rule.create(**param_set)
     yield r1
     r1.delete()
 
@@ -363,3 +374,163 @@ class TestRuleList(object):
         assert isinstance(rc, list)
         assert len(rc)
         assert isinstance(rc[0], Rule_List)
+
+
+class TestRules(object):
+    def test_mutually_exclusive_raises(self, rulelst):
+        param_set = {'name': 'fake_rule', 'place-after': 'first',
+                     'action': 'reject', 'place-before': 'last'}
+        ERR = 'Mutually exclusive arguments submitted. ' \
+              'The following arguments cannot be set together: ' \
+              '"place-after, place-before".'
+        with pytest.raises(ExclusiveAttributesPresent) as err:
+            rulelst.rules_s.rule.create(**param_set)
+        assert err.value.message == ERR
+
+    def test_mandatory_attribute_missing(self, rulelst):
+        param_set = {'name': 'fake_rule', 'action': 'reject'}
+        ERR = "This resource requires at least one of the mandatory " \
+              "additional parameters to be provided: " \
+              "set(['place-before', 'place-after'])"
+        with pytest.raises(MissingRequiredCreationParameter) as err:
+            rulelst.rules_s.rule.create(**param_set)
+        assert err.value.message == ERR
+
+    def test_create_req_arg(self, rule):
+        r1 = rule
+        URI = 'https://localhost/mgmt/tm/security/' \
+              'firewall/rule-list/~Common~fake_rule_list/rules/fake_rule'
+        assert r1.name == 'fake_rule'
+        assert r1.selfLink.startswith(URI)
+        assert not hasattr(r1, 'description')
+
+    def test_create_optional_args(self, rulelst):
+        param_set = {'name': 'fake_rule', 'place-after': 'first',
+                     'action': 'reject', 'description': DESC}
+        r1 = rulelst.rules_s.rule.create(**param_set)
+        URI = 'https://localhost/mgmt/tm/security/' \
+              'firewall/rule-list/~Common~fake_rule_list/rules/fake_rule'
+        assert r1.name == 'fake_rule'
+        assert r1.selfLink.startswith(URI)
+        assert hasattr(r1, 'description')
+        assert r1.description == DESC
+
+    def test_refresh(self, rulelst, rule):
+        r1 = rule
+        r2 = rulelst.rules_s.rule.load(name='fake_rule')
+        assert r1.name == r2.name
+        assert r1.selfLink == r2.selfLink
+        assert r1.kind == r2.kind
+        assert not hasattr(r1, 'description')
+        assert not hasattr(r2, 'description')
+        r2.modify(description=DESC)
+        assert r1.selfLink == r2.selfLink
+        assert r1.name == r2.name
+        assert r1.kind == r2.kind
+        assert hasattr(r2, 'description')
+        assert r2.description == DESC
+        r1.refresh()
+        assert r1.description == r2.description
+
+    def test_modify(self, rule):
+        r1 = rule
+        original_dict = copy.deepcopy(r1.__dict__)
+        itm = 'description'
+        r1.modify(description=DESC)
+        for k, v in iteritems(original_dict):
+            if k != itm:
+                original_dict[k] = r1.__dict__[k]
+            elif k == itm:
+                assert r1.__dict__[k] == DESC
+
+    @pytest.mark.skipif(
+        LooseVersion(
+            pytest.config.getoption('--release')
+        ) == LooseVersion('11.6.0'),
+        reason='This test will fail on 11.6.0 due to a known bug.'
+    )
+    def test_delete(self, rulelst):
+        param_set = {'name': 'delete_me', 'place-after': 'first',
+                     'action': 'reject'}
+        r1 = rulelst.rules_s.rule.create(**param_set)
+        r1.delete()
+        with pytest.raises(HTTPError) as err:
+            rulelst.rules_s.rule.load(name='delete_me')
+        assert err.value.response.status_code == 404
+
+    @pytest.mark.skipif(
+        LooseVersion(
+            pytest.config.getoption('--release')
+        ) == LooseVersion('11.6.0'),
+        reason='This test will fail on 11.6.0 due to a known bug.'
+    )
+    def test_load_no_object(self, rulelst):
+        with pytest.raises(HTTPError) as err:
+            rulelst.rules_s.rule.load(name='not_exist')
+        assert err.value.response.status_code == 404
+
+    @pytest.mark.skipif(
+        LooseVersion(
+            pytest.config.getoption('--release')
+        ) != LooseVersion('11.6.0'),
+        reason='This test is for 11.6.0 TMOS only, due to a known bug.'
+    )
+    def test_delete_11_6_0(self, rulelst):
+        param_set = {'name': 'delete_me', 'place-after': 'first',
+                     'action': 'reject'}
+        r1 = rulelst.rules_s.rule.create(**param_set)
+        r1.delete()
+        try:
+            rulelst.rules_s.rule.load(name='delete_me')
+
+        except NonExtantFirewallRule as err:
+            msg = 'The application resource named, delete_me, ' \
+                  'does not exist on the device.'
+
+            assert err.message == msg
+
+    @pytest.mark.skipif(
+        LooseVersion(
+            pytest.config.getoption('--release')
+        ) != LooseVersion('11.6.0'),
+        reason='This test is for 11.6.0 TMOS only, due to a known bug.'
+    )
+    def test_load_no_object_11_6_0(self, rulelst):
+        try:
+            rulelst.rules_s.rule.load(name='not_exist')
+
+        except NonExtantFirewallRule as err:
+            msg = 'The application resource named, not_exist, ' \
+                  'does not exist on the device.'
+
+            assert err.message == msg
+
+    def test_load_and_update(self, rulelst, rule):
+        r1 = rule
+        URI = 'https://localhost/mgmt/tm/security/' \
+              'firewall/rule-list/~Common~fake_rule_list/rules/fake_rule'
+        assert r1.name == 'fake_rule'
+        assert r1.selfLink.startswith(URI)
+        assert not hasattr(r1, 'description')
+        r1.description = DESC
+        r1.update()
+        assert hasattr(r1, 'description')
+        assert r1.description == DESC
+        r2 = rulelst.rules_s.rule.load(name='fake_rule')
+        assert r1.name == r2.name
+        assert r1.selfLink == r2.selfLink
+        assert hasattr(r2, 'description')
+        assert r1.description == r2.description
+
+    def test_rules_subcollection(self, rulelst, rule):
+        r1 = rule
+        URI = 'https://localhost/mgmt/tm/security/' \
+              'firewall/rule-list/~Common~fake_rule_list/rules/fake_rule'
+        assert r1.name == 'fake_rule'
+        assert r1.selfLink.startswith(URI)
+        assert not hasattr(r1, 'description')
+
+        rc = rulelst.rules_s.get_collection()
+        assert isinstance(rc, list)
+        assert len(rc)
+        assert isinstance(rc[0], Rule)

--- a/f5/bigip/tm/security/test/unit/test_firewall.py
+++ b/f5/bigip/tm/security/test/unit/test_firewall.py
@@ -19,6 +19,7 @@ import pytest
 from f5.bigip import ManagementRoot
 from f5.bigip.tm.security.firewall import Address_List
 from f5.bigip.tm.security.firewall import Port_List
+from f5.bigip.tm.security.firewall import Rule_List
 
 from f5.sdk_exception import MissingRequiredCreationParameter
 
@@ -35,6 +36,13 @@ def FakePortLst():
     fake_col = mock.MagicMock()
     fake_portlst = Port_List(fake_col)
     return fake_portlst
+
+
+@pytest.fixture
+def FakeRuleLst():
+    fake_col = mock.MagicMock()
+    fake_rulelst = Rule_List(fake_col)
+    return fake_rulelst
 
 
 class TestAddressList(object):
@@ -71,3 +79,15 @@ class TestPortList(object):
         with pytest.raises(MissingRequiredCreationParameter):
             b.tm.security.firewall.port_lists.port_list.create(
                 name='destined_to_fail', partition='Fake')
+
+
+class TestRuleList(object):
+    def test_create_two(self, fakeicontrolsession):
+        b = ManagementRoot('192.168.1.1', 'admin', 'admin')
+        r1 = b.tm.security.firewall.rule_lists.rule_list
+        r2 = b.tm.security.firewall.rule_lists.rule_list
+        assert r1 is not r2
+
+    def test_create_no_args(self, FakeRuleLst):
+        with pytest.raises(MissingRequiredCreationParameter):
+            FakeRuleLst.create()

--- a/f5/bigip/tm/security/test/unit/test_firewall.py
+++ b/f5/bigip/tm/security/test/unit/test_firewall.py
@@ -19,9 +19,12 @@ import pytest
 from f5.bigip import ManagementRoot
 from f5.bigip.tm.security.firewall import Address_List
 from f5.bigip.tm.security.firewall import Port_List
+from f5.bigip.tm.security.firewall import Rule
 from f5.bigip.tm.security.firewall import Rule_List
-
+from f5.bigip.tm.security.firewall import Rules_s
 from f5.sdk_exception import MissingRequiredCreationParameter
+
+from six import iterkeys
 
 
 @pytest.fixture
@@ -43,6 +46,15 @@ def FakeRuleLst():
     fake_col = mock.MagicMock()
     fake_rulelst = Rule_List(fake_col)
     return fake_rulelst
+
+
+def Makerulelist(fakeicontrolsession):
+    b = ManagementRoot('192.168.1.1', 'admin', 'admin')
+    p = b.tm.security.firewall.rule_lists.rule_list
+    p._meta_data['uri'] = \
+        'https://192.168.1.1:443/mgmt/tm/security/firewall/rule-list/~Common' \
+        '~testrulelst/'
+    return p
 
 
 class TestAddressList(object):
@@ -91,3 +103,26 @@ class TestRuleList(object):
     def test_create_no_args(self, FakeRuleLst):
         with pytest.raises(MissingRequiredCreationParameter):
             FakeRuleLst.create()
+
+
+class TestRulesSubcollection(object):
+    def test_rule_subcollection(self, fakeicontrolsession):
+        pc = Rules_s(Makerulelist(fakeicontrolsession))
+        kind = 'tm:security:firewall:rule-list:rules:rulesstate'
+        test_meta = pc._meta_data['attribute_registry']
+        test_meta2 = pc._meta_data['allowed_lazy_attributes']
+        assert isinstance(pc, Rules_s)
+        assert kind in list(iterkeys(test_meta))
+        assert Rule in test_meta2
+
+    def test_app_create(self, fakeicontrolsession):
+        pc = Rules_s(Makerulelist(fakeicontrolsession))
+        pc2 = Rules_s(Makerulelist(fakeicontrolsession))
+        r1 = pc.rule
+        r2 = pc2.rule
+        assert r1 is not r2
+
+    def test_app_create_no_args_v11(self, fakeicontrolsession):
+        pc = Rules_s(Makerulelist(fakeicontrolsession))
+        with pytest.raises(MissingRequiredCreationParameter):
+            pc.rule.create()

--- a/f5/sdk_exception.py
+++ b/f5/sdk_exception.py
@@ -144,11 +144,6 @@ class NodeStateModifyUnsupported(F5SDKError):
     pass
 
 
-class NonExtantVirtualPolicy(F5SDKError):
-    """Raise if the policy does not exist on the device."""
-    pass
-
-
 class NonExtantApplication(F5SDKError):
     """Raise if the dos profile application sub-collection
 
@@ -159,6 +154,16 @@ class NonExtantApplication(F5SDKError):
 
 class NonExtantPolicyRule(F5SDKError):
     """Raise if a rule does not exist on the device."""
+    pass
+
+
+class NonExtantFirewallRule(F5SDKError):
+    """Raise if the policy does not exist on the device."""
+    pass
+
+
+class NonExtantVirtualPolicy(F5SDKError):
+    """Raise if the policy does not exist on the device."""
     pass
 
 


### PR DESCRIPTION
Problem:
AFM Firewall Rule Lists collection was missing

Analysis:
This PR adds AFM Firewall Rule Lists collection endpoint and its sub-collection. Due to a known bug in 11.6.0 load() and exists() methods had to be modified.

Tests:
Functional
Unit
Flake8