### PR TITLE
Fixes #985

### DIFF
--- a/f5/bigip/tm/ltm/node.py
+++ b/f5/bigip/tm/ltm/node.py
@@ -74,11 +74,11 @@ class Node(Resource):
     def _check_node_parameters(self, **kwargs):
         """See discussion in issue #840."""
         if 'fqdn' in kwargs:
-            kwargs['fqdn'].pop('autopopulate')
-            kwargs['fqdn'].pop('addressFamily')
+            kwargs['fqdn'].pop('autopopulate', '')
+            kwargs['fqdn'].pop('addressFamily', '')
         if 'fqdn' in self.__dict__:
-            self.__dict__['fqdn'].pop('autopopulate')
-            self.__dict__['fqdn'].pop('addressFamily')
+            self.__dict__['fqdn'].pop('autopopulate', '')
+            self.__dict__['fqdn'].pop('addressFamily', '')
         if 'state' in kwargs:
             if kwargs['state'] != 'user-up' and kwargs['state'] != \
                     'user-down':
@@ -95,6 +95,9 @@ class Node(Resource):
             if self.__dict__['session'] != 'user-enabled' and \
                     self.__dict__['session'] != 'user-disabled':
                 self.__dict__.pop('session')
+        # Until we implement sanity checks for __dict__ this needs to stay here
+        self.__dict__.pop('ephemeral', '')
+        self.__dict__.pop('address', '')
         return kwargs
 
     def _modify(self, **patch):

--- a/f5/sdk_exception.py
+++ b/f5/sdk_exception.py
@@ -109,8 +109,8 @@ class LazyAttributesRequired(F5SDKError):
     pass
 
 
-class MemberStateAlwaysRequiredOnUpdate(F5SDKError):
-    """Raise this is a pool member state is not passed on update."""
+class MemberStateModifyUnsupported(F5SDKError):
+    """Modify of node with state=unchecked is unsupported."""
     pass
 
 


### PR DESCRIPTION
Problem:
Pool Members were suffering from the same issue with state/session setting, as described in #840

Analysis:
This PR brings the user experience of pool members in line with that of nodes. Minor adjustments made to node.py to add some defaults to prevent key errors raising during attribute pop

Tests:
Functional
Flake8