### PR TITLE
Give twine a chance to use its reasonable defaults

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,7 +38,6 @@ deploy:
   - provider: pypi
     user: $PYPI_USER
     password: $PYPI_PASSWORD
-    server: https://pypi.python.org/pypi
     on:
       all_branches: true
       tags: true


### PR DESCRIPTION
Issues:
Fixes #1289

Problem:

Uploading f5-sdk-3.0.0.tar.gz
HTTPError: 410 Client Error: Gone (This API has been deprecated and
removed from legacy PyPI in favor of using the APIs available in the new
PyPI.org implementation of PyPI (located at https://pypi.org/). For more
information about migrating your use of this API to PyPI.org, please see
https://packaging.python.org/guides/migrating-to-pypi-org/#uploading.
For more information about the sunsetting of this API, please see
https://mail.python.org/pipermail/distutils-sig/2017-June/030766.html)
for url: https://pypi.python.org/pypi

Analysis:  This commit tests whether deleting a reference to the
deprecated API fixes the issue.

Tests:  Untested!