### PR TITLE
Issues: #1116 - Multi-step fix for RPM and DEB package validation

### DIFF
--- a/f5-sdk-dist/deb_dist/stdeb.cfg
+++ b/f5-sdk-dist/deb_dist/stdeb.cfg
@@ -1,5 +1,6 @@
 [DEFAULT]
 Depends:
-    python-f5-icontrol-rest (>=1.3.0), python-f5-icontrol-rest (<2),
-    python-six (>=1.9), python-six (<2) 
-
+     python-six (>=1.9.0), 
+    python-six (<2.0.0), 
+    python-f5-icontrol-rest (>=1.3.0), 
+    python-f5-icontrol-rest (<2.0.0), 


### PR DESCRIPTION
Fixes #1116

Problem:
This issue is a few fold:
1. RPM spec file format was not being followed properly
  * Requires: <module> <modifier> <version>, [repeat]
2. RPM was not actually installing dependencies during test
3. RPM was not failing when project package failed to install during test
4. DEB was not actually installing dependencies during test
5. DEB was not fialing when project package failed to install during test

Analysis:
1. added a check_requires() function that will add the proper formatting
  * Change performed in the build-rpm.py
2. Changed the Dependency.cmd to be handled differently with a
Dependency.install_cmd
  * Change performed in the redhat's fetch_and_install_deps.py
3. Fix was multi-fold, but all under redhat's fetch_and_install_deps.py:
  * runCommand() was changed to use subprocess.check_output
  * runCommand()'s call for rpm -i <project> now has a status check
  * a last verification against rpm -qa is performed
4. Made a Dependency._install_req to be cond. exec. by parent
  * This is always executed by F5Dependency
  * This is added to the ubuntu's fetch_and_install_deps.py
5. Again multi-fold in the ubuntu's fetch_and_install_deps.py:
  * runCommand() was changed to use subprocess.check_output
  * runCommand()'s call for dpkg -i <project> now has a status check
  * a last verification against dpkg -l is performed

Tests:
This is a test in and of itself; however, there is now an additional
ring of tests for both ubuntu and debian that assures, using its
individual packaging medium, a means to verify that the package is, in
fact, installed after the processing of the test scripts on the
associated docker container instance.

Assignee:
@pjbreaux 

Reviewers:
@richbrowne 