### PR TITLE
re-adds the csrf protection tests

### DIFF
--- a/f5/bigip/tm/asm/policies/test/functional/test_csrf_protection.py
+++ b/f5/bigip/tm/asm/policies/test/functional/test_csrf_protection.py
@@ -1,0 +1,56 @@
+# Copyright 2017 F5 Networks Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import pytest
+
+from distutils.version import LooseVersion
+from f5.sdk_exception import UnsupportedOperation
+
+
+@pytest.mark.skipif(
+    LooseVersion(pytest.config.getoption('--release')) < LooseVersion('11.6.0'),
+    reason='This collection is fully implemented on 11.6.0 or greater.'
+)
+class TestCsrfProtection(object):
+    def test_update_raises(self, policy):
+        with pytest.raises(UnsupportedOperation):
+            policy.csrf_protection.update()
+
+    def test_load(self, policy):
+        r1 = policy.csrf_protection.load()
+        assert r1.kind == 'tm:asm:policies:csrf-protection:csrf-protectionstate'
+        assert r1.enabled is False
+        assert not hasattr(r1, 'expirationTimeInSeconds')
+        r1.modify(enabled=True)
+        assert r1.enabled is True
+        assert hasattr(r1, 'expirationTimeInSeconds')
+        r2 = policy.csrf_protection.load()
+        assert r1.kind == r2.kind
+        assert r1.enabled == r2.enabled
+
+    def test_refresh(self, policy):
+        r1 = policy.csrf_protection.load()
+        assert r1.kind == 'tm:asm:policies:csrf-protection:csrf-protectionstate'
+        assert r1.enabled is False
+        assert not hasattr(r1, 'expirationTimeInSeconds')
+        r2 = policy.csrf_protection.load()
+        assert r1.kind == r2.kind
+        assert r1.enabled == r2.enabled
+        r2.modify(enabled=True)
+        assert r2.enabled is True
+        assert hasattr(r2, 'expirationTimeInSeconds')
+        r1.refresh()
+        assert r1.enabled is True
+        assert hasattr(r1, 'expirationTimeInSeconds')

--- a/f5/bigip/tm/asm/policies/test/unit/test_csrf_protection.py
+++ b/f5/bigip/tm/asm/policies/test/unit/test_csrf_protection.py
@@ -1,0 +1,35 @@
+# Copyright 2015 F5 Networks Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+from f5.bigip.tm.asm.policies.csrf_protection import Csrf_Protection
+from f5.sdk_exception import UnsupportedOperation
+
+
+import mock
+import pytest
+
+
+@pytest.fixture
+def FakeCsrf():
+    fake_policy = mock.MagicMock()
+    fake_resp = Csrf_Protection(fake_policy)
+    fake_resp._meta_data['bigip'].tmos_version = '11.6.0'
+    return fake_resp
+
+
+class TestCrfProtection(object):
+    def test_update_raises(self, FakeCsrf):
+        with pytest.raises(UnsupportedOperation):
+            FakeCsrf.update()


### PR DESCRIPTION
Issues:
Fixes #1208

Problem:
Tests were disabled

Analysis:
This enables them

Tests:
unit
functional