### PR TITLE
Change proxying to be keyword arguments of the iWorkflow ManagementRoot

### DIFF
--- a/f5/bigip/__init__.py
+++ b/f5/bigip/__init__.py
@@ -109,6 +109,8 @@ class BaseManagement(PathElement):
 
     @property
     def tmos_version(self):
+        if self._meta_data['tmos_version'] is None:
+            self._meta_data['tmos_version'] = self._get_tmos_version()
         return self._meta_data['tmos_version']
 
 


### PR DESCRIPTION
Issues:
Fixes #1082

Problem:
Prior to this patch, the usage was to get a ManagementProxy class. This
was not very intuitive though, so I've changed it to use keyword args
to the iWorkflow ManagementRoot class. Presumably the same would apply
to BIG-IQ

Analysis:
Refactors out ManagementProxy in favor of kwargs to ManagementRoot

Tests:
functional