### PR TITLE
Adds support for the QUERY operation

### DIFF
--- a/f5/bigip/shared/iapp.py
+++ b/f5/bigip/shared/iapp.py
@@ -18,6 +18,7 @@
 from f5.bigip.resource import Collection
 from f5.bigip.resource import OrganizingCollection
 from f5.bigip.resource import TaskResource
+from f5.sdk_exception import MissingRequiredCreationParameter
 from f5.sdk_exception import UnsupportedOperation
 
 
@@ -46,8 +47,18 @@ class Package_Management_Task(TaskResource):
         super(Package_Management_Task, self).__init__(package_management_tasks)
         self._meta_data['required_json_kind'] = \
             'shared:iapp:package-management-tasks:iapppackagemanagementtaskstate'  # NOQA
-        self._meta_data['required_creation_parameters'] = {
-            'operation', 'packageFilePath'}
+        self._meta_data['required_creation_parameters'] = {'operation'}
+
+    def create(self, **kwargs):
+        if 'operation' not in kwargs:
+            error_message = "Missing required params: ['operation']"
+            raise MissingRequiredCreationParameter(error_message)
+
+        if kwargs['operation'] == 'INSTALL':
+            if 'packageFilePath' not in kwargs:
+                error_message = "Missing required params: ['packageFilePath']"
+                raise MissingRequiredCreationParameter(error_message)
+        return self._create(**kwargs)
 
     def update(self, **kwargs):
         raise UnsupportedOperation(

--- a/f5/bigip/shared/test/unit/test_iapp.py
+++ b/f5/bigip/shared/test/unit/test_iapp.py
@@ -45,6 +45,10 @@ class TestIapp(object):
         with pytest.raises(MissingRequiredCreationParameter):
             FakeIapp.create()
 
+    def test_create_no_package(self, FakeIapp):
+        with pytest.raises(MissingRequiredCreationParameter):
+            FakeIapp.create(operation='INSTALL')
+
     def test_collection(self, fakeicontrolsession):
         b = ManagementRoot('192.168.1.1', 'admin', 'admin')
         t = b.shared.iapp.package_management_tasks_s


### PR DESCRIPTION
Issues:
Fixes #1163

Problem:
Previously, the required creation params were too strict and did
not allow for QUERY operations to be created

Analysis:
This patch fixes that while at the same time retaining the previous
requirements for INSTALL operations

Tests:
functional
unit