### PR TITLE
Adds partition support to SDK.

### DIFF
--- a/f5/bigip/tm/auth/__init__.py
+++ b/f5/bigip/tm/auth/__init__.py
@@ -29,6 +29,7 @@ REST Kind
 
 
 from f5.bigip.resource import OrganizingCollection
+from f5.bigip.tm.auth.partition import Partitions
 from f5.bigip.tm.auth.password_policy import Password_Policy
 from f5.bigip.tm.auth.user import Users
 
@@ -37,6 +38,7 @@ class Auth(OrganizingCollection):
     def __init__(self, tm):
         super(Auth, self).__init__(tm)
         self._meta_data['allowed_lazy_attributes'] = [
+            Partitions,
             Password_Policy,
             Users
         ]

--- a/f5/bigip/tm/auth/partition.py
+++ b/f5/bigip/tm/auth/partition.py
@@ -1,0 +1,48 @@
+# coding=utf-8
+#
+# Copyright 2017 F5 Networks Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""BIG-IP® system folder (partition) module
+
+REST URI
+    ``http://localhost/mgmt/tm/sys/folder``
+
+GUI Path
+    ``System --> Users --> Partition List``
+
+REST Kind
+    ``tm:auth:partition:*``
+"""
+
+from f5.bigip.resource import Collection
+from f5.bigip.resource import Resource
+
+
+class Partitions(Collection):
+    def __init__(self, auth):
+        super(Partitions, self).__init__(auth)
+        self._meta_data['required_json_kind'] = \
+            'tm:auth:partition:partitioncollectionstate'
+        self._meta_data['allowed_lazy_attributes'] = [Partition]
+        self._meta_data['attribute_registry'] = \
+            {'tm:auth:partition:partitionstate': Partition}
+
+
+class Partition(Resource):
+    def __init__(self, users):
+        super(Partition, self).__init__(users)
+        self._meta_data['required_json_kind'] = \
+            'tm:auth:partition:partitionstate'

--- a/f5/bigip/tm/auth/test/functional/test_partition.py
+++ b/f5/bigip/tm/auth/test/functional/test_partition.py
@@ -1,0 +1,139 @@
+# Copyright 2017 F5 Networks Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import pytest
+
+from f5.bigip.tm.auth.partition import Partition
+from f5.sdk_exception import MissingRequiredCreationParameter
+from requests.exceptions import HTTPError
+
+PARTITION_NAME1 = 'part1'
+PARTITION_NAME2 = 'part2'
+PARTITION_NAME3 = 'part3'
+
+
+@pytest.fixture(scope='function')
+def partition(mgmt_root):
+    partitions = mgmt_root.tm.auth.partitions.partition
+    local = partitions.create(name=PARTITION_NAME1)
+    yield local
+    local.delete()
+
+
+@pytest.fixture(scope='function')
+def partition_desc(mgmt_root):
+    partitions = mgmt_root.tm.auth.partitions.partition
+    local = partitions.create(name=PARTITION_NAME2, description='foo')
+    yield local
+    local.delete()
+
+
+@pytest.fixture(scope='function')
+def partition_delete(mgmt_root):
+    partitions = mgmt_root.tm.auth.partitions.partition
+    local = partitions.create(name=PARTITION_NAME3)
+    yield local
+
+
+def delete_partition(mgmt_root, name):
+    partition = mgmt_root.tm.auth.partitions.partition
+    try:
+        part1 = partition.load(name=name)
+    except HTTPError as err:
+        if err.response.status_code != 404:
+            raise
+        return
+    part1.delete()
+
+
+def setup_create_test(request, mgmt_root):
+    def teardown():
+        delete_partition(mgmt_root, 'part1')
+    request.addfinalizer(teardown)
+
+
+def setup_create_two(request, mgmt_root):
+    def teardown():
+        for name in ['part1', 'part2']:
+            delete_partition(mgmt_root, name)
+    request.addfinalizer(teardown)
+
+
+class TestCreate(object):
+    def test_create_two(self, request, mgmt_root):
+        setup_create_two(request, mgmt_root)
+
+        n1 = mgmt_root.tm.auth.partitions.partition.create(name='part1')
+        n2 = mgmt_root.tm.auth.partitions.partition.create(name='part2')
+
+        assert n1 is not n2
+        assert n2.name != n1.name
+
+    def test_create_no_args(self, mgmt_root):
+        '''Test that partition.create() with no options throws a ValueError '''
+        part1 = mgmt_root.tm.auth.partitions.partition
+        with pytest.raises(MissingRequiredCreationParameter):
+            part1.create()
+
+    def test_create_description(self, partition_desc):
+        assert partition_desc.description == 'foo'
+
+
+class TestLoad(object):
+    def test_load_no_object(self, mgmt_root):
+        with pytest.raises(HTTPError) as err:
+            mgmt_root.tm.auth.partitions.partition.load(name='user10')
+            assert err.response.status == 404
+
+    def test_load(self, partition_desc):
+        assert partition_desc.name == 'part2'
+        assert partition_desc.description == 'foo'
+        assert isinstance(partition_desc, Partition)
+
+
+class TestRefresh(object):
+    def test_refresh(self, mgmt_root, partition_desc):
+        n1 = mgmt_root.tm.auth.partitions.partition.load(name='part2')
+        n2 = mgmt_root.tm.auth.partitions.partition.load(name='part2')
+        assert n1.description == 'foo'
+        assert n2.description == 'foo'
+
+        n2.update(description='foobaz')
+        assert n2.description == 'foobaz'
+        assert n1.description == 'foo'
+
+        n1.refresh()
+        assert n1.description == 'foobaz'
+
+
+class TestDelete(object):
+    def test_delete(self, mgmt_root, partition_delete):
+        partition_delete.delete()
+        with pytest.raises(HTTPError) as err:
+            mgmt_root.tm.auth.partitions.partition.load(name='part3')
+        assert err.value.response.status_code == 404
+
+
+class TestUpdate(object):
+    def test_update_with_args(self, partition_desc):
+        assert partition_desc.description == 'foo'
+        partition_desc.update(description='foobar')
+        assert partition_desc.description == 'foobar'
+
+    def test_update_parameters(self, partition_desc):
+        assert partition_desc.description == 'foo'
+        partition_desc.description = 'foobar'
+        partition_desc.update()
+        assert partition_desc.description == 'foobar'

--- a/f5/bigip/tm/auth/test/unit/test_partition.py
+++ b/f5/bigip/tm/auth/test/unit/test_partition.py
@@ -1,0 +1,44 @@
+# Copyright 2017 F5 Networks Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import mock
+import pytest
+
+from f5.bigip import ManagementRoot
+from f5.bigip.tm.auth.partition import Partition
+from f5.sdk_exception import MissingRequiredCreationParameter
+
+
+@pytest.fixture
+def FakePartition():
+    fake_part_s = mock.MagicMock()
+    fake_part = Partition(fake_part_s)
+    return fake_part
+
+
+class TestCreate(object):
+    def test_create_two(self, fakeicontrolsession):
+        b = ManagementRoot('localhost', 'admin', 'admin')
+        n1 = b.tm.auth.partitions.partition
+        n2 = b.tm.auth.partitions.partition
+        assert n1 is not n2
+
+    def test_create_no_args(self, FakePartition):
+        with pytest.raises(MissingRequiredCreationParameter):
+            FakePartition.create()
+
+    def test_create_description(self, FakePartition):
+        with pytest.raises(MissingRequiredCreationParameter):
+            FakePartition.create(description='description')

--- a/f5/bigip/tm/sys/folder.py
+++ b/f5/bigip/tm/sys/folder.py
@@ -15,13 +15,10 @@
 # limitations under the License.
 #
 
-"""BIG-IP® system folder (partition) module
+"""BIG-IP® system folder module
 
 REST URI
     ``http://localhost/mgmt/tm/sys/folder``
-
-GUI Path
-    ``System --> Users --> Partition List``
 
 REST Kind
     ``tm:sys:folder:*``


### PR DESCRIPTION
Somebody added folder support, but folders are not partitions as
recognized by TMUI. So this adds proper partition API support

Issues:
Fixes #1149

Problem:
Partition support did not exist in the SDK

Analysis:
This patch adds it

Tests:
* functional
* unit