### PR TITLE
Fixes #1113

### DIFF
--- a/f5/bigip/tm/ltm/pool.py
+++ b/f5/bigip/tm/ltm/pool.py
@@ -52,6 +52,43 @@ class Pool(Resource):
             'tm:ltm:pool:memberscollectionstate': Members_s
         }
 
+    @staticmethod
+    def _format_monitor_parameter(param):
+        """This is a workaround for a known issue ID645289, which affects
+
+        all versions of TMOS at this time.
+        """
+        if '{' in param and '}':
+            tmp = param.strip('}').split('{')
+            monitor = ''.join(tmp).rstrip()
+            return monitor
+        else:
+            return param
+
+    def create(self, **kwargs):
+        """Custom create method to implement monitor parameter formatting."""
+        if 'monitor' in kwargs:
+            value = self._format_monitor_parameter(kwargs['monitor'])
+            kwargs['monitor'] = value
+        return super(Pool, self)._create(**kwargs)
+
+    def update(self, **kwargs):
+        """Custom update method to implement monitor parameter formatting."""
+        if 'monitor' in kwargs:
+            value = self._format_monitor_parameter(kwargs['monitor'])
+            kwargs['monitor'] = value
+        elif 'monitor' in self.__dict__:
+            value = self._format_monitor_parameter(self.__dict__['monitor'])
+            self.__dict__['monitor'] = value
+        return super(Pool, self)._update(**kwargs)
+
+    def modify(self, **patch):
+        """Custom modify method to implement monitor parameter formatting."""
+        if 'monitor' in patch:
+            value = self._format_monitor_parameter(patch['monitor'])
+            patch['monitor'] = value
+        return super(Pool, self)._modify(**patch)
+
 
 class Members_s(Collection):
     """BIG-IP® LTM pool members sub-collection"""

--- a/f5/bigip/tm/ltm/test/functional/test_pool.py
+++ b/f5/bigip/tm/ltm/test/functional/test_pool.py
@@ -281,3 +281,34 @@ class TestPool(object):
         pool1.allowNat = "yes"
         pool1.refresh()
         assert pool1.allowNat == "no"
+
+    def test_create_monitor_parameter(self, request, bigip):
+        setup_create_test(request, bigip, 'pool1', 'Common')
+        mon = 'min 1 of { /Common/http /Common/tcp }'
+        pool1 = bigip.ltm.pools.pool.create(
+            name='pool1', partition='Common', monitor=mon)
+        assert pool1.name == 'pool1'
+        assert pool1.partition == 'Common'
+        assert pool1.monitor == mon
+        assert pool1.generation and isinstance(pool1.generation, int)
+        assert pool1.fullPath == '/Common/pool1'
+        assert pool1.kind == 'tm:ltm:pool:poolstate'
+        assert pool1.selfLink.startswith(
+            'https://localhost/mgmt/tm/ltm/pool/~Common~pool1')
+
+    def test_update_monitor_parameter(self, request, bigip):
+        pool1 = setup_basic_test(request, bigip, 'pool1', 'Common')
+        mon = 'min 1 of { /Common/http /Common/tcp }'
+        pool1.monitor = mon
+        pool1.update()
+        assert pool1.monitor == mon
+        # Test kwargs
+        mon2 = 'min 2 of { /Common/http /Common/tcp }'
+        pool1.update(monitor=mon2)
+        assert pool1.monitor == mon2
+
+    def test_modify_monitor_parameter(self, request, bigip):
+        pool1 = setup_basic_test(request, bigip, 'pool1', 'Common')
+        mon = 'min 1 of { /Common/http /Common/tcp }'
+        pool1.modify(monitor=mon)
+        assert pool1.monitor == mon


### PR DESCRIPTION
Problem:
Due to a known issue monitor property of the pool would error out if x of m value was specified

Analysis:
Added workaround to update/create/modify methods so that user can still input the valid data and we transform it under the hood. This fix will be in place until the bug is resolved in TMOS

Tests:
Flake8
Unit
Functional