### PR TITLE
Adds hard timeout for management initialization

### DIFF
--- a/devtools/bin/create-test-list.py
+++ b/devtools/bin/create-test-list.py
@@ -59,7 +59,8 @@ def determine_files_to_test(product, commit):
     results = []
     build_all = [
         'setup.py', 'f5/bigip/contexts.py', 'f5/bigip/mixins.py',
-        'f5/bigip/resource.py', 'f5sdk_plugins/fixtures.py'
+        'f5/bigip/resource.py', 'f5sdk_plugins/fixtures.py',
+        'f5/bigip/__init__.py'
     ]
     output_file = "pytest.{0}.jenkins.txt".format(product)
 

--- a/f5-sdk-dist/deb_dist/stdeb.cfg
+++ b/f5-sdk-dist/deb_dist/stdeb.cfg
@@ -4,3 +4,4 @@ Depends:
     python-six (<2.0.0), 
     python-f5-icontrol-rest (>=1.3.0), 
     python-f5-icontrol-rest (<2.0.0), 
+    python-eventlet (>=0.21.0), 

--- a/f5/bigip/test/functional/test__init__.py
+++ b/f5/bigip/test/functional/test__init__.py
@@ -15,6 +15,7 @@
 import pytest
 
 from f5.bigip import ManagementRoot
+from f5.sdk_exception import TimeoutError
 
 
 def test_invalid_args(opt_bigip, opt_username, opt_password, opt_port):
@@ -34,3 +35,10 @@ def test_tmos_version(mgmt_root):
         mgmt_root._meta_data['bigip']._meta_data['tmos_version']
     assert mgmt_root.tmos_version is not None
     assert mgmt_root._meta_data['bigip']._meta_data['tmos_version'] != ''
+
+
+def test_hard_timeout():
+    # The IP and port here are set to these values deliberately. They should never resolve.
+    with pytest.raises(TimeoutError) as ex:
+        ManagementRoot('10.255.255.1', 'foo', 'bar', port=81, timeout=1)
+    assert str(ex.value) == 'Timed out waiting for response'

--- a/f5/sdk_exception.py
+++ b/f5/sdk_exception.py
@@ -248,3 +248,7 @@ class RequiredOneOf(F5SDKError):
             errors.append(error)
         msg = message.format(' or '.join(errors))
         super(RequiredOneOf, self).__init__(msg)
+
+
+class TimeoutError(F5SDKError):
+    """Raised when hard-timeout (timeout keyword to ManagementRoot) is met"""

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,7 @@
 [bdist_rpm]
 release = 1
-requires = f5-icontrol-rest >= 1.3.0
-    f5-icontrol-rest < 2 
-    python-six >= 1.9 
-    python-six < 2 
+requires = six>=1.9.0
+    six<2.0.0
+    f5-icontrol-rest>=1.3.0
+    f5-icontrol-rest<2.0.0
+    eventlet>=0.21.0

--- a/setup_requirements.txt
+++ b/setup_requirements.txt
@@ -3,3 +3,4 @@ six>=1.9.0
 six<2.0.0
 f5-icontrol-rest>=1.3.0
 f5-icontrol-rest<2.0.0
+eventlet>=0.21.0


### PR DESCRIPTION
Issues:
Fixes #541

Problem:
The management root initialization may hang for longer than the
specified timeout value

Analysis:
The requests library's underlying urllib3 code is doing retries when
it fails to connect to a host or the connection is taking a long time.
If you have a timeout set (for example 5), the default retries is 10
and therefore your timeout is actually 50 seconds.

We can technically change this by providing a custom Retry() object
to the `from requests.adapters import HTTPAdapter` adapter, but that
would cause this retry to affect __all__ the API calls. We really
only want to override the initial management root `_get_tmos_version`
call.

So we use the eventlet package to override this. If eventlet is not
installed, the package will not be able to enforce this hard timeout
and will pass on trying.

By default, eventlet is installed with f5-sdk

Tests:
functional