### PR TITLE
Fixes #1155

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -69,8 +69,41 @@ def fakeicontrolsessionfactory(monkeypatch):
             mock.MagicMock(return_value=Response(**json_keys))
         fakesessionclass.return_value = fakesessioninstance
         monkeypatch.setattr('f5.bigip.iControlRESTSession', fakesessionclass)
-
     return _session_factory
+
+
+@pytest.fixture
+def responsivesessionfactory(monkeypatch):
+    class Response(object):
+        def __init__(self, http_code, **json_keys):
+            if 'selfLink' not in json_keys:
+                json_keys['selfLink'] =\
+                    'https://localhost/mgmt/tm/sys?ver=12.1.0'
+            self.params = json_keys
+            self.status_code = http_code
+
+        def json(self):
+            return self.params
+
+    def _session_factory(http_code, **json_keys):
+        fakesessionclass = mock.create_autospec(iControlRESTSession,
+                                                spec_set=True)
+        fakesessioninstance =\
+            mock.create_autospec(iControlRESTSession('A', 'B'), spec_set=True)
+        fakesessioninstance.get =\
+            mock.MagicMock(return_value=Response(http_code, **json_keys))
+        fakesessioninstance.delete =\
+            mock.MagicMock(return_value=Response(http_code))
+        fakesessioninstance.patch =\
+            mock.MagicMock(return_value=Response(http_code, **json_keys))
+        fakesessioninstance.put = \
+            mock.MagicMock(return_value=Response(http_code, **json_keys))
+        fakesessioninstance.post = \
+            mock.MagicMock(return_value=Response(http_code, **json_keys))
+        fakesessionclass.return_value = fakesessioninstance
+        monkeypatch.setattr('f5.bigip.iControlRESTSession', fakesessionclass)
+    return _session_factory
+
 
 
 @pytest.fixture

--- a/conftest.py
+++ b/conftest.py
@@ -105,7 +105,6 @@ def responsivesessionfactory(monkeypatch):
     return _session_factory
 
 
-
 @pytest.fixture
 def fakeicontrolsession_v12(monkeypatch):
     class Response(object):

--- a/f5/bigip/tm/sys/software/test/unit/fixtures/load_hotfix.json
+++ b/f5/bigip/tm/sys/software/test/unit/fixtures/load_hotfix.json
@@ -1,0 +1,14 @@
+{
+  "kind": "tm:sys:software:hotfix:hotfixstate",
+  "name": "Hotfix-BIGIP-12.1.0.1.0.1447-HF1.iso",
+  "fullPath": "Hotfix-BIGIP-12.1.0.1.0.1447-HF1.iso",
+  "generation": 44,
+  "selfLink": "https://localhost/mgmt/tm/sys/software/hotfix/Hotfix-BIGIP-12.1.0.1.0.1447-HF1.iso?ver=12.1.0",
+  "build": "1.0.1447",
+  "checksum": "c727a20957d5cbce287f99c0ba3fe83f",
+  "id": "HF1",
+  "product": "BIG-IP",
+  "title": "Hotfix Version 1.0.1447",
+  "verified": "yes",
+  "version": "12.1.0"
+}

--- a/f5/bigip/tm/sys/software/test/unit/fixtures/load_hotfixes.json
+++ b/f5/bigip/tm/sys/software/test/unit/fixtures/load_hotfixes.json
@@ -1,0 +1,20 @@
+{
+  "kind": "tm:sys:software:hotfix:hotfixcollectionstate",
+  "selfLink": "https://localhost/mgmt/tm/sys/software/hotfix?ver=12.1.0",
+  "items": [
+    {
+      "kind": "tm:sys:software:hotfix:hotfixstate",
+      "name": "Hotfix-BIGIP-12.1.0.1.0.1447-HF1.iso",
+      "fullPath": "Hotfix-BIGIP-12.1.0.1.0.1447-HF1.iso",
+      "generation": 44,
+      "selfLink": "https://localhost/mgmt/tm/sys/software/hotfix/Hotfix-BIGIP-12.1.0.1.0.1447-HF1.iso?ver=12.1.0",
+      "build": "1.0.1447",
+      "checksum": "c727a20957d5cbce287f99c0ba3fe83f",
+      "id": "HF1",
+      "product": "BIG-IP",
+      "title": "Hotfix Version 1.0.1447",
+      "verified": "yes",
+      "version": "12.1.0"
+    }
+  ]
+}

