### PR TITLE
Adds tox command to generate docs

### DIFF
--- a/devtools/bin/build-docs.sh
+++ b/devtools/bin/build-docs.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+DIR="file://$( cd "$( dirname $( dirname $( dirname "${BASH_SOURCE[0]}" )))" && pwd )/docs/_build"
+sphinx-build docs docs/_build
+echo "Open ${DIR} in your browser"

--- a/tox.ini
+++ b/tox.ini
@@ -6,6 +6,7 @@ envlist =
     unit
     flake
     coveralls
+    docs
 
 [testenv]
 basepython =
@@ -14,6 +15,7 @@ basepython =
     unit: python
     flake: python
     coveralls: python
+    docs: python
 passenv = COVERALLS_REPO_TOKEN
 deps =
     -rrequirements.test.txt
@@ -38,6 +40,7 @@ commands =
     unit: py.test -k "not /functional/" -vv --cov {posargs:.}
     flake: flake8 {posargs:.}
     coveralls: coveralls
+    docs: bash ./devtools/bin/build-docs.sh
 usedevelop = true
 
 [flake8]


### PR DESCRIPTION
Issues:
Fixes #1086

Problem:
the command to build the docs was elusive. this makes it part of tox
so that developers can use it before they submit a pr

tox -e docs

Analysis:

Tests: