### PR TITLE
Makes the rules attribute return an empty list if it is not set

### DIFF
--- a/f5/bigip/tm/ltm/virtual.py
+++ b/f5/bigip/tm/ltm/virtual.py
@@ -58,6 +58,28 @@ class Virtual(Resource):
             {'tm:ltm:virtual:profiles:profilescollectionstate': Profiles_s,
              'tm:ltm:virtual:policies:policiescollectionstate': Policies_s}
 
+    def load(self, **kwargs):
+        result = self._load(**kwargs)
+        if not hasattr(result, 'rules'):
+            result.__dict__.update({'rules': []})
+        return result
+
+    def create(self, **kwargs):
+        result = self._create(**kwargs)
+        if not hasattr(result, 'rules'):
+            result.__dict__.update({'rules': []})
+        return result
+
+    def update(self, **kwargs):
+        result = self._update(**kwargs)
+        if not hasattr(result, 'rules'):
+            self.__dict__.update({'rules': []})
+
+    def modify(self, **kwargs):
+        result = self._modify(**kwargs)
+        if not hasattr(result, 'rules'):
+            self.__dict__.update({'rules': []})
+
 
 class Profiles(Resource):
     """BIG-IP® LTM profile resource"""


### PR DESCRIPTION
Issues:
Fixes #1170

Problem:
If there are no rules for a Virtual, the API will return no attribute.
This causes problems when wanting to loop through that.

Analysis:
So instead, the SDK will return just an empty list so that you dont need to catch
AttributeError exceptions

Tests:
functional