### PR TITLE
Fixes missing vulnerability assessment code

### DIFF
--- a/f5/bigip/tm/asm/policies/__init__.py
+++ b/f5/bigip/tm/asm/policies/__init__.py
@@ -41,7 +41,7 @@ from . parameters import Parameters_s
 # from . response_pages import Response_Pages_s
 # from . policy_builder import Policy_Builder
 # from . history_revisions import History_Revisions_s
-# from . vulnerability_assessment import Vulnerability_Assessment
+from . vulnerability_assessment import Vulnerability_Assessment
 # from . geolocation_enforcement import Geolocation_Enforcement
 # from . session_tracking import Session_Tracking
 # from . session_tracking_status import Session_Tracking_Statuses_s
@@ -97,7 +97,7 @@ class Policy(AsmResource):
             #            'tm:asm:policies:headers:headercollectionstate': Headers_s,
             #            'tm:asm:policies:response-pages:response-pagecollectionstate': Response_Pages_s,
             #            'tm:asm:policies:history-revisions:history-revisioncollectionstate': History_Revisions_s,
-            #            'tm:asm:policies:vulnerability-assessment:vulnerability-assessmentstate': Vulnerability_Assessment,
+            'tm:asm:policies:vulnerability-assessment:vulnerability-assessmentstate': Vulnerability_Assessment,
             #            'tm:asm:policies:data-guard:data-guardstate': Data_Guard,
             #            'tm:asm:policies:geolocation-enforcement:geolocation-enforcementstate': Geolocation_Enforcement,
             #            'tm:asm:policies:session-tracking:session-awareness-settingsstate': Session_Tracking,

--- a/f5/bigip/tm/asm/policies/test/functional/test_vulnerability_assessment.py
+++ b/f5/bigip/tm/asm/policies/test/functional/test_vulnerability_assessment.py
@@ -1,0 +1,51 @@
+# Copyright 2017 F5 Networks Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import pytest
+
+from distutils.version import LooseVersion
+from f5.sdk_exception import UnsupportedOperation
+
+
+@pytest.mark.skipif(
+    LooseVersion(pytest.config.getoption('--release')) < LooseVersion('11.6.0'),
+    reason='This collection is fully implemented on 11.6.0 or greater.'
+)
+class TestVulnerabilityAssessment(object):
+    def test_update_raises(self, policy):
+        with pytest.raises(UnsupportedOperation):
+            policy.vulnerability_assessment.update()
+
+    def test_load(self, policy, scan_type):
+        r1 = policy.vulnerability_assessment.load()
+        assert r1.kind == 'tm:asm:policies:vulnerability-assessment:vulnerability-assessmentstate'
+        assert r1.scannerType == 'none'
+        r1.modify(scannerType=scan_type)
+        assert r1.scannerType == scan_type
+        r2 = policy.vulnerability_assessment.load()
+        assert r1.kind == r2.kind
+        assert r1.scannerType == r2.scannerType
+
+    def test_refresh(self, policy):
+        r1 = policy.vulnerability_assessment.load()
+        assert r1.kind == 'tm:asm:policies:vulnerability-assessment:vulnerability-assessmentstate'
+        assert r1.scannerType == 'none'
+        r2 = policy.vulnerability_assessment.load()
+        assert r1.kind == r2.kind
+        assert r1.scannerType == r2.scannerType
+        r2.modify(scannerType='none')
+        assert r2.scannerType == 'none'
+        r1.refresh()
+        assert r1.scannerType == r2.scannerType

--- a/f5/bigip/tm/asm/policies/test/unit/test_vulnerability_assessment.py
+++ b/f5/bigip/tm/asm/policies/test/unit/test_vulnerability_assessment.py
@@ -1,0 +1,35 @@
+# Copyright 2015 F5 Networks Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+from f5.bigip.tm.asm.policies.vulnerability_assessment import Vulnerability_Assessment
+from f5.sdk_exception import UnsupportedOperation
+
+
+import mock
+import pytest
+
+
+@pytest.fixture
+def FakeVulnerability():
+    fake_policy = mock.MagicMock()
+    fake_v = Vulnerability_Assessment(fake_policy)
+    fake_v._meta_data['bigip'].tmos_version = '11.6.0'
+    return fake_v
+
+
+class TestVulnerabilityAssessment(object):
+    def test_update_raises(self, FakeVulnerability):
+        with pytest.raises(UnsupportedOperation):
+            FakeVulnerability.update()


### PR DESCRIPTION
Issues:
Fixes #1168

Problem:
Vulnerability assessment code was left out of original PR to make it
finish quicker.

Analysis:
This patch re-adds it.

Tests:
unit
functional