### PR TITLE
Adds cm device mv command

### DIFF
--- a/f5/bigip/tm/cm/device.py
+++ b/f5/bigip/tm/cm/device.py
@@ -27,11 +27,12 @@ REST Kind
 """
 
 
+from f5.bigip.mixins import CommandExecutionMixin
 from f5.bigip.resource import Collection
 from f5.bigip.resource import Resource
 
 
-class Devices(Collection):
+class Devices(Collection, CommandExecutionMixin):
     """BIG-IP® cluster devices collection.
 
     """
@@ -40,6 +41,7 @@ class Devices(Collection):
         self._meta_data['allowed_lazy_attributes'] = [Device]
         self._meta_data['attribute_registry'] =\
             {'tm:cm:device:devicestate': Device}
+        self._meta_data['allowed_commands'].append('mv')
 
 
 class Device(Resource):

--- a/f5/bigip/tm/cm/test/functional/test_device.py
+++ b/f5/bigip/tm/cm/test/functional/test_device.py
@@ -64,3 +64,34 @@ class TestDevice(object):
         d2.refresh()
         assert d2.description == TEST_DESCR
         assert d1.generation == d2.generation
+
+
+class TestDeviceMoving(object):
+    def test_device_mv(self, request, mgmt_root):
+        d1 = mgmt_root.tm.cm.devices.device.load(
+            name='bigip1', partition='Common'
+        )
+
+        # Move it
+        mgmt_root.tm.cm.devices.exec_cmd(
+            'mv', name='bigip1', target='bigip2'
+        )
+
+        # Load
+        d2 = mgmt_root.tm.cm.devices.device.load(
+            name='bigip2', partition=d1.partition
+        )
+        assert d1.name != d2.name
+        assert d1.generation == d2.generation
+        assert d1.hostname == 'bigip1'
+        assert d2.hostname == 'bigip1'
+
+        # Refresh
+        d2.refresh()
+        assert d1.name != d2.name
+        assert d1.generation == d2.generation
+
+        # Move it back
+        mgmt_root.tm.cm.devices.exec_cmd(
+            'mv', name='bigip2', target='bigip1'
+        )


### PR DESCRIPTION
Issues:
Fixes #1067

Problem:
I hope this isn't one of those private APIs, but the BD team uses
this for some of their demos, and the bigip_hostname uses this
to ensure the hostname matches the cm device name. It was not part
of the SDK though

Analysis:
This patch adds it