### PR TITLE
Fixes #1122

### DIFF
--- a/f5/bigip/tm/sys/software/__init__.py
+++ b/f5/bigip/tm/sys/software/__init__.py
@@ -28,6 +28,7 @@ REST Kind
 """
 
 from f5.bigip.resource import OrganizingCollection
+from f5.bigip.tm.sys.software.hotfix import Hotfix_s
 from f5.bigip.tm.sys.software.image import Images
 from f5.bigip.tm.sys.software.update import Update
 
@@ -36,6 +37,7 @@ class Software(OrganizingCollection):
     def __init__(self, tm):
         super(Software, self).__init__(tm)
         self._meta_data['allowed_lazy_attributes'] = [
+            Hotfix_s,
             Images,
             Update
         ]

--- a/f5/bigip/tm/sys/software/hotfix.py
+++ b/f5/bigip/tm/sys/software/hotfix.py
@@ -15,16 +15,16 @@
 # limitations under the License.
 #
 
-"""BIG-IP® System Software Image sub-module
+"""BIG-IP® System Software Hotfix sub-module
 
 REST URI
-    ``http://localhost/mgmt/tm/sys/software/image``
+    ``http://localhost/mgmt/tm/sys/software/hotfix``
 
 GUI Path
-    ``System --> Software Management --> Image List``
+    ``System --> Software Management --> Hotfix List``
 
 REST Kind
-    ``tm:sys:software:image*``
+    ``tm:sys:software:hotfix*``
 """
 
 from f5.bigip.resource import Collection
@@ -32,24 +32,24 @@ from f5.bigip.resource import Resource
 from f5.sdk_exception import UnsupportedOperation
 
 
-class Images(Collection):
-    """BIG-IP® system software image collection."""
+class Hotfix_s(Collection):
+    """BIG-IP® system software hotfix collection."""
     def __init__(self, software):
-        super(Images, self).__init__(software)
-        self._meta_data['allowed_lazy_attributes'] = [Image]
+        super(Hotfix_s, self).__init__(software)
+        self._meta_data['allowed_lazy_attributes'] = [Hotfix]
         self._meta_data['attribute_registry'] = \
-            {'tm:sys:software:image:imagestate': Image}
+            {'tm:sys:software:hotfix:hotfixstate': Hotfix}
 
 
-class Image(Resource):
-    """BIG-IP® system software image resource."""
+class Hotfix(Resource):
+    """BIG-IP® system software hotfix resource."""
     def __init__(self, images):
-        super(Image, self).__init__(images)
+        super(Hotfix, self).__init__(images)
         self._meta_data['required_json_kind'] = \
-            'tm:sys:software:image:imagestate'
+            'tm:sys:software:hotfix:hotfixstate'
 
     def create(self, **kwargs):
-        """Create is not supported for Image resource.
+        """Create is not supported for hotfix resource.
 
         :raises: UnsupportedOperation
         """
@@ -58,7 +58,7 @@ class Image(Resource):
         )
 
     def modify(self, **kwargs):
-        """Modify is not supported for Image resource.
+        """Modify is not supported for hotfix resource.
 
         :raises: UnsupportedOperation
         """
@@ -67,7 +67,7 @@ class Image(Resource):
         )
 
     def update(self, **kwargs):
-        """Update is not supported for Image resource.
+        """Update is not supported for hotfix resource.
 
         :raises: UnsupportedOperation
         """

--- a/f5/bigip/tm/sys/software/test/unit/test_hotfix.py
+++ b/f5/bigip/tm/sys/software/test/unit/test_hotfix.py
@@ -1,0 +1,45 @@
+# Copyright 2017 F5 Networks Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import mock
+import pytest
+
+
+from f5.bigip.tm.sys.software.hotfix import Hotfix
+from f5.sdk_exception import UnsupportedOperation
+
+
+@pytest.fixture
+def FakeHotfix():
+    fake_software = mock.MagicMock()
+    return Hotfix(fake_software)
+
+
+def test_create_raises(FakeHotfix):
+    with pytest.raises(UnsupportedOperation) as EIO:
+        FakeHotfix.create()
+    assert EIO.value.message == "Hotfix does not support the create method."
+
+
+def test_update_raises(FakeHotfix):
+    with pytest.raises(UnsupportedOperation) as EIO:
+        FakeHotfix.update()
+    assert EIO.value.message == "Hotfix does not support the update method."
+
+
+def test_modify_raises(FakeHotfix):
+    with pytest.raises(UnsupportedOperation) as EIO:
+        FakeHotfix.modify()
+    assert EIO.value.message == "Hotfix does not support the modify method."


### PR DESCRIPTION
Problem:
Currently there are no endpoints to volumes, images and hotfixes which are required for software installation/volume management

Analysis:
Added Hotfix Endpoint

Tests:
Flake8
Unit