### PR TITLE
Members modify() broken when setting session attribute

### DIFF
--- a/f5/bigip/tm/ltm/pool.py
+++ b/f5/bigip/tm/ltm/pool.py
@@ -214,7 +214,7 @@ class Members(Resource):
                       "'user-down'" % patch['state']
                 raise MemberStateModifyUnsupported(msg)
         if 'session' in patch:
-            if patch['session'] != 'user-enabled' and patch['state'] != \
+            if patch['session'] != 'user-enabled' and patch['session'] != \
                     'user-disabled':
                 msg = "The members resource does not support a modify with " \
                       "the value of the 'session' attribute as %s. " \

--- a/f5/bigip/tm/ltm/test/functional/test_pool.py
+++ b/f5/bigip/tm/ltm/test/functional/test_pool.py
@@ -219,6 +219,16 @@ class TestPoolMembersCollection(object):
         m2.session = m1.session
         m2.state = m1.state
 
+    def test_session_modify(self, request, bigip):
+        m1, pool = setup_member_test(request, bigip, 'membertestpool1',
+                                     'Common')
+        assert m1.session == 'user-enabled'
+        m1.modify(session='user-disabled')
+        m2 = pool.members_s.members.load(
+            name='192.168.15.15:80', partition='Common')
+        assert m2.session == 'user-disabled'
+        assert m1.session == m2.session
+
     def test_state_modify(self, request, bigip):
         m1, pool = setup_member_test(request, bigip, 'membertestpool1',
                                      'Common')


### PR DESCRIPTION
Issues:
Fixes #1137

Problem: Member modify incorrectly checks value of 'state' attribute
when user passes 'session' attribute to modify.

Analysis: patch['state'] is not correct. should be patch['session']

Tests: Added new test, test_session_modify(), to match existing test
test_state_modify().