### PR TITLE
Adds auth_provider

### DIFF
--- a/f5/bigip/__init__.py
+++ b/f5/bigip/__init__.py
@@ -51,7 +51,8 @@ class BaseManagement(PathElement):
             timeout=kwargs.pop('timeout', 30),
             port=kwargs.pop('port', 443),
             icontrol_version=kwargs.pop('icontrol_version', ''),
-            token=kwargs.pop('token', False)
+            token=kwargs.pop('token', False),
+            auth_provider=kwargs.pop('auth_provider', None)
         )
         if kwargs:
             raise TypeError('Unexpected **kwargs: %r' % kwargs)
@@ -63,12 +64,17 @@ class BaseManagement(PathElement):
         return result
 
     def _get_icr_session(self, *args, **kwargs):
-        return iControlRESTSession(
+        params = dict(
             username=kwargs['username'],
             password=kwargs['password'],
-            timeout=kwargs['timeout'],
-            token=kwargs['token']
+            timeout=kwargs['timeout']
         )
+        if kwargs['auth_provider']:
+            params['auth_provider'] = kwargs['auth_provider']
+        else:
+            params['token'] = kwargs['token']
+        result = iControlRESTSession(**params)
+        return result
 
     def configure_meta_data(self, *args, **kwargs):
         self._meta_data = {

--- a/f5/bigiq/__init__.py
+++ b/f5/bigiq/__init__.py
@@ -31,12 +31,13 @@ class ManagementRoot(PathElement):
 
         # The BIG-IQ token is called "local", as opposed to BIG-IP's which
         # is called "tmos"
-        token = kwargs.pop('token', 'local')
+        auth_provider = kwargs.pop('auth_provider', 'local')
         if kwargs:
             raise TypeError('Unexpected **kwargs: %r' % kwargs)
         # _meta_data variable values
-        iCRS = iControlRESTSession(username, password, timeout=timeout,
-                                   token=token)
+        iCRS = iControlRESTSession(
+            username, password, timeout=timeout, auth_provider=auth_provider
+        )
         # define _meta_data
         self._meta_data = {
             'allowed_lazy_attributes': [Cm, Shared, Tm],

--- a/f5/bigiq/conftest.py
+++ b/f5/bigiq/conftest.py
@@ -20,4 +20,4 @@ import pytest
 @pytest.fixture(scope='module')
 def mgmt_root(opt_bigip, opt_username, opt_password, opt_port, opt_token):
     return ManagementRoot(opt_bigip, opt_username, opt_password,
-                          port=opt_port, token=opt_token)
+                          port=opt_port, auth_provider="local")

--- a/f5/bigiq/resource.py
+++ b/f5/bigiq/resource.py
@@ -37,7 +37,7 @@ class PathElement(BigIpPathElement):
 
     def __init__(self, container):
         super(PathElement, self).__init__(container)
-        self._meta_data['minimum_version'] = '5.0.0'
+        self._meta_data['minimum_version'] = '5.3.0'
 
 
 class Resource(BigIpResource, PathElement):


### PR DESCRIPTION
Issues:
Fixes #1325

Problem:
auth_provider specification was not available. Therefore, it was not possible
to authenticate to a BIG-IQ using different remote auths

Analysis:
This patch adds that after adding a patch to the f5-icontrol-rest-python repo

Tests: