### PR TITLE
Feature.add ability to redraft a traffic policy

### DIFF
--- a/f5/bigip/tm/ltm/test/functional/test_policy.py
+++ b/f5/bigip/tm/ltm/test/functional/test_policy.py
@@ -344,6 +344,22 @@ class TestPolicy(object):
         assert 'Modify operation not allowed on a published policy.' in \
             ex2.value.message
 
+    def test_policy_draft_to_publish_and_back(self, setup, request, mgmt_root):
+        pol, pc = setup_policy_test(request, mgmt_root, 'Common',
+                                    'draft-policy', subPath='Drafts')
+        assert pol.status == 'draft'
+        pol.publish()
+        assert pol.status == 'published'
+        pol.draft()
+        assert pol.status == 'draft'
+        pol.modify(
+            description='foo'
+        )
+        pol.publish()
+
+        pol2 = pc.policy.load(name='draft-policy', partition='Common')
+        assert pol2.description == 'foo'
+
 
 @pytest.mark.skipif(
     LooseVersion(

--- a/f5/sdk_exception.py
+++ b/f5/sdk_exception.py
@@ -223,6 +223,14 @@ class UtilError(F5SDKError):
     pass
 
 
+class DraftPolicyNotSupportedInTMOSVersion(F5SDKError):
+    """Raise when using Drafts in a legacy TMOS version
+
+    Raise this if handling Draft work in a Policy class that is
+    used by legacy, and current, versions of BIG-IP
+    """
+
+
 class RequiredOneOf(F5SDKError):
     """Raise this if more than one of required argument sets is provided."""
     def __init__(self, required_one_of):


### PR DESCRIPTION
Adds ability to re-draft a traffic policy
    
Issues:
Fixes #1098
    
Problem:
Policies cannot be successfully re-drafted for editing and re-publishing.
    
Analysis:
This patch adds a `draft` method that allows you to put the policy into
a draft state from where you can then edit it.
    
Tests:
functional
