### PR TITLE
Adds API for UCS upload and download

### DIFF
--- a/f5/bigip/shared/file_transfer.py
+++ b/f5/bigip/shared/file_transfer.py
@@ -35,7 +35,9 @@ class File_Transfer(PathElement):
         self._meta_data['allowed_lazy_attributes'] = [
             Bulk,
             Madm,
-            Uploads
+            Uploads,
+            Ucs_Uploads,
+            Ucs_Downloads
         ]
 
 
@@ -76,6 +78,32 @@ class Madm(PathElement, FileDownloadMixin):
     """A file upload resource."""
     def __init__(self, file_transfer):
         super(Madm, self).__init__(file_transfer)
+
+    def download_file(self, src, dest, **kwargs):
+        filename = os.path.basename(src)
+        self.file_bound_uri = self._meta_data['uri'] + filename
+        self._download_file(src, dest, **kwargs)
+
+
+class Ucs_Uploads(PathElement, FileUploadMixin):
+    def __init__(self, file_transfer):
+        super(Ucs_Uploads, self).__init__(file_transfer)
+
+    def upload_file(self, filepathname, **kwargs):
+        filename = os.path.basename(filepathname)
+        if os.path.splitext(filename)[-1] == '.iso':
+            raise FileMustNotHaveDotISOExtension(filename)
+        self.file_bound_uri = self._meta_data['uri'] + filename
+        self._upload_file(filepathname, **kwargs)
+
+    def upload_bytes(self, bytestring, target, **kwargs):
+        self.file_bound_uri = self._meta_data['uri'] + target
+        self._upload(StringIO(bytestring), **kwargs)
+
+
+class Ucs_Downloads(PathElement, FileDownloadMixin):
+    def __init__(self, file_transfer):
+        super(Ucs_Downloads, self).__init__(file_transfer)
 
     def download_file(self, src, dest, **kwargs):
         filename = os.path.basename(src)


### PR DESCRIPTION
Issues:
Fixes #1161

Problem:
The APIs for UCS upload and download did not exist

Analysis:
This patch adds them

Tests:
functional