### PR TITLE
Fixes #1133

### DIFF
--- a/f5/bigip/tm/sys/software/test/unit/test_volume.py
+++ b/f5/bigip/tm/sys/software/test/unit/test_volume.py
@@ -18,6 +18,9 @@ import pytest
 
 
 from f5.bigip.tm.sys.software.volume import Volume
+from f5.bigip.tm.sys.software.volume import Volumes
+from f5.sdk_exception import InvalidCommand
+from f5.sdk_exception import MissingRequiredCommandParameter
 from f5.sdk_exception import UnsupportedOperation
 
 
@@ -25,6 +28,12 @@ from f5.sdk_exception import UnsupportedOperation
 def FakeVolume():
     fake_software = mock.MagicMock()
     return Volume(fake_software)
+
+
+@pytest.fixture
+def FakeVolumes():
+    fake_software = mock.MagicMock()
+    return Volumes(fake_software)
 
 
 def test_create_raises(FakeVolume):
@@ -43,3 +52,16 @@ def test_modify_raises(FakeVolume):
     with pytest.raises(UnsupportedOperation) as EIO:
         FakeVolume.modify()
     assert EIO.value.message == "Volume does not support the modify method."
+
+
+def test_no_command_param_raises(FakeVolumes):
+    with pytest.raises(MissingRequiredCommandParameter) as EIO:
+        FakeVolumes.exec_cmd('reboot')
+    assert EIO.value.message == "Missing required params: ['volume']"
+
+
+def test_invalid_command_raises(FakeVolumes):
+    with pytest.raises(InvalidCommand) as EIO:
+        FakeVolumes.exec_cmd('foobar')
+    assert EIO.value.message == "The command value foobar does not exist" \
+                                "Valid commands are ['reboot']"

--- a/f5/bigip/tm/sys/software/volume.py
+++ b/f5/bigip/tm/sys/software/volume.py
@@ -27,18 +27,21 @@ REST Kind
     ``tm:sys:software:volume*``
 """
 
+from f5.bigip.mixins import CommandExecutionMixin
 from f5.bigip.resource import Collection
 from f5.bigip.resource import Resource
 from f5.sdk_exception import UnsupportedOperation
 
 
-class Volumes(Collection):
+class Volumes(Collection, CommandExecutionMixin):
     """BIG-IP® system software Volume collection."""
     def __init__(self, software):
         super(Volumes, self).__init__(software)
         self._meta_data['allowed_lazy_attributes'] = [Volume]
         self._meta_data['attribute_registry'] = \
             {'tm:sys:software:volume:volumestate': Volume}
+        self._meta_data['allowed_commands'].append('reboot')
+        self._meta_data['required_command_parameters'].update(('volume',))
 
 
 class Volume(Resource):


### PR DESCRIPTION
Problem:
We could not reboot to a new volume with REST API

Analysis:
Allowed to run reboot command on volumes endpoint.

Tests:
Flake8
Unit