### PR TITLE
Fixes #1128

### DIFF
--- a/f5/bigip/tm/sys/software/hotfix.py
+++ b/f5/bigip/tm/sys/software/hotfix.py
@@ -27,18 +27,22 @@ REST Kind
     ``tm:sys:software:hotfix*``
 """
 
+from f5.bigip.mixins import CommandExecutionMixin
 from f5.bigip.resource import Collection
 from f5.bigip.resource import Resource
 from f5.sdk_exception import UnsupportedOperation
 
 
-class Hotfix_s(Collection):
+class Hotfix_s(Collection, CommandExecutionMixin):
     """BIG-IP® system software hotfix collection."""
     def __init__(self, software):
         super(Hotfix_s, self).__init__(software)
         self._meta_data['allowed_lazy_attributes'] = [Hotfix]
         self._meta_data['attribute_registry'] = \
             {'tm:sys:software:hotfix:hotfixstate': Hotfix}
+        self._meta_data['allowed_commands'].append('install')
+        self._meta_data['required_command_parameters'].update((
+            'name', 'volume'))
 
 
 class Hotfix(Resource):

--- a/f5/bigip/tm/sys/software/image.py
+++ b/f5/bigip/tm/sys/software/image.py
@@ -27,18 +27,22 @@ REST Kind
     ``tm:sys:software:image*``
 """
 
+from f5.bigip.mixins import CommandExecutionMixin
 from f5.bigip.resource import Collection
 from f5.bigip.resource import Resource
 from f5.sdk_exception import UnsupportedOperation
 
 
-class Images(Collection):
+class Images(Collection, CommandExecutionMixin):
     """BIG-IP® system software image collection."""
     def __init__(self, software):
         super(Images, self).__init__(software)
         self._meta_data['allowed_lazy_attributes'] = [Image]
         self._meta_data['attribute_registry'] = \
             {'tm:sys:software:image:imagestate': Image}
+        self._meta_data['allowed_commands'].append('install')
+        self._meta_data['required_command_parameters'].update((
+            'name', 'volume'))
 
 
 class Image(Resource):

--- a/f5/bigip/tm/sys/software/test/functional/test_hotfix.py
+++ b/f5/bigip/tm/sys/software/test/functional/test_hotfix.py
@@ -13,6 +13,8 @@
 #   limitations under the License.
 #
 
+from f5.sdk_exception import InvalidCommand
+from f5.sdk_exception import MissingRequiredCommandParameter
 from f5.sdk_exception import UnsupportedOperation
 import pytest
 
@@ -44,3 +46,12 @@ class TestHotfix(object):
         # Until we are able to install ISOs in Jenkins (which will allow us to
         # create hotfixes) we cannot test collection
         pass
+
+    def test_command_argument_missing(self, mgmt_root):
+        with pytest.raises(MissingRequiredCommandParameter):
+            mgmt_root.tm.sys.software.images.exec_cmd('install',
+                                                      name='fake.iso')
+
+    def test_invalid_command(self, mgmt_root):
+        with pytest.raises(InvalidCommand):
+            mgmt_root.tm.sys.software.images.exec_cmd('run')

--- a/f5/bigip/tm/sys/software/test/functional/test_image.py
+++ b/f5/bigip/tm/sys/software/test/functional/test_image.py
@@ -14,7 +14,10 @@
 #
 
 
+from f5.sdk_exception import InvalidCommand
+from f5.sdk_exception import MissingRequiredCommandParameter
 from f5.sdk_exception import UnsupportedOperation
+
 import pytest
 
 
@@ -45,3 +48,12 @@ class TestImage(object):
         # Until we are able to install ISOs in Jenkins (which will allow us to
         # create images) we cannot test collection
         pass
+
+    def test_command_argument_missing(self, mgmt_root):
+        with pytest.raises(MissingRequiredCommandParameter):
+            mgmt_root.tm.sys.software.images.exec_cmd('install',
+                                                      name='fake.iso')
+
+    def test_invalid_command(self, mgmt_root):
+        with pytest.raises(InvalidCommand):
+            mgmt_root.tm.sys.software.images.exec_cmd('run')


### PR DESCRIPTION
Problem:
Hotfix, Image did not have install command enabled.

Analysis:
Enabled install command on image and hotfix to facilitate software installation. We still require the ability to provide more ISO image on Jenkins so we can write more comprehensive tests

Tests:
Flake8
Unit
Functional