### PR TITLE
Fixes #1123

### DIFF
--- a/f5/bigip/tm/sys/software/__init__.py
+++ b/f5/bigip/tm/sys/software/__init__.py
@@ -31,6 +31,7 @@ from f5.bigip.resource import OrganizingCollection
 from f5.bigip.tm.sys.software.hotfix import Hotfix_s
 from f5.bigip.tm.sys.software.image import Images
 from f5.bigip.tm.sys.software.update import Update
+from f5.bigip.tm.sys.software.volume import Volumes
 
 
 class Software(OrganizingCollection):
@@ -39,7 +40,8 @@ class Software(OrganizingCollection):
         self._meta_data['allowed_lazy_attributes'] = [
             Hotfix_s,
             Images,
-            Update
+            Update,
+            Volumes
         ]
 
     def __getattribute__(self, name):

--- a/f5/bigip/tm/sys/software/test/functional/test_hotfix.py
+++ b/f5/bigip/tm/sys/software/test/functional/test_hotfix.py
@@ -1,0 +1,46 @@
+# Copyright 2017 F5 Networks Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+
+from f5.sdk_exception import UnsupportedOperation
+import pytest
+
+
+class TestHotfix(object):
+    def test_create_raises(self, mgmt_root):
+        with pytest.raises(UnsupportedOperation):
+            mgmt_root.tm.sys.software.hotfix_s.hotfix.create()
+
+    def test_modify_raises(self, mgmt_root):
+        with pytest.raises(UnsupportedOperation):
+            mgmt_root.tm.sys.software.hotfix_s.hotfix.modify()
+
+    def test_update_raises(self, mgmt_root):
+        with pytest.raises(UnsupportedOperation):
+            mgmt_root.tm.sys.software.hotfix_s.hotfix.update()
+
+    def test_delete(self, mgmt_root):
+        # Until we are able to install ISOs in Jenkins (which will allow us to
+        # create hotfixes) we cannot test delete
+        pass
+
+    def test_load(self, mgmt_root, opt_release):
+        # Until we are able to install ISOs in Jenkins (which will allow us to
+        # create hotfixes) we cannot test load
+        pass
+
+    def test_collection(self, mgmt_root):
+        # Until we are able to install ISOs in Jenkins (which will allow us to
+        # create hotfixes) we cannot test collection
+        pass

--- a/f5/bigip/tm/sys/software/test/functional/test_image.py
+++ b/f5/bigip/tm/sys/software/test/functional/test_image.py
@@ -1,0 +1,47 @@
+# Copyright 2017 F5 Networks Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+
+
+from f5.sdk_exception import UnsupportedOperation
+import pytest
+
+
+class TestImage(object):
+    def test_create_raises(self, mgmt_root):
+        with pytest.raises(UnsupportedOperation):
+            mgmt_root.tm.sys.software.images.image.create()
+
+    def test_modify_raises(self, mgmt_root):
+        with pytest.raises(UnsupportedOperation):
+            mgmt_root.tm.sys.software.images.image.modify()
+
+    def test_update_raises(self, mgmt_root):
+        with pytest.raises(UnsupportedOperation):
+            mgmt_root.tm.sys.software.images.image.update()
+
+    def test_delete(self, mgmt_root):
+        # Until we are able to install ISOs in Jenkins (which will allow us to
+        # create images) we cannot test delete
+        pass
+
+    def test_load(self, mgmt_root, opt_release):
+        # Until we are able to install ISOs in Jenkins (which will allow us to
+        # create images) we cannot test load
+        pass
+
+    def test_collection(self, mgmt_root):
+        # Until we are able to install ISOs in Jenkins (which will allow us to
+        # create images) we cannot test collection
+        pass

