### PR TITLE
Convert properties to attrs

### DIFF
--- a/f5/bigip/resource.py
+++ b/f5/bigip/resource.py
@@ -710,7 +710,7 @@ class ResourceBase(PathElement, ToDictMixin):
         return config_dict
 
     @property
-    def properties(self):
+    def attrs(self):
         no_meta_dict = {k: v for k, v in self.__dict__.iteritems()
                         if k != '_meta_data'}
         return no_meta_dict

--- a/f5/bigip/test/unit/test_resource.py
+++ b/f5/bigip/test/unit/test_resource.py
@@ -799,7 +799,7 @@ def test_ResourceBase():
     assert str(delete_EIO.value) == "Only Resources support 'delete'."
 
 
-def test_resource_base_properties():
+def test_resource_base_attrs():
     MockBigIP = mock.MagicMock(name='MockBigIP')
     MockBigIP._meta_data = {'uri': 'https://TESTDOMAIN/mgmt/tm/',
                             'bigip': MockBigIP,
@@ -811,7 +811,7 @@ def test_resource_base_properties():
     assert hasattr(rb, '_meta_data')
     assert hasattr(rb, 'item')
     assert hasattr(rb, 'item2')
-    no_meta = rb.properties
+    no_meta = rb.attrs
     assert type(no_meta) is dict
     assert '_meta_data' not in no_meta.keys()
     assert no_meta['item'] == {'fake_key': 'fake_value'}


### PR DESCRIPTION
Issues:
Fixes #1069

Problem:
Properties is an attribute of some existing resources. So it needs to
not be called that. attrs is a better name

for example

```
[
  {
    "uuid": "d13074df-4f0c-4ed3-baf6-0050fe74695f",
    "deviceUri": "https://10.2.2.3:443",
    "machineId": "d13074df-4f0c-4ed3-baf6-0050fe74695f",
    "state": "ACTIVE",
    "address": "10.2.2.3",
    "httpsPort": 443,
    "hostname": "bigip1",
    "version": "12.1.2",
    "product": "BIG-IP",
    "edition": "Final",
    "build": "0.0.249",
    "restFrameworkVersion": "13.1.0-0.0.5711",
    "managementAddress": "10.0.2.15",
    "mcpDeviceName": "/Common/bigip1",
    "trustDomainGuid": "5c9e2e37-e8c4-4556-881b080027277482",
    "properties": {
      "dmaConfigPathScope": "basic",
      "isSoapProxyEnabled": true,
      "isTmshProxyEnabled": false,
      "shared:resolver:device-groups:discoverer": "f34e87f5-0494-4707-8dcc-980c7c0cdec3",
      "isRestProxyEnabled": true,
      "dmaFinished": true
    },
    "isClustered": false,
    "isVirtual": true,
    "groupName": "cm-cloud-managed-devices",
    "generation": 5,
    "lastUpdateMicros": 1489787182051700,
    "kind": "shared:resolver:device-groups:restdeviceresolverdevicestate",
    "selfLink": "https://localhost/mgmt/shared/resolver/device-groups/cm-cloud-managed-devices/devices/d13074df-4f0c-4ed3-baf6-0050fe74695f"
  },
  {
    "uuid": "f34e87f5-0494-4707-8dcc-980c7c0cdec3",
    "deviceUri": "https://10.2.2.2:443",
    "machineId": "f34e87f5-0494-4707-8dcc-980c7c0cdec3",
    "state": "ACTIVE",
    "address": "10.2.2.2",
    "httpsPort": 443,
    "hostname": "iworkflow1",
    "version": "2.1.0",
    "product": "iWorkflow",
    "edition": "Final",
    "build": "0.0.10285",
    "restFrameworkVersion": "13.1.0-0.0.5711",
    "managementAddress": "10.0.2.15",
    "mcpDeviceName": "/Common/iworkflow1",
    "trustDomainGuid": "d1a69249-a8d6-4e1a-8bcd080027b29e2d",
    "isClustered": false,
    "isVirtual": true,
    "groupName": "cm-cloud-managed-devices",
    "generation": 2,
    "lastUpdateMicros": 1489783461448004,
    "kind": "shared:resolver:device-groups:restdeviceresolverdevicestate",
    "selfLink": "https://localhost/mgmt/shared/resolver/device-groups/cm-cloud-managed-devices/devices/f34e87f5-0494-4707-8dcc-980c7c0cdec3"
  }
]

```
Analysis:
This patch changes properties property to attrs

Tests: