### PR TITLE
Fixes broken "exists" method in 11.6.0

### DIFF
--- a/f5/bigip/tm/ltm/test/functional/test_virtual.py
+++ b/f5/bigip/tm/ltm/test/functional/test_virtual.py
@@ -163,6 +163,11 @@ class TestProfiles(object):
         # Check for existence with partition given
         p1.exists(name='http', partition='Common')
 
+    def test_profiles_known_invalid(self, request, mgmt_root):
+        v1, _ = setup_virtual_test(request, mgmt_root, 'Common', 'tv1')
+        p1 = v1.profiles_s.profiles.exists(name="asdasdasd", partition='Common')
+        assert p1 is False
+
 
 class TestPolicies(object):
     def test_policies(self, policy_setup, virtual_setup):

--- a/f5/bigip/tm/ltm/virtual.py
+++ b/f5/bigip/tm/ltm/virtual.py
@@ -81,7 +81,7 @@ class Virtual(Resource):
             self.__dict__.update({'rules': []})
 
 
-class Profiles(Resource):
+class Profiles(Resource, CheckExistenceMixin):
     """BIG-IP® LTM profile resource"""
     def __init__(self, Profiles_s):
         super(Profiles, self).__init__(Profiles_s)
@@ -89,6 +89,12 @@ class Profiles(Resource):
         self._meta_data['required_load_parameters'].update(('partition',))
         self._meta_data['required_json_kind'] =\
             "tm:ltm:virtual:profiles:profilesstate"
+
+    def _exists(self, **kwargs):
+        tmos_v = self._meta_data['bigip']._meta_data['tmos_version']
+        if LooseVersion(tmos_v) == LooseVersion('11.6.0'):
+            return self._check_existence_by_collection(self._meta_data['container'], kwargs['name'])
+        return super(Profiles, self)._exists(**kwargs)
 
 
 class Profiles_s(Collection):


### PR DESCRIPTION
Issues:
Fixes #1286

Problem:
The exists method will always return true on 11.6.0 because the REST
API does not accurately check if a virtual->profile resource exists when issuing a
GET

Analysis:
This patch adds functionality similar to the policies fixes that
are in virtual

Tests:
functional