### PR TITLE
Removes generation tests from icall

### DIFF
--- a/f5/bigip/tm/sys/test/functional/test_icall.py
+++ b/f5/bigip/tm/sys/test/functional/test_icall.py
@@ -291,7 +291,6 @@ class Test_CULD_Periodic_Handler(object):
             request, mgmt_root, 'myhandler', 'Common')
         h2 = mgmt_root.tm.sys.icall.handler.periodics.periodic.load(
             name='myhandler', partition='Common')
-        assert h1.generation is not h2.generation
         assert h2.name == 'myhandler'
 
     def test_delete(self, request, mgmt_root):
@@ -335,7 +334,6 @@ class Test_CULD_Perpetual_Handler(object):
             request, mgmt_root, 'myhandler', 'Common')
         h2 = mgmt_root.tm.sys.icall.handler.perpetuals.perpetual.load(
             name='myhandler', partition='Common')
-        assert h1.generation is not h2.generation
         assert h2.name == 'myhandler'
 
     def test_delete(self, request, mgmt_root):
@@ -379,7 +377,6 @@ class Test_CULD_Triggered_Handler(object):
             request, mgmt_root, 'myhandler', 'Common')
         h2 = mgmt_root.tm.sys.icall.handler.triggered_s.triggered.load(
             name='myhandler', partition='Common')
-        assert h1.generation is not h2.generation
         assert h2.name == 'myhandler'
 
     def test_delete(self, request, mgmt_root):

--- a/f5/bigip/tm/sys/test/functional/test_icall.py
+++ b/f5/bigip/tm/sys/test/functional/test_icall.py
@@ -14,6 +14,7 @@
 #
 
 import pytest
+from distutils.version import LooseVersion
 
 from f5.sdk_exception import MissingRequiredCreationParameter
 from icontrol.exceptions import iControlUnexpectedHTTPError
@@ -302,6 +303,10 @@ class Test_CULD_Periodic_Handler(object):
                 name='myhandler', partition='Common')
         assert err.value.response.status_code == 404
 
+    @pytest.mark.skipif(
+        LooseVersion(pytest.config.getoption('--release')) < LooseVersion('12.0.0'),
+        reason='Needs v12.0.0 TMOS or greater to pass.'
+    )
     def test_update(self, request, mgmt_root):
         h1, s1 = setup_basic_periodic_handler_test(
             request, mgmt_root, 'myhandler', 'Common')


### PR DESCRIPTION
Issues:
Fixes #1262

Problem:
iCall tests include generation tests

Analysis:
This removes them

Tests:
functinal