--- a/f5/bigip/tm/sys/software/test/unit/fixtures/load_image.json
+++ b/f5/bigip/tm/sys/software/test/unit/fixtures/load_image.json
@@ -1,0 +1,15 @@
+{
+  "kind": "tm:sys:software:image:imagestate",
+  "name": "BIGIP-12.1.0.0.0.1434.iso",
+  "fullPath": "BIGIP-12.1.0.0.0.1434.iso",
+  "generation": 43,
+  "selfLink": "https://localhost/mgmt/tm/sys/software/image/BIGIP-12.1.0.0.0.1434.iso?ver=12.1.0",
+  "build": "0.0.1434",
+  "buildDate": "Wed May 11 11 45 11 PDT 2016",
+  "checksum": "c2300ca7b630a0b46a9047a1bafe4922",
+  "fileSize": "1946 MB",
+  "lastModified": "Thu Sep 22 02:46:26 2016",
+  "product": "BIG-IP",
+  "verified": "yes",
+  "version": "12.1.0"
+}

--- a/f5/bigip/tm/sys/software/test/unit/fixtures/load_images.json
+++ b/f5/bigip/tm/sys/software/test/unit/fixtures/load_images.json
@@ -1,0 +1,36 @@
+{
+  "kind": "tm:sys:software:image:imagecollectionstate",
+  "selfLink": "https://localhost/mgmt/tm/sys/software/image?ver=12.1.0",
+  "items": [
+    {
+      "kind": "tm:sys:software:image:imagestate",
+      "name": "BIGIP-12.1.0.0.0.1434.iso",
+      "fullPath": "BIGIP-12.1.0.0.0.1434.iso",
+      "generation": 43,
+      "selfLink": "https://localhost/mgmt/tm/sys/software/image/BIGIP-12.1.0.0.0.1434.iso?ver=12.1.0",
+      "build": "0.0.1434",
+      "buildDate": "Wed May 11 11 45 11 PDT 2016",
+      "checksum": "c2300ca7b630a0b46a9047a1bafe4922",
+      "fileSize": "1946 MB",
+      "lastModified": "Thu Sep 22 02:46:26 2016",
+      "product": "BIG-IP",
+      "verified": "yes",
+      "version": "12.1.0"
+    },
+    {
+      "kind": "tm:sys:software:image:imagestate",
+      "name": "BIGIP-12.1.1.0.0.184.iso",
+      "fullPath": "BIGIP-12.1.1.0.0.184.iso",
+      "generation": 42,
+      "selfLink": "https://localhost/mgmt/tm/sys/software/image/BIGIP-12.1.1.0.0.184.iso?ver=12.1.0",
+      "build": "0.0.184",
+      "buildDate": "Thu Aug 11 17 09 01 PDT 2016",
+      "checksum": "2f89a4667b8651e2e1f28a569e5c0742",
+      "fileSize": "1997 MB",
+      "lastModified": "Sun Oct  2 20:50:04 2016",
+      "product": "BIG-IP",
+      "verified": "yes",
+      "version": "12.1.1"
+    }
+  ]
+}

--- a/f5/bigip/tm/sys/software/test/unit/fixtures/load_volume.json
+++ b/f5/bigip/tm/sys/software/test/unit/fixtures/load_volume.json
@@ -1,0 +1,25 @@
+{
+  "kind": "tm:sys:software:volume:volumestate",
+  "name": "HD1.1",
+  "fullPath": "HD1.1",
+  "generation": 39,
+  "selfLink": "https://localhost/mgmt/tm/sys/software/volume/HD1.1?ver=12.1.0",
+  "active": true,
+  "apiRawValues": {},
+  "basebuild": "0.0.1434",
+  "build": "1.0.1447",
+  "product": "BIG-IP",
+  "status": "complete",
+  "version": "12.1.0",
+  "media": [
+    {
+      "name": "HD1.1",
+      "defaultBootLocation": true,
+      "media": "hd",
+      "size": "default",
+      "nameReference": {
+        "link": "https://localhost/mgmt/tm/sys/software/volume/HD1.1?ver=12.1.0"
+      }
+    }
+  ]
+}

--- a/f5/bigip/tm/sys/software/test/unit/fixtures/load_volumes.json
+++ b/f5/bigip/tm/sys/software/test/unit/fixtures/load_volumes.json
@@ -1,0 +1,75 @@
+{
+  "kind": "tm:sys:software:volume:volumecollectionstate",
+  "selfLink": "https://localhost/mgmt/tm/sys/software/volume?ver=12.1.0",
+  "items": [
+    {
+      "kind": "tm:sys:software:volume:volumestate",
+      "name": "HD1.1",
+      "fullPath": "HD1.1",
+      "generation": 39,
+      "selfLink": "https://localhost/mgmt/tm/sys/software/volume/HD1.1?ver=12.1.0",
+      "active": true,
+      "apiRawValues": {},
+      "basebuild": "0.0.1434",
+      "build": "1.0.1447",
+      "product": "BIG-IP",
+      "status": "complete",
+      "version": "12.1.0",
+      "media": [
+        {
+          "name": "HD1.1",
+          "defaultBootLocation": true,
+          "media": "hd",
+          "size": "default",
+          "nameReference": {
+            "link": "https://localhost/mgmt/tm/sys/software/volume/HD1.1?ver=12.1.0"
+          }
+        }
+      ]
+    },
+    {
+      "kind": "tm:sys:software:volume:volumestate",
+      "name": "HD1.2",
+      "fullPath": "HD1.2",
+      "generation": 40,
+      "selfLink": "https://localhost/mgmt/tm/sys/software/volume/HD1.2?ver=12.1.0",
+      "basebuild": "0.0.184",
+      "build": "0.0.184",
+      "product": "BIG-IP",
+      "status": "complete",
+      "version": "12.1.1",
+      "media": [
+        {
+          "name": "HD1.2",
+          "media": "hd",
+          "size": "default",
+          "nameReference": {
+            "link": "https://localhost/mgmt/tm/sys/software/volume/HD1.2?ver=12.1.0"
+          }
+        }
+      ]
+    },
+    {
+      "kind": "tm:sys:software:volume:volumestate",
+      "name": "HD1.3",
+      "fullPath": "HD1.3",
+      "generation": 240,
+      "selfLink": "https://localhost/mgmt/tm/sys/software/volume/HD1.3?ver=12.1.0",
+      "basebuild": "0.0.1434",
+      "build": "0.0.1434",
+      "product": "BIG-IP",
+      "status": "complete",
+      "version": "12.1.0",
+      "media": [
+        {
+          "name": "HD1.3",
+          "media": "hd",
+          "size": "default",
+          "nameReference": {
+            "link": "https://localhost/mgmt/tm/sys/software/volume/HD1.3?ver=12.1.0"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/f5/bigip/tm/sys/software/test/unit/test_hotfix.py
+++ b/f5/bigip/tm/sys/software/test/unit/test_hotfix.py
@@ -13,12 +13,36 @@
 # limitations under the License.
 #
 
+import json
 import mock
+import os
 import pytest
 
-
+from f5.bigip import ManagementRoot
 from f5.bigip.tm.sys.software.hotfix import Hotfix
 from f5.sdk_exception import UnsupportedOperation
+
+
+fixture_path = os.path.join(os.path.dirname(__file__), 'fixtures')
+fixture_data = {}
+
+
+def load_fixture(name):
+    path = os.path.join(fixture_path, name)
+
+    if path in fixture_data:
+        return fixture_data[path]
+
+    with open(path) as f:
+        data = f.read()
+
+    try:
+        data = json.loads(data)
+    except Exception:
+        pass
+
+    fixture_data[path] = data
+    return data
 
 
 @pytest.fixture
@@ -43,3 +67,40 @@ def test_modify_raises(FakeHotfix):
     with pytest.raises(UnsupportedOperation) as EIO:
         FakeHotfix.modify()
     assert EIO.value.message == "Hotfix does not support the modify method."
+
+
+def test_load(responsivesessionfactory):
+    responsivesessionfactory(200, **load_fixture('load_hotfix.json'))
+    mr = ManagementRoot('192.168.1.1', 'admin', 'admin')
+    res = mr.tm.sys.software.hotfix_s.hotfix.load(
+        name='Hotfix-BIGIP-12.1.0.1.0.1447-HF1.iso'
+    )
+    assert res.kind == 'tm:sys:software:hotfix:hotfixstate'
+    assert res.name == 'Hotfix-BIGIP-12.1.0.1.0.1447-HF1.iso'
+    assert res.build == '1.0.1447'
+    assert res.version == '12.1.0'
+
+
+def test_delete(responsivesessionfactory):
+    responsivesessionfactory(200, **load_fixture('load_hotfix.json'))
+    mr = ManagementRoot('192.168.1.1', 'admin', 'admin')
+    res = mr.tm.sys.software.hotfix_s.hotfix.load(
+        name='Hotfix-BIGIP-12.1.0.1.0.1447-HF1.iso'
+    )
+    assert res.kind == 'tm:sys:software:hotfix:hotfixstate'
+    assert res.name == 'Hotfix-BIGIP-12.1.0.1.0.1447-HF1.iso'
+    assert res.build == '1.0.1447'
+    assert res.version == '12.1.0'
+
+    res.delete()
+    assert res.deleted is True
+
+
+def test_collection(responsivesessionfactory):
+    responsivesessionfactory(200, **load_fixture('load_hotfixes.json'))
+    mr = ManagementRoot('192.168.1.1', 'admin', 'admin')
+    resc = mr.tm.sys.software.hotfix_s.get_collection()
+
+    assert isinstance(resc, list)
+    assert len(resc)
+    assert isinstance(resc[0], Hotfix)

--- a/f5/bigip/tm/sys/software/test/unit/test_image.py
+++ b/f5/bigip/tm/sys/software/test/unit/test_image.py
@@ -13,12 +13,35 @@
 # limitations under the License.
 #
 
+import json
 import mock
+import os
 import pytest
 
-
+from f5.bigip import ManagementRoot
 from f5.bigip.tm.sys.software.image import Image
 from f5.sdk_exception import UnsupportedOperation
+
+fixture_path = os.path.join(os.path.dirname(__file__), 'fixtures')
+fixture_data = {}
+
+
+def load_fixture(name):
+    path = os.path.join(fixture_path, name)
+
+    if path in fixture_data:
+        return fixture_data[path]
+
+    with open(path) as f:
+        data = f.read()
+
+    try:
+        data = json.loads(data)
+    except Exception:
+        pass
+
+    fixture_data[path] = data
+    return data
 
 
 @pytest.fixture
@@ -43,3 +66,39 @@ def test_modify_raises(FakeImage):
     with pytest.raises(UnsupportedOperation) as EIO:
         FakeImage.modify()
     assert EIO.value.message == "Image does not support the modify method."
+
+
+def test_load(responsivesessionfactory):
+    responsivesessionfactory(200, **load_fixture('load_image.json'))
+    mr = ManagementRoot('192.168.1.1', 'admin', 'admin')
+    res = mr.tm.sys.software.images.image.load(
+        name='BIGIP-12.1.0.0.0.1434.iso'
+    )
+    assert res.kind == 'tm:sys:software:image:imagestate'
+    assert res.name == 'BIGIP-12.1.0.0.0.1434.iso'
+    assert res.build == '0.0.1434'
+    assert res.version == '12.1.0'
+
+
+def test_delete(responsivesessionfactory):
+    responsivesessionfactory(200, **load_fixture('load_image.json'))
+    mr = ManagementRoot('192.168.1.1', 'admin', 'admin')
+    res = mr.tm.sys.software.images.image.load(
+        name='BIGIP-12.1.0.0.0.1434.iso'
+    )
+    assert res.kind == 'tm:sys:software:image:imagestate'
+    assert res.name == 'BIGIP-12.1.0.0.0.1434.iso'
+    assert res.build == '0.0.1434'
+    assert res.version == '12.1.0'
+    res.delete()
+    assert res.deleted is True
+
+
+def test_collection(responsivesessionfactory):
+    responsivesessionfactory(200, **load_fixture('load_images.json'))
+    mr = ManagementRoot('192.168.1.1', 'admin', 'admin')
+    resc = mr.tm.sys.software.images.get_collection()
+
+    assert isinstance(resc, list)
+    assert len(resc)
+    assert isinstance(resc[0], Image)


### PR DESCRIPTION
Problem:
Since we cannot run functional tests due to harness limitation, we needed better unit tests

Analysis:
Added tests for load, delete and collection for all of the endpoints, those tests use raw json files to and sessionfactory fixture to simulate bigip responses

Tests:
Flake8
Unit