--- a/f5/bigip/tm/sys/software/test/functional/test_volume.py
+++ b/f5/bigip/tm/sys/software/test/functional/test_volume.py
@@ -1,0 +1,57 @@
+# Copyright 2017 F5 Networks Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+
+
+from distutils.version import LooseVersion
+from f5.bigip.tm.sys.software.volume import Volume
+from f5.sdk_exception import UnsupportedOperation
+import pytest
+
+
+class TestVolume(object):
+    def test_create_raises(self, mgmt_root):
+        with pytest.raises(UnsupportedOperation):
+            mgmt_root.tm.sys.software.volumes.volume.create()
+
+    def test_modify_raises(self, mgmt_root):
+        with pytest.raises(UnsupportedOperation):
+            mgmt_root.tm.sys.software.volumes.volume.modify()
+
+    def test_update_raises(self, mgmt_root):
+        with pytest.raises(UnsupportedOperation):
+            mgmt_root.tm.sys.software.volumes.volume.update()
+
+    def test_delete(self, mgmt_root):
+        # Until we are able to install ISOs in Jenkins (which will allow us to
+        # create volumes) we cannot test delete
+        pass
+
+    def test_load(self, mgmt_root, opt_release):
+        r1 = mgmt_root.tm.sys.software.volumes.volume.load(name='HD1.1')
+        link = 'https://localhost/mgmt/tm/sys/software/volume/HD1.1'
+        assert r1.selfLink.startswith(link)
+        assert r1.status == 'complete'
+        assert r1.product == 'BIG-IP'
+        rc = mgmt_root.tm.sys.software.volumes.get_collection()
+        if len(rc) == 1:
+            assert rc[0].active is True
+            assert rc[0].name == 'HD1.1'
+            assert LooseVersion(rc[0].version) == LooseVersion(opt_release)
+
+    def test_collection(self, mgmt_root):
+        rc = mgmt_root.tm.sys.software.volumes.get_collection()
+        assert isinstance(rc, list)
+        assert len(rc)
+        assert isinstance(rc[0], Volume)

--- a/f5/bigip/tm/sys/software/test/unit/test_volume.py
+++ b/f5/bigip/tm/sys/software/test/unit/test_volume.py
@@ -1,0 +1,45 @@
+# Copyright 2017 F5 Networks Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import mock
+import pytest
+
+
+from f5.bigip.tm.sys.software.volume import Volume
+from f5.sdk_exception import UnsupportedOperation
+
+
+@pytest.fixture
+def FakeVolume():
+    fake_software = mock.MagicMock()
+    return Volume(fake_software)
+
+
+def test_create_raises(FakeVolume):
+    with pytest.raises(UnsupportedOperation) as EIO:
+        FakeVolume.create()
+    assert EIO.value.message == "Volume does not support the create method."
+
+
+def test_update_raises(FakeVolume):
+    with pytest.raises(UnsupportedOperation) as EIO:
+        FakeVolume.update()
+    assert EIO.value.message == "Volume does not support the update method."
+
+
+def test_modify_raises(FakeVolume):
+    with pytest.raises(UnsupportedOperation) as EIO:
+        FakeVolume.modify()
+    assert EIO.value.message == "Volume does not support the modify method."

--- a/f5/bigip/tm/sys/software/volume.py
+++ b/f5/bigip/tm/sys/software/volume.py
@@ -1,0 +1,76 @@
+# coding=utf-8
+#
+# Copyright 2017 F5 Networks Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""BIG-IP® System Software Volume sub-module
+
+REST URI
+    ``http://localhost/mgmt/tm/sys/software/volume``
+
+GUI Path
+    ``System --> Software Management --> Image List``
+
+REST Kind
+    ``tm:sys:software:volume*``
+"""
+
+from f5.bigip.resource import Collection
+from f5.bigip.resource import Resource
+from f5.sdk_exception import UnsupportedOperation
+
+
+class Volumes(Collection):
+    """BIG-IP® system software Volume collection."""
+    def __init__(self, software):
+        super(Volumes, self).__init__(software)
+        self._meta_data['allowed_lazy_attributes'] = [Volume]
+        self._meta_data['attribute_registry'] = \
+            {'tm:sys:software:volume:volumestate': Volume}
+
+
+class Volume(Resource):
+    """BIG-IP® system software Volume resource."""
+    def __init__(self, images):
+        super(Volume, self).__init__(images)
+        self._meta_data['required_json_kind'] = \
+            'tm:sys:software:volume:volumestate'
+
+    def create(self, **kwargs):
+        """Create is not supported for Volume resource.
+
+        :raises: UnsupportedOperation
+        """
+        raise UnsupportedOperation(
+            "%s does not support the create method." % self.__class__.__name__
+        )
+
+    def modify(self, **kwargs):
+        """Modify is not supported for Volume resource.
+
+        :raises: UnsupportedOperation
+        """
+        raise UnsupportedOperation(
+            "%s does not support the modify method." % self.__class__.__name__
+        )
+
+    def update(self, **kwargs):
+        """Update is not supported for Volume resource.
+
+        :raises: UnsupportedOperation
+        """
+        raise UnsupportedOperation(
+            "%s does not support the update method." % self.__class__.__name__
+        )


### PR DESCRIPTION
Problem:
Currently there are no endpoints to volumes, images and hotfixes which are required for software installation/volume management

Analysis:
Added Volume Endpoint, added some basic functional tests for volume and hotfix, images endpoints. We need to be able to load ISO image to Jenkins so we can test more. Issue tracked under #1124

Tests:
Flake8
Unit
Functional