### PR TITLE
The testing of non-python files was breaking tox

### DIFF
--- a/devtools/bin/create-test-list.py
+++ b/devtools/bin/create-test-list.py
@@ -52,7 +52,7 @@ def examine_python_rules(line):
 
 def examine_non_python_rules(line):
     if 'test/functional' in line:
-        return line
+        return os.path.dirname(line)
 
 
 def determine_files_to_test(product, commit):


### PR DESCRIPTION
Issues:
Fixes #<issueid>

Problem:
The testing of non-python files was breaking tox

Analysis:
non-python file's should be tested via their directory

Tests: