### PR TITLE
Fixes pip installs for python 3

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -16,20 +16,17 @@
 #
 
 import os
-
 import f5
 
-from pip.req import parse_requirements as parse_reqs
 from setuptools import find_packages
 from setuptools import setup
 
 if 'rpm' not in os.getcwd():
-    install_requires = map(lambda x: str(x.req),
-                           parse_reqs('./setup_requirements.txt',
-                           session='setup'))
+    with open('setup_requirements.txt') as fh:
+        required = [x for x in fh.read().splitlines() if not x.startswith('#')]
 else:
-    install_requires = []
-print('install_requires', install_requires)
+    required = []
+
 setup(
     name='f5-sdk',
     description='F5 Networks Python SDK',
@@ -39,7 +36,7 @@ setup(
     author_email='f5_common_python@f5.com',
     url='https://github.com/F5Networks/f5-common-python',
     keywords=['F5', 'sdk', 'api', 'icontrol', 'bigip', 'api', 'ltm'],
-    install_requires=install_requires,
+    install_requires=required,
     packages=find_packages(
         exclude=["*.test", "*.test.*", "test.*", "test_*", "test", "test*"]
     ),


### PR DESCRIPTION
Issues:
Fixes #1106

Problem:
The means by which dependencies was being determined was not working
in python 3. The pip API is not public, so we shouldn't be using it
as we were

Analysis:
This changes the means of looking up requirements to be similar,
but to not use the interal pip APIs to prevent breakage

Tests: