### PR TITLE
# Update functional tests to reference mgmt_root instead of bigip

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -188,11 +188,10 @@ def USER(bigip):
     return n
 
 
-def _delete_pools_members(bigip, pool_records):
+def _delete_pools_members(mgmt_root, pool_records):
     for pr in pool_records:
-        if bigip.ltm.pools.pool.exists(partition=pr.partition, name=pr.name):
-            pool_inst = bigip.ltm.pools.pool.load(partition=pr.partition,
-                                                  name=pr.name)
+        if mgmt_root.tm.ltm.pools.pool.exists(partition=pr.partition, name=pr.name):
+            pool_inst = mgmt_root.tm.ltm.pools.pool.load(partition=pr.partition, name=pr.name)
             members_list = pool_inst.members_s.get_collection()
             pool_inst.delete()
             for mem_inst in members_list:
@@ -201,14 +200,13 @@ def _delete_pools_members(bigip, pool_records):
 
 @pytest.fixture
 def pool_factory():
-    def _setup_boilerplate(bigip, request, pool_records):
-        _delete_pools_members(bigip, pool_records)
+    def _setup_boilerplate(mgmt_root, request, pool_records):
+        _delete_pools_members(mgmt_root, pool_records)
         pool_registry = {}
         members_registry = {}
         for pr in pool_records:
             pool_registry[pr.name] =\
-                bigip.ltm.pools.pool.create(partition=pr.partition,
-                                            name=pr.name)
+                mgmt_root.tm.ltm.pools.pool.create(partition=pr.partition, name=pr.name)
             if pr.memberconfigs != (tuple(),):
                 members_collection = pool_registry[pr.name].members_s
                 for memconf in pr.memberconfigs:

--- a/f5/bigip/shared/test/functional/test_bigip_failover_state.py
+++ b/f5/bigip/shared/test/functional/test_bigip_failover_state.py
@@ -20,10 +20,10 @@ from f5.sdk_exception import UnsupportedMethod
 @pytest.mark.skipif(pytest.config.getoption('--release') != '12.0.0',
                     reason='Needs v12 TMOS to pass')
 class TestBigIPFailoverState(object):
-    def test_load(self, request, bigip):
-        a = bigip.shared.bigip_failover_state.load()
+    def test_load(self, request, mgmt_root):
+        a = mgmt_root.shared.bigip_failover_state.load()
         assert hasattr(a, 'generation')
 
-    def test_update(self, request, bigip):
+    def test_update(self, request, mgmt_root):
         with pytest.raises(UnsupportedMethod):
-            bigip.shared.bigip_failover_state.update()
+            mgmt_root.shared.bigip_failover_state.update()

--- a/f5/bigip/shared/test/functional/test_licensing.py
+++ b/f5/bigip/shared/test/functional/test_licensing.py
@@ -18,20 +18,20 @@ from f5.sdk_exception import UnsupportedMethod
 
 
 class TestActivation(object):
-    def test_load(self, request, bigip):
-        a = bigip.shared.licensing.activation.load()
+    def test_load(self, request, mgmt_root):
+        a = mgmt_root.tm.shared.licensing.activation.load()
         assert hasattr(a, 'generation')
 
-    def test_update(self, request, bigip):
+    def test_update(self, request, mgmt_root):
         with pytest.raises(UnsupportedMethod):
-            bigip.shared.licensing.activation.update()
+            mgmt_root.tm.shared.licensing.activation.update()
 
 
 class TestRegistration(object):
-    def test_load(self, request, bigip):
-        reg = bigip.shared.licensing.registration.load()
+    def test_load(self, request, mgmt_root):
+        reg = mgmt_root.tm.shared.licensing.registration.load()
         assert hasattr(reg, 'generation')
 
-    def test_update(self, request, bigip):
+    def test_update(self, request, mgmt_root):
         with pytest.raises(UnsupportedMethod):
-            bigip.shared.licensing.registration.update()
+            mgmt_root.tm.shared.licensing.registration.update()

--- a/f5/bigip/test/functional/test_requests_params.py
+++ b/f5/bigip/test/functional/test_requests_params.py
@@ -20,13 +20,13 @@ PoolConfig = namedtuple('PoolConfig', 'partition name memberconfigs')
 MemberConfig = namedtuple('MemberConfig', 'mempartition memname')
 
 
-def test_get_collection(request, bigip, pool_factory, opt_release):
+def test_get_collection(request, mgmt_root, pool_factory, opt_release):
     Pool1MemberConfigs = (MemberConfig('Common', '192.168.15.15:80'),
                           MemberConfig('Common', '192.168.16.16:8080'),)
     Pool1Config = PoolConfig('Common', 'TEST', Pool1MemberConfigs)
     test_pools = (Pool1Config,)
     pool_registry, member_registry =\
-        pool_factory(bigip, request, test_pools)
+        pool_factory(mgmt_root, request, test_pools)
     selfLinks = []
     for pool_inst in list(itervalues(pool_registry)):
         for mem in pool_inst.members_s.get_collection():
@@ -39,23 +39,23 @@ def test_get_collection(request, bigip, pool_factory, opt_release):
         '?ver='+opt_release
 
 
-def test_get_dollar_filtered_collection(request, bigip, pool_factory):
-    if bigip.sys.folders.folder.exists(name='za', partition=''):
-        bigip.sys.folders.folder.load(name='za', partition='')
+def test_get_dollar_filtered_collection(request, mgmt_root, pool_factory):
+    if mgmt_root.tm.sys.folders.folder.exists(name='za', partition=''):
+        mgmt_root.tm.sys.folders.folder.load(name='za', partition='')
     else:
-        bigip.sys.folders.folder.create(name='za', subPath='/')
+        mgmt_root.tm.sys.folders.folder.create(name='za', subPath='/')
     Pool1Config = PoolConfig('Common', 'TEST', ((),))
     Pool2Config = PoolConfig('za', 'TEST', ((),))
     test_pools = (Pool1Config, Pool2Config)
     pool_registry, member_registry =\
-        pool_factory(bigip, request, test_pools)
+        pool_factory(mgmt_root, request, test_pools)
     rp = {'params': '$filter=partition+eq+za'}
-    pools_in_za = bigip.ltm.pools.get_collection(requests_params=rp)
+    pools_in_za = mgmt_root.tm.ltm.pools.get_collection(requests_params=rp)
     muri = pools_in_za[0]._meta_data['uri']
     assert muri.endswith('/mgmt/tm/ltm/pool/~za~TEST/')
 
 
-def test_get_dollar_select_collection_properties(request, bigip, mgmt_root):
+def test_get_dollar_select_collection_properties(request, mgmt_root):
     http_profiles = mgmt_root.tm.ltm.profile.https
     without_select = http_profiles.get_collection()
     with_select = http_profiles.get_collection(

--- a/f5/bigip/tm/auth/test/functional/test_password_policy.py
+++ b/f5/bigip/tm/auth/test/functional/test_password_policy.py
@@ -17,14 +17,14 @@ import copy
 
 
 class TestPasswordPolicy(object):
-    def test_load(self, bigip):
-        password_policy = bigip.auth.password_policy.load()
+    def test_load(self, mgmt_root):
+        password_policy = mgmt_root.tm.auth.password_policy.load()
         assert password_policy.maxLoginFailures == 0
         password_policy.refresh()
         assert password_policy.maxLoginFailures == 0
 
-    def test_update(self, bigip):
-        password_policy = bigip.auth.password_policy.load()
+    def test_update(self, mgmt_root):
+        password_policy = mgmt_root.tm.auth.password_policy.load()
         password_policy.update(maxLoginFailures=10)
         assert password_policy.maxLoginFailures == 10
         password_policy.update(maxLoginFailures=0)

--- a/f5/bigip/tm/cm/test/functional/test_sync_status.py
+++ b/f5/bigip/tm/cm/test/functional/test_sync_status.py
@@ -15,8 +15,8 @@
 
 
 class TestSyncStatus(object):
-    def test_get_status(self, request, bigip):
-        sync_status = bigip.cm.sync_status
+    def test_get_status(self, request, mgmt_root):
+        sync_status = mgmt_root.tm.cm.sync_status
         assert sync_status._meta_data['uri'].endswith(
             "/mgmt/tm/cm/sync-status/")
         sync_status.refresh()

--- a/f5/bigip/tm/cm/test/functional/test_traffic_group.py
+++ b/f5/bigip/tm/cm/test/functional/test_traffic_group.py
@@ -20,7 +20,7 @@ from requests import HTTPError
 TEST_DESCR = "TEST DESCRIPTION"
 
 
-def setup_traffic_group_test(request, bigip, name, partition, **kwargs):
+def setup_traffic_group_test(request, mgmt_root, name, partition, **kwargs):
     def teardown():
         try:
             tg.delete()
@@ -28,7 +28,7 @@ def setup_traffic_group_test(request, bigip, name, partition, **kwargs):
             if err.response.status_code is not 404:
                 raise
     request.addfinalizer(teardown)
-    tg = bigip.cm.traffic_groups.traffic_group.create(
+    tg = mgmt_root.tm.cm.traffic_groups.traffic_group.create(
         name=name, partition=partition, **kwargs)
     return tg
 
@@ -40,29 +40,29 @@ class TestTrafficGroups(object):
         ) < LooseVersion('11.6.0'),
         reason='Skip test if on a version below 11.6.0. The '
         'mac attribute does not exist in 11.5.4.')
-    def test_device_list_11_6_and_greater(self, bigip):
-        groups = bigip.cm.traffic_groups.get_collection()
+    def test_device_list_11_6_and_greater(self, mgmt_root):
+        groups = mgmt_root.tm.cm.traffic_groups.get_collection()
         assert len(groups)
         assert groups[0].generation > 0
         assert hasattr(groups[0], 'mac')
 
-    def test_device_list_alternative(self, bigip):
+    def test_device_list_alternative(self, mgmt_root):
         '''An alternative to test above that works regardless of version.'''
-        groups = bigip.cm.traffic_groups.get_collection()
+        groups = mgmt_root.tm.cm.traffic_groups.get_collection()
         assert len(groups)
         assert groups[0].generation > 0
         assert hasattr(groups[0], 'isFloating')
 
 
 class TestDevice(object):
-    def test_device_CURDL(self, request, bigip):
+    def test_device_CURDL(self, request, mgmt_root):
         # Create and Delete are done by setup/teardown
         tg1 = setup_traffic_group_test(
-            request, bigip, 'test-tg', 'Common')
+            request, mgmt_root, 'test-tg', 'Common')
         assert tg1.generation > 0
 
         # Load
-        tg2 = bigip.cm.traffic_groups.traffic_group.load(
+        tg2 = mgmt_root.tm.cm.traffic_groups.traffic_group.load(
             name=tg1.name, partition=tg1.partition)
         assert tg1.generation == tg2.generation
 

--- a/f5/bigip/tm/gtm/test/functional/test_wideips.py
+++ b/f5/bigip/tm/gtm/test/functional/test_wideips.py
@@ -67,7 +67,7 @@ class HelperTest(object):
             self.delete_resource(resource)
 
         resourcecollection =\
-            getattr(getattr(getattr(mgmt_root, 'gtm'), 'wideips'),
+            getattr(getattr(getattr(mgmt_root.tm, 'gtm'), 'wideips'),
                     self.lowered)
         resource = getattr(resourcecollection, self.urielementname())
         self.delete_resource(resource)
@@ -77,9 +77,9 @@ class HelperTest(object):
         request.addfinalizer(teardown)
         return created, resourcecollection
 
-    def test_MCURDL(self, request, bigip, **kwargs):
+    def test_MCURDL(self, request, mgmt_root, **kwargs):
         # Testing create
-        res, rescollection = self.setup_test(request, bigip, **kwargs)
+        res, rescollection = self.setup_test(request, mgmt_root, **kwargs)
         assert res.name == self.test_name
         assert res.fullPath == '/Common/'+self.test_name
         assert res.generation and isinstance(res.generation, int)
@@ -115,8 +115,8 @@ class HelperTest(object):
         res2 = p2.load(partition=self.partition, name=self.test_name)
         assert res.selfLink == res2.selfLink
 
-    def test_collection(self, request, bigip, **kwargs):
-        res, rescollection = self.setup_test(request, bigip, **kwargs)
+    def test_collection(self, request, mgmt_root, **kwargs):
+        res, rescollection = self.setup_test(request, mgmt_root, **kwargs)
         assert res.name == self.test_name
         assert res.fullPath == '/Common/'+self.test_name
         assert res.generation and isinstance(res.generation, int)
@@ -145,10 +145,10 @@ class HelperTest(object):
     reason='This collection exists on 12.0.0 or greater.'
 )
 class TestWideipAtype(object):
-    def test_MCURDL_and_collection(self, request, bigip):
+    def test_MCURDL_and_collection(self, request, mgmt_root):
         wideip = HelperTest('A_s')
-        wideip.test_MCURDL(request, bigip)
-        wideip.test_collection(request, bigip)
+        wideip.test_MCURDL(request, mgmt_root)
+        wideip.test_collection(request, mgmt_root)
 
 
 @pytest.mark.skipif(
@@ -157,10 +157,10 @@ class TestWideipAtype(object):
     reason='This collection exists on 12.0.0 or greater.'
 )
 class TestWideipAaaaType(object):
-    def test_MCURDL_and_collection(self, request, bigip):
+    def test_MCURDL_and_collection(self, request, mgmt_root):
         wideip = HelperTest('Aaaas')
-        wideip.test_MCURDL(request, bigip)
-        wideip.test_collection(request, bigip)
+        wideip.test_MCURDL(request, mgmt_root)
+        wideip.test_collection(request, mgmt_root)
 
 
 @pytest.mark.skipif(
@@ -169,10 +169,10 @@ class TestWideipAaaaType(object):
     reason='This collection exists on 12.0.0 or greater.'
 )
 class TestWideipCnameType(object):
-    def test_MCURDL_and_collection(self, request, bigip):
+    def test_MCURDL_and_collection(self, request, mgmt_root):
         wideip = HelperTest('Cnames')
-        wideip.test_MCURDL(request, bigip)
-        wideip.test_collection(request, bigip)
+        wideip.test_MCURDL(request, mgmt_root)
+        wideip.test_collection(request, mgmt_root)
 
 
 @pytest.mark.skipif(
@@ -181,10 +181,10 @@ class TestWideipCnameType(object):
     reason='This collection exists on 12.0.0 or greater.'
 )
 class TestWideipMxType(object):
-    def test_MCURDL_and_collection(self, request, bigip):
+    def test_MCURDL_and_collection(self, request, mgmt_root):
         wideip = HelperTest('Mxs')
-        wideip.test_MCURDL(request, bigip)
-        wideip.test_collection(request, bigip)
+        wideip.test_MCURDL(request, mgmt_root)
+        wideip.test_collection(request, mgmt_root)
 
 
 @pytest.mark.skipif(
@@ -193,10 +193,10 @@ class TestWideipMxType(object):
     reason='This collection exists on 12.0.0 or greater.'
 )
 class TestWideipNaptrType(object):
-    def test_MCURDL_and_collection(self, request, bigip):
+    def test_MCURDL_and_collection(self, request, mgmt_root):
         wideip = HelperTest('Naptrs')
-        wideip.test_MCURDL(request, bigip)
-        wideip.test_collection(request, bigip)
+        wideip.test_MCURDL(request, mgmt_root)
+        wideip.test_collection(request, mgmt_root)
 
 
 @pytest.mark.skipif(
@@ -205,10 +205,10 @@ class TestWideipNaptrType(object):
     reason='This collection exists on 12.0.0 or greater.'
 )
 class TestWideipSrvType(object):
-    def test_MCURDL_and_collection(self, request, bigip):
+    def test_MCURDL_and_collection(self, request, mgmt_root):
         wideip = HelperTest('Srvs')
-        wideip.test_MCURDL(request, bigip)
-        wideip.test_collection(request, bigip)
+        wideip.test_MCURDL(request, mgmt_root)
+        wideip.test_collection(request, mgmt_root)
 
 # End of v12.x Tests
 

--- a/f5/bigip/tm/ltm/test/functional/test_monitor.py
+++ b/f5/bigip/tm/ltm/test/functional/test_monitor.py
@@ -17,8 +17,8 @@
 TESTDESCRIPTION = "TESTDESCRIPTION"
 
 
-def setup_basic_test(request, bigip):
-    monitor1 = bigip.ltm.monitor
+def setup_basic_test(request, mgmt_root):
+    monitor1 = mgmt_root.tm.ltm.monitor
     return monitor1
 
 
@@ -44,25 +44,25 @@ def delete_resource(resources):
             resource.delete()
 
 
-def setup_http_test(request, bigip, partition, name):
+def setup_http_test(request, mgmt_root, partition, name):
     def teardown():
         delete_resource(hc1)
     request.addfinalizer(teardown)
-    hc1 = bigip.ltm.monitor.https
+    hc1 = mgmt_root.tm.ltm.monitor.https
     http1 = hc1.http.create(name=name, partition=partition)
     return http1, hc1
 
 
 class TestMonitor(object):
-    def test_get_collection(self, request, bigip):
-        m1 = setup_basic_test(request, bigip)
+    def test_get_collection(self, request, mgmt_root):
+        m1 = setup_basic_test(request, mgmt_root)
         list_of_references = m1.get_collection()
         assert len(list_of_references) == 39
 
 
 class TestMonitorHTTP(object):
-    def test_http_create_refresh_update_delete_load(self, request, bigip):
-        http1, hc1 = setup_http_test(request, bigip, 'Common', 'test1')
+    def test_http_create_refresh_update_delete_load(self, request, mgmt_root):
+        http1, hc1 = setup_http_test(request, mgmt_root, 'Common', 'test1')
         assert http1.name == 'test1'
         http1.description = TESTDESCRIPTION
         http1.update()
@@ -77,18 +77,18 @@ class TestMonitorHTTP(object):
 # End HTTP Tests
 # Begin HTTPS Tests
 
-def setup_https_test(request, bigip, partition, name):
+def setup_https_test(request, mgmt_root, partition, name):
     def teardown():
         delete_resource(hc1)
     request.addfinalizer(teardown)
-    hc1 = bigip.ltm.monitor.https_s
+    hc1 = mgmt_root.tm.ltm.monitor.https_s
     https1 = hc1.https.create(name=name, partition=partition)
     return https1, hc1
 
 
 class TestMonitorHTTPS(object):
-    def test_https_create_refresh_update_delete_load(self, request, bigip):
-        https1, hc1 = setup_https_test(request, bigip, 'Common', 'httpstest')
+    def test_https_create_refresh_update_delete_load(self, request, mgmt_root):
+        https1, hc1 = setup_https_test(request, mgmt_root, 'Common', 'httpstest')
         assert https1.name == 'httpstest'
         https1.description = TESTDESCRIPTION
         https1.update()
@@ -103,18 +103,18 @@ class TestMonitorHTTPS(object):
 # End HTTPS Tests
 # Begin Diameter Tests
 
-def setup_diameter_test(request, bigip, partition, name):
+def setup_diameter_test(request, mgmt_root, partition, name):
     def teardown():
         delete_resource(hc1)
     request.addfinalizer(teardown)
-    hc1 = bigip.ltm.monitor.diameters
+    hc1 = mgmt_root.tm.ltm.monitor.diameters
     diameter1 = hc1.diameter.create(name=name, partition=partition)
     return diameter1, hc1
 
 
 class TestMonitorDiameter(object):
-    def test_diameter_create_refresh_update_delete_load(self, request, bigip):
-        diameter1, hc1 = setup_diameter_test(request, bigip, 'Common',
+    def test_diameter_create_refresh_update_delete_load(self, request, mgmt_root):
+        diameter1, hc1 = setup_diameter_test(request, mgmt_root, 'Common',
                                              'diametertest')
         assert diameter1.name == 'diametertest'
         diameter1.description = TESTDESCRIPTION
@@ -130,18 +130,18 @@ class TestMonitorDiameter(object):
 # End Diameter Tests
 # Begin DNS Tests
 
-def setup_dns_test(request, bigip, partition, name, qname):
+def setup_dns_test(request, mgmt_root, partition, name, qname):
     def teardown():
         delete_resource(hc1)
     request.addfinalizer(teardown)
-    hc1 = bigip.ltm.monitor.dns_s
+    hc1 = mgmt_root.tm.ltm.monitor.dns_s
     dns1 = hc1.dns.create(name=name, partition=partition, qname=qname)
     return dns1, hc1
 
 
 class TestMonitorDNS(object):
-    def test_dns_create_refresh_update_delete_load(self, request, bigip):
-        dns1, hc1 = setup_dns_test(request, bigip, 'Common', 'dnstest', 'aqna')
+    def test_dns_create_refresh_update_delete_load(self, request, mgmt_root):
+        dns1, hc1 = setup_dns_test(request, mgmt_root, 'Common', 'dnstest', 'aqna')
         assert dns1.name == 'dnstest'
         dns1.description = TESTDESCRIPTION
         dns1.update()
@@ -156,18 +156,18 @@ class TestMonitorDNS(object):
 # End DNS Tests
 # Begin External
 
-def setup_external_test(request, bigip, partition, name):
+def setup_external_test(request, mgmt_root, partition, name):
     def teardown():
         delete_resource(hc1)
     request.addfinalizer(teardown)
-    hc1 = bigip.ltm.monitor.externals
+    hc1 = mgmt_root.tm.ltm.monitor.externals
     external1 = hc1.external.create(name=name, partition=partition)
     return external1, hc1
 
 
 class TestMonitorExternal(object):
-    def test_external_create_refresh_update_delete_load(self, request, bigip):
-        external1, hc1 = setup_external_test(request, bigip, 'Common',
+    def test_external_create_refresh_update_delete_load(self, request, mgmt_root):
+        external1, hc1 = setup_external_test(request, mgmt_root, 'Common',
                                              'externaltest')
         assert external1.name == 'externaltest'
         external1.description = TESTDESCRIPTION
@@ -183,18 +183,18 @@ class TestMonitorExternal(object):
 # End External Tests
 # Begin FirePass
 
-def setup_firepass_test(request, bigip, partition, name):
+def setup_firepass_test(request, mgmt_root, partition, name):
     def teardown():
         delete_resource(hc1)
     request.addfinalizer(teardown)
-    hc1 = bigip.ltm.monitor.firepass_s
+    hc1 = mgmt_root.tm.ltm.monitor.firepass_s
     firepass1 = hc1.firepass.create(name=name, partition=partition)
     return firepass1, hc1
 
 
 class TestMonitorFirePass(object):
-    def test_firepass_create_refresh_update_delete_load(self, request, bigip):
-        firepass1, hc1 = setup_firepass_test(request, bigip, 'Common',
+    def test_firepass_create_refresh_update_delete_load(self, request, mgmt_root):
+        firepass1, hc1 = setup_firepass_test(request, mgmt_root, 'Common',
                                              'firepasstest')
         assert firepass1.name == 'firepasstest'
         firepass1.description = TESTDESCRIPTION
@@ -210,18 +210,18 @@ class TestMonitorFirePass(object):
 # End FirePass Tests
 # Begin FTP Tests
 
-def setup_ftp_test(request, bigip, partition, name):
+def setup_ftp_test(request, mgmt_root, partition, name):
     def teardown():
         delete_resource(hc1)
     request.addfinalizer(teardown)
-    hc1 = bigip.ltm.monitor.ftps
+    hc1 = mgmt_root.tm.ltm.monitor.ftps
     ftp1 = hc1.ftp.create(name=name, partition=partition)
     return ftp1, hc1
 
 
 class TestMonitorFTP(object):
-    def test_ftp_create_refresh_update_delete_load(self, request, bigip):
-        ftp1, hc1 = setup_ftp_test(request, bigip, 'Common', 'ftptest')
+    def test_ftp_create_refresh_update_delete_load(self, request, mgmt_root):
+        ftp1, hc1 = setup_ftp_test(request, mgmt_root, 'Common', 'ftptest')
         assert ftp1.name == 'ftptest'
         ftp1.description = TESTDESCRIPTION
         ftp1.update()
@@ -236,11 +236,11 @@ class TestMonitorFTP(object):
 # End FTP Tests
 # Begin GateWay-ICMP
 
-def setup_gateway_icmp_test(request, bigip, partition, name):
+def setup_gateway_icmp_test(request, mgmt_root, partition, name):
     def teardown():
         delete_resource(hc1)
     request.addfinalizer(teardown)
-    hc1 = bigip.ltm.monitor.gateway_icmps
+    hc1 = mgmt_root.tm.ltm.monitor.gateway_icmps
     gateway_icmp1 = hc1.gateway_icmp.create(name=name, partition=partition)
     return gateway_icmp1, hc1
 
@@ -248,10 +248,10 @@ def setup_gateway_icmp_test(request, bigip, partition, name):
 class TestMonitorGateWay_ICMP(object):
     def test_gateway_icmp_create_refresh_update_delete_load(self,
                                                             request,
-                                                            bigip):
+                                                            mgmt_root):
         gateway_icmp1, hc1 =\
             setup_gateway_icmp_test(request,
-                                    bigip,
+                                    mgmt_root,
                                     'Common',
                                     'gateway_icmptest')
         assert gateway_icmp1.name == 'gateway_icmptest'
@@ -269,18 +269,18 @@ class TestMonitorGateWay_ICMP(object):
 # End GateWay-ICMP
 # Begin ICMP
 
-def setup_icmp_test(request, bigip, partition, name):
+def setup_icmp_test(request, mgmt_root, partition, name):
     def teardown():
         delete_resource(hc1)
     request.addfinalizer(teardown)
-    hc1 = bigip.ltm.monitor.icmps
+    hc1 = mgmt_root.tm.ltm.monitor.icmps
     icmp1 = hc1.icmp.create(name=name, partition=partition)
     return icmp1, hc1
 
 
 class TestMonitorICMP(object):
-    def test_icmp_create_refresh_update_delete_load(self, request, bigip):
-        icmp1, hc1 = setup_icmp_test(request, bigip, 'Common', 'icmptest')
+    def test_icmp_create_refresh_update_delete_load(self, request, mgmt_root):
+        icmp1, hc1 = setup_icmp_test(request, mgmt_root, 'Common', 'icmptest')
         assert icmp1.name == 'icmptest'
         icmp1.description = TESTDESCRIPTION
         icmp1.update()
@@ -295,18 +295,18 @@ class TestMonitorICMP(object):
 # End ICMP
 # Begin IMAP
 
-def setup_imap_test(request, bigip, partition, name):
+def setup_imap_test(request, mgmt_root, partition, name):
     def teardown():
         delete_resource(hc1)
     request.addfinalizer(teardown)
-    hc1 = bigip.ltm.monitor.imaps
+    hc1 = mgmt_root.tm.ltm.monitor.imaps
     imap1 = hc1.imap.create(name=name, partition=partition)
     return imap1, hc1
 
 
 class TestMonitorIMAP(object):
-    def test_imap_create_refresh_update_delete_load(self, request, bigip):
-        imap1, hc1 = setup_imap_test(request, bigip, 'Common', 'imaptest')
+    def test_imap_create_refresh_update_delete_load(self, request, mgmt_root):
+        imap1, hc1 = setup_imap_test(request, mgmt_root, 'Common', 'imaptest')
         assert imap1.name == 'imaptest'
         imap1.description = TESTDESCRIPTION
         imap1.update()
@@ -321,19 +321,19 @@ class TestMonitorIMAP(object):
 # End IMAP
 # Begin InBand
 
-def setup_inband_test(request, bigip, partition, name):
+def setup_inband_test(request, mgmt_root, partition, name):
     def teardown():
         delete_resource(hc1)
     request.addfinalizer(teardown)
-    hc1 = bigip.ltm.monitor.inbands
+    hc1 = mgmt_root.tm.ltm.monitor.inbands
     inband1 = hc1.inband.create(name=name, partition=partition)
     return inband1, hc1
 
 
 class TestMonitorInBand(object):
-    def test_inband_create_refresh_update_delete_load(self, request, bigip):
+    def test_inband_create_refresh_update_delete_load(self, request, mgmt_root):
         inband1, hc1 =\
-            setup_inband_test(request, bigip, 'Common', 'inbandtest')
+            setup_inband_test(request, mgmt_root, 'Common', 'inbandtest')
         assert inband1.name == 'inbandtest'
         inband1.description = TESTDESCRIPTION
         inband1.update()
@@ -348,18 +348,18 @@ class TestMonitorInBand(object):
 # End InBand
 # Begin LDAP
 
-def setup_ldap_test(request, bigip, partition, name):
+def setup_ldap_test(request, mgmt_root, partition, name):
     def teardown():
         delete_resource(hc1)
     request.addfinalizer(teardown)
-    hc1 = bigip.ltm.monitor.ldaps
+    hc1 = mgmt_root.tm.ltm.monitor.ldaps
     ldap1 = hc1.ldap.create(name=name, partition=partition)
     return ldap1, hc1
 
 
 class TestMonitorLDAP(object):
-    def test_ldap_create_refresh_update_delete_load(self, request, bigip):
-        ldap1, hc1 = setup_ldap_test(request, bigip, 'Common', 'ldaptest')
+    def test_ldap_create_refresh_update_delete_load(self, request, mgmt_root):
+        ldap1, hc1 = setup_ldap_test(request, mgmt_root, 'Common', 'ldaptest')
         assert ldap1.name == 'ldaptest'
         ldap1.description = TESTDESCRIPTION
         ldap1.update()
@@ -374,11 +374,11 @@ class TestMonitorLDAP(object):
 # Begin Module-Score
 
 
-def setup_module_score_test(request, bigip, partition, name, snmpaddr):
+def setup_module_score_test(request, mgmt_root, partition, name, snmpaddr):
     def teardown():
         delete_resource(hc1)
     request.addfinalizer(teardown)
-    hc1 = bigip.ltm.monitor.module_scores
+    hc1 = mgmt_root.tm.ltm.monitor.module_scores
     creation_params = {'name': name,
                        'partition': partition,
                        'snmp-ip-address': snmpaddr}
@@ -388,10 +388,10 @@ def setup_module_score_test(request, bigip, partition, name, snmpaddr):
 
 class TestMonitorModule_Score(object):
     def test_module_score_create_refresh_update_delete_load(self, request,
-                                                            bigip):
+                                                            mgmt_root):
         module_score1, hc1 =\
             setup_module_score_test(request,
-                                    bigip,
+                                    mgmt_root,
                                     'Common',
                                     'module_scoretest',
                                     '9.9.9.9')
@@ -410,11 +410,11 @@ class TestMonitorModule_Score(object):
 # End Module-Score
 # Begin MSSQL
 
-def setup_mssql_test(request, bigip, partition, name):
+def setup_mssql_test(request, mgmt_root, partition, name):
     def teardown():
         delete_resource(hc1)
     request.addfinalizer(teardown)
-    hc1 = bigip.ltm.monitor.mssqls
+    hc1 = mgmt_root.tm.ltm.monitor.mssqls
     creation_params = {'name': name,
                        'partition': partition}
     mssql1 = hc1.mssql.create(**creation_params)
@@ -422,8 +422,8 @@ def setup_mssql_test(request, bigip, partition, name):
 
 
 class TestMonitorMSSQL(object):
-    def test_mssql_create_refresh_update_delete_load(self, request, bigip):
-        mssql1, hc1 = setup_mssql_test(request, bigip, 'Common', 'mssqltest')
+    def test_mssql_create_refresh_update_delete_load(self, request, mgmt_root):
+        mssql1, hc1 = setup_mssql_test(request, mgmt_root, 'Common', 'mssqltest')
         assert mssql1.name == 'mssqltest'
         mssql1.description = TESTDESCRIPTION
         mssql1.update()
@@ -438,11 +438,11 @@ class TestMonitorMSSQL(object):
 # End MSSQL
 # Begin MYSQL
 
-def setup_mysql_test(request, bigip, partition, name):
+def setup_mysql_test(request, mgmt_root, partition, name):
     def teardown():
         delete_resource(hc1)
     request.addfinalizer(teardown)
-    hc1 = bigip.ltm.monitor.mysqls
+    hc1 = mgmt_root.tm.ltm.monitor.mysqls
     creation_params = {'name': name,
                        'partition': partition}
     mysql1 = hc1.mysql.create(**creation_params)
@@ -450,8 +450,8 @@ def setup_mysql_test(request, bigip, partition, name):
 
 
 class TestMonitorMYSQL(object):
-    def test_mysql_create_refresh_update_delete_load(self, request, bigip):
-        mysql1, hc1 = setup_mysql_test(request, bigip, 'Common', 'mysqltest')
+    def test_mysql_create_refresh_update_delete_load(self, request, mgmt_root):
+        mysql1, hc1 = setup_mysql_test(request, mgmt_root, 'Common', 'mysqltest')
         assert mysql1.name == 'mysqltest'
         mysql1.description = TESTDESCRIPTION
         mysql1.update()
@@ -466,11 +466,11 @@ class TestMonitorMYSQL(object):
 # Begin NNTP
 
 
-def setup_nntp_test(request, bigip, partition, name):
+def setup_nntp_test(request, mgmt_root, partition, name):
     def teardown():
         delete_resource(hc1)
     request.addfinalizer(teardown)
-    hc1 = bigip.ltm.monitor.nntps
+    hc1 = mgmt_root.tm.ltm.monitor.nntps
     creation_params = {'name': name,
                        'partition': partition}
     nntp1 = hc1.nntp.create(**creation_params)
@@ -478,8 +478,8 @@ def setup_nntp_test(request, bigip, partition, name):
 
 
 class TestMonitorNNTP(object):
-    def test_nntp_create_refresh_update_delete_load(self, request, bigip):
-        nntp1, hc1 = setup_nntp_test(request, bigip, 'Common', 'nntptest')
+    def test_nntp_create_refresh_update_delete_load(self, request, mgmt_root):
+        nntp1, hc1 = setup_nntp_test(request, mgmt_root, 'Common', 'nntptest')
         assert nntp1.name == 'nntptest'
         nntp1.description = TESTDESCRIPTION
         nntp1.update()
@@ -494,11 +494,11 @@ class TestMonitorNNTP(object):
 # End NNTP
 # Begin NONE
 '''
-def setup_none_test(request, bigip, partition, name):
+def setup_none_test(request, mgmt_root, partition, name):
     def teardown():
         delete_resource(hc1)
     request.addfinalizer(teardown)
-    hc1 = bigip.ltm.monitor.nones
+    hc1 = mgmt_root.tm.ltm.monitor.nones
     none1 = hc1.none
     creation_params = {'name': name,
                        'partition': partition}
@@ -508,8 +508,8 @@ def setup_none_test(request, bigip, partition, name):
 
 class TestMonitorNONE(object):
     def test_none_create_refresh_update_delete_load(self, request,
-                                                            bigip):
-        none1, hc1 = setup_none_test(request, bigip, 'Common', 'nonetest')
+                                                            mgmt_root):
+        none1, hc1 = setup_none_test(request, mgmt_root, 'Common', 'nonetest')
         assert none1.name == 'nonetest'
         none1.description = TESTDESCRIPTION
         none1.update()
@@ -526,11 +526,11 @@ class TestMonitorNONE(object):
 # Begin Oracle
 
 
-def setup_oracle_test(request, bigip, partition, name):
+def setup_oracle_test(request, mgmt_root, partition, name):
     def teardown():
         delete_resource(hc1)
     request.addfinalizer(teardown)
-    hc1 = bigip.ltm.monitor.oracles
+    hc1 = mgmt_root.tm.ltm.monitor.oracles
     creation_params = {'name': name,
                        'partition': partition}
     oracle1 = hc1.oracle.create(**creation_params)
@@ -538,9 +538,9 @@ def setup_oracle_test(request, bigip, partition, name):
 
 
 class TestMonitorOracle(object):
-    def test_oracle_create_refresh_update_delete_load(self, request, bigip):
+    def test_oracle_create_refresh_update_delete_load(self, request, mgmt_root):
         oracle1, hc1 =\
-            setup_oracle_test(request, bigip, 'Common', 'oracletest')
+            setup_oracle_test(request, mgmt_root, 'Common', 'oracletest')
         assert oracle1.name == 'oracletest'
         oracle1.description = TESTDESCRIPTION
         oracle1.update()
@@ -555,11 +555,11 @@ class TestMonitorOracle(object):
 # End Oracle
 # Begin POP3
 
-def setup_pop3_test(request, bigip, partition, name):
+def setup_pop3_test(request, mgmt_root, partition, name):
     def teardown():
         delete_resource(hc1)
     request.addfinalizer(teardown)
-    hc1 = bigip.ltm.monitor.pop3s
+    hc1 = mgmt_root.tm.ltm.monitor.pop3s
     creation_params = {'name': name,
                        'partition': partition}
     pop31 = hc1.pop3.create(**creation_params)
@@ -567,8 +567,8 @@ def setup_pop3_test(request, bigip, partition, name):
 
 
 class TestMonitorPOP3(object):
-    def test_pop3_create_refresh_update_delete_load(self, request, bigip):
-        pop31, hc1 = setup_pop3_test(request, bigip, 'Common', 'pop3test')
+    def test_pop3_create_refresh_update_delete_load(self, request, mgmt_root):
+        pop31, hc1 = setup_pop3_test(request, mgmt_root, 'Common', 'pop3test')
         assert pop31.name == 'pop3test'
         pop31.description = TESTDESCRIPTION
         pop31.update()
@@ -583,11 +583,11 @@ class TestMonitorPOP3(object):
 # End POP3
 # Begin PostGRESQL
 
-def setup_postgresql_test(request, bigip, partition, name):
+def setup_postgresql_test(request, mgmt_root, partition, name):
     def teardown():
         delete_resource(hc1)
     request.addfinalizer(teardown)
-    hc1 = bigip.ltm.monitor.postgresqls
+    hc1 = mgmt_root.tm.ltm.monitor.postgresqls
     creation_params = {'name': name,
                        'partition': partition}
     postgresql1 = hc1.postgresql.create(**creation_params)
@@ -596,9 +596,9 @@ def setup_postgresql_test(request, bigip, partition, name):
 
 class TestMonitorPostGRESQL(object):
     def test_postgresql_create_refresh_update_delete_load(self, request,
-                                                          bigip):
+                                                          mgmt_root):
         postgresql1, hc1 =\
-            setup_postgresql_test(request, bigip, 'Common', 'postgresqltest')
+            setup_postgresql_test(request, mgmt_root, 'Common', 'postgresqltest')
         assert postgresql1.name == 'postgresqltest'
         postgresql1.description = TESTDESCRIPTION
         postgresql1.update()
@@ -614,11 +614,11 @@ class TestMonitorPostGRESQL(object):
 # End PostGRESQL
 # Begin Radius
 
-def setup_radius_test(request, bigip, partition, name):
+def setup_radius_test(request, mgmt_root, partition, name):
     def teardown():
         delete_resource(hc1)
     request.addfinalizer(teardown)
-    hc1 = bigip.ltm.monitor.radius_s
+    hc1 = mgmt_root.tm.ltm.monitor.radius_s
     creation_params = {'name': name,
                        'partition': partition}
     radius1 = hc1.radius.create(**creation_params)
@@ -626,9 +626,9 @@ def setup_radius_test(request, bigip, partition, name):
 
 
 class TestMonitorRadius(object):
-    def test_radius_create_refresh_update_delete_load(self, request, bigip):
+    def test_radius_create_refresh_update_delete_load(self, request, mgmt_root):
         radius1, hc1 =\
-            setup_radius_test(request, bigip, 'Common', 'radiustest')
+            setup_radius_test(request, mgmt_root, 'Common', 'radiustest')
         assert radius1.name == 'radiustest'
         radius1.description = TESTDESCRIPTION
         radius1.update()
@@ -643,11 +643,11 @@ class TestMonitorRadius(object):
 # End Radius
 # Begin Radius_Accounting
 
-def setup_radius_accounting_test(request, bigip, partition, name):
+def setup_radius_accounting_test(request, mgmt_root, partition, name):
     def teardown():
         delete_resource(hc1)
     request.addfinalizer(teardown)
-    hc1 = bigip.ltm.monitor.radius_accountings
+    hc1 = mgmt_root.tm.ltm.monitor.radius_accountings
     creation_params = {'name': name,
                        'partition': partition}
     radius_accounting1 = hc1.radius_accounting.create(**creation_params)
@@ -656,10 +656,10 @@ def setup_radius_accounting_test(request, bigip, partition, name):
 
 class TestMonitorRadius_Accounting(object):
     def test_radius_accounting_create_refresh_update_delete_load(self, request,
-                                                                 bigip):
+                                                                 mgmt_root):
         radius_accounting1, hc1 =\
             setup_radius_accounting_test(request,
-                                         bigip,
+                                         mgmt_root,
                                          'Common',
                                          'radius_accountingtest')
         assert radius_accounting1.name == 'radius_accountingtest'
@@ -678,11 +678,11 @@ class TestMonitorRadius_Accounting(object):
 # End Radius_Accounting
 # Begin Real_Server
 
-def setup_real_server_test(request, bigip, partition, name):
+def setup_real_server_test(request, mgmt_root, partition, name):
     def teardown():
         delete_resource(hc1)
     request.addfinalizer(teardown)
-    hc1 = bigip.ltm.monitor.real_servers
+    hc1 = mgmt_root.tm.ltm.monitor.real_servers
     creation_params = {'name': name,
                        'partition': partition}
     real_server1 = hc1.real_server.create(**creation_params)
@@ -691,9 +691,9 @@ def setup_real_server_test(request, bigip, partition, name):
 
 class TestMonitorReal_Server(object):
     def test_real_server_create_refresh_update_delete_load(self, request,
-                                                           bigip):
+                                                           mgmt_root):
         real_server1, hc1 =\
-            setup_real_server_test(request, bigip, 'Common', 'real_servertest')
+            setup_real_server_test(request, mgmt_root, 'Common', 'real_servertest')
         assert real_server1.name == 'real_servertest'
         real_server1.description = TESTDESCRIPTION
         real_server1.update()
@@ -709,11 +709,11 @@ class TestMonitorReal_Server(object):
 # End Real_Server
 # Begin RPC
 
-def setup_rpc_test(request, bigip, partition, name):
+def setup_rpc_test(request, mgmt_root, partition, name):
     def teardown():
         delete_resource(hc1)
     request.addfinalizer(teardown)
-    hc1 = bigip.ltm.monitor.rpcs
+    hc1 = mgmt_root.tm.ltm.monitor.rpcs
     creation_params = {'name': name,
                        'partition': partition}
     rpc1 = hc1.rpc.create(**creation_params)
@@ -721,8 +721,8 @@ def setup_rpc_test(request, bigip, partition, name):
 
 
 class TestMonitorRPC(object):
-    def test_rpc_create_refresh_update_delete_load(self, request, bigip):
-        rpc1, hc1 = setup_rpc_test(request, bigip, 'Common', 'rpctest')
+    def test_rpc_create_refresh_update_delete_load(self, request, mgmt_root):
+        rpc1, hc1 = setup_rpc_test(request, mgmt_root, 'Common', 'rpctest')
         assert rpc1.name == 'rpctest'
         rpc1.description = TESTDESCRIPTION
         rpc1.update()
@@ -737,11 +737,11 @@ class TestMonitorRPC(object):
 # End RPC
 # Begin SASP
 
-def setup_sasp_test(request, bigip, partition, name, primaryAddress='1.1.1.1'):
+def setup_sasp_test(request, mgmt_root, partition, name, primaryAddress='1.1.1.1'):
     def teardown():
         delete_resource(hc1)
     request.addfinalizer(teardown)
-    hc1 = bigip.ltm.monitor.sasps
+    hc1 = mgmt_root.tm.ltm.monitor.sasps
     creation_params = {'name': name,
                        'partition': partition,
                        'primaryAddress': primaryAddress}
@@ -750,8 +750,8 @@ def setup_sasp_test(request, bigip, partition, name, primaryAddress='1.1.1.1'):
 
 
 class TestMonitorSASP(object):
-    def test_sasp_create_refresh_update_delete_load(self, request, bigip):
-        sasp1, hc1 = setup_sasp_test(request, bigip, 'Common', 'sasptest')
+    def test_sasp_create_refresh_update_delete_load(self, request, mgmt_root):
+        sasp1, hc1 = setup_sasp_test(request, mgmt_root, 'Common', 'sasptest')
         assert sasp1.name == 'sasptest'
         sasp1.description = TESTDESCRIPTION
         sasp1.update()
@@ -766,11 +766,11 @@ class TestMonitorSASP(object):
 # End SASP
 # Begin Scripted
 
-def setup_scripted_test(request, bigip, partition, name):
+def setup_scripted_test(request, mgmt_root, partition, name):
     def teardown():
         delete_resource(hc1)
     request.addfinalizer(teardown)
-    hc1 = bigip.ltm.monitor.scripteds
+    hc1 = mgmt_root.tm.ltm.monitor.scripteds
     creation_params = {'name': name,
                        'partition': partition}
     scripted1 = hc1.scripted.create(**creation_params)
@@ -778,9 +778,9 @@ def setup_scripted_test(request, bigip, partition, name):
 
 
 class TestMonitorScripted(object):
-    def test_scripted_create_refresh_update_delete_load(self, request, bigip):
+    def test_scripted_create_refresh_update_delete_load(self, request, mgmt_root):
         scripted1, hc1 =\
-            setup_scripted_test(request, bigip, 'Common', 'scriptedtest')
+            setup_scripted_test(request, mgmt_root, 'Common', 'scriptedtest')
         assert scripted1.name == 'scriptedtest'
         scripted1.description = TESTDESCRIPTION
         scripted1.update()
@@ -796,11 +796,11 @@ class TestMonitorScripted(object):
 # End Scripted
 # Begin SIP
 
-def setup_sip_test(request, bigip, partition, name):
+def setup_sip_test(request, mgmt_root, partition, name):
     def teardown():
         delete_resource(hc1)
     request.addfinalizer(teardown)
-    hc1 = bigip.ltm.monitor.sips
+    hc1 = mgmt_root.tm.ltm.monitor.sips
     creation_params = {'name': name,
                        'partition': partition}
     sip1 = hc1.sip.create(**creation_params)
@@ -808,8 +808,8 @@ def setup_sip_test(request, bigip, partition, name):
 
 
 class TestMonitorSIP(object):
-    def test_sip_create_refresh_update_delete_load(self, request, bigip):
-        sip1, hc1 = setup_sip_test(request, bigip, 'Common', 'siptest')
+    def test_sip_create_refresh_update_delete_load(self, request, mgmt_root):
+        sip1, hc1 = setup_sip_test(request, mgmt_root, 'Common', 'siptest')
         assert sip1.name == 'siptest'
         sip1.description = TESTDESCRIPTION
         sip1.update()
@@ -824,11 +824,11 @@ class TestMonitorSIP(object):
 # End SIP
 # Begin SMB
 
-def setup_smb_test(request, bigip, partition, name):
+def setup_smb_test(request, mgmt_root, partition, name):
     def teardown():
         delete_resource(hc1)
     request.addfinalizer(teardown)
-    hc1 = bigip.ltm.monitor.smbs
+    hc1 = mgmt_root.tm.ltm.monitor.smbs
     creation_params = {'name': name,
                        'partition': partition}
     smb1 = hc1.smb.create(**creation_params)
@@ -836,8 +836,8 @@ def setup_smb_test(request, bigip, partition, name):
 
 
 class TestMonitorSMB(object):
-    def test_smb_create_refresh_update_delete_load(self, request, bigip):
-        smb1, hc1 = setup_smb_test(request, bigip, 'Common', 'smbtest')
+    def test_smb_create_refresh_update_delete_load(self, request, mgmt_root):
+        smb1, hc1 = setup_smb_test(request, mgmt_root, 'Common', 'smbtest')
         assert smb1.name == 'smbtest'
         smb1.description = TESTDESCRIPTION
         smb1.update()
@@ -852,11 +852,11 @@ class TestMonitorSMB(object):
 # End SMB
 # Begin SMTP
 
-def setup_smtp_test(request, bigip, partition, name):
+def setup_smtp_test(request, mgmt_root, partition, name):
     def teardown():
         delete_resource(hc1)
     request.addfinalizer(teardown)
-    hc1 = bigip.ltm.monitor.smtps
+    hc1 = mgmt_root.tm.ltm.monitor.smtps
     creation_params = {'name': name,
                        'partition': partition}
     smtp1 = hc1.smtp.create(**creation_params)
@@ -864,8 +864,8 @@ def setup_smtp_test(request, bigip, partition, name):
 
 
 class TestMonitorSMTP(object):
-    def test_smtp_create_refresh_update_delete_load(self, request, bigip):
-        smtp1, hc1 = setup_smtp_test(request, bigip, 'Common', 'smtptest')
+    def test_smtp_create_refresh_update_delete_load(self, request, mgmt_root):
+        smtp1, hc1 = setup_smtp_test(request, mgmt_root, 'Common', 'smtptest')
         assert smtp1.name == 'smtptest'
         smtp1.description = TESTDESCRIPTION
         smtp1.update()
@@ -880,11 +880,11 @@ class TestMonitorSMTP(object):
 # End SMTP
 # Begin SNMP_DCA
 
-def setup_snmp_dca_test(request, bigip, partition, name):
+def setup_snmp_dca_test(request, mgmt_root, partition, name):
     def teardown():
         delete_resource(hc1)
     request.addfinalizer(teardown)
-    hc1 = bigip.ltm.monitor.snmp_dcas
+    hc1 = mgmt_root.tm.ltm.monitor.snmp_dcas
     creation_params = {'name': name,
                        'partition': partition}
     snmp_dca1 = hc1.snmp_dca.create(**creation_params)
@@ -892,9 +892,9 @@ def setup_snmp_dca_test(request, bigip, partition, name):
 
 
 class TestMonitorSNMP_DCA(object):
-    def test_snmp_dca_create_refresh_update_delete_load(self, request, bigip):
+    def test_snmp_dca_create_refresh_update_delete_load(self, request, mgmt_root):
         snmp_dca1, hc1 =\
-            setup_snmp_dca_test(request, bigip, 'Common', 'snmp_dcatest')
+            setup_snmp_dca_test(request, mgmt_root, 'Common', 'snmp_dcatest')
         assert snmp_dca1.name == 'snmp_dcatest'
         snmp_dca1.description = TESTDESCRIPTION
         snmp_dca1.update()
@@ -909,11 +909,11 @@ class TestMonitorSNMP_DCA(object):
 # End SNMP_DCA
 # Begin SNMP_DCA_Base
 
-def setup_snmp_dca_base_test(request, bigip, partition, name):
+def setup_snmp_dca_base_test(request, mgmt_root, partition, name):
     def teardown():
         delete_resource(hc1)
     request.addfinalizer(teardown)
-    hc1 = bigip.ltm.monitor.snmp_dca_bases
+    hc1 = mgmt_root.tm.ltm.monitor.snmp_dca_bases
     creation_params = {'name': name,
                        'partition': partition}
     snmp_dca_base1 = hc1.snmp_dca_base.create(**creation_params)
@@ -922,10 +922,10 @@ def setup_snmp_dca_base_test(request, bigip, partition, name):
 
 class TestMonitorSNMP_DCA_Base(object):
     def test_snmp_dca_base_create_refresh_update_delete_load(self, request,
-                                                             bigip):
+                                                             mgmt_root):
         snmp_dca_base1, hc1 =\
             setup_snmp_dca_base_test(request,
-                                     bigip,
+                                     mgmt_root,
                                      'Common',
                                      'snmp_dca_basetest')
         assert snmp_dca_base1.name == 'snmp_dca_basetest'
@@ -944,11 +944,11 @@ class TestMonitorSNMP_DCA_Base(object):
 # End SNMP_DCA_Base
 # Begin SOAP
 
-def setup_soap_test(request, bigip, partition, name):
+def setup_soap_test(request, mgmt_root, partition, name):
     def teardown():
         delete_resource(hc1)
     request.addfinalizer(teardown)
-    hc1 = bigip.ltm.monitor.soaps
+    hc1 = mgmt_root.tm.ltm.monitor.soaps
     creation_params = {'name': name,
                        'partition': partition}
     soap1 = hc1.soap.create(**creation_params)
@@ -956,8 +956,8 @@ def setup_soap_test(request, bigip, partition, name):
 
 
 class TestMonitorSOAP(object):
-    def test_soap_create_refresh_update_delete_load(self, request, bigip):
-        soap1, hc1 = setup_soap_test(request, bigip, 'Common', 'soaptest')
+    def test_soap_create_refresh_update_delete_load(self, request, mgmt_root):
+        soap1, hc1 = setup_soap_test(request, mgmt_root, 'Common', 'soaptest')
         assert soap1.name == 'soaptest'
         soap1.description = TESTDESCRIPTION
         soap1.update()
@@ -972,11 +972,11 @@ class TestMonitorSOAP(object):
 # End SOAP
 # Begin TCP
 
-def setup_tcp_test(request, bigip, partition, name):
+def setup_tcp_test(request, mgmt_root, partition, name):
     def teardown():
         delete_resource(hc1)
     request.addfinalizer(teardown)
-    hc1 = bigip.ltm.monitor.tcps
+    hc1 = mgmt_root.tm.ltm.monitor.tcps
     creation_params = {'name': name,
                        'partition': partition}
     tcp1 = hc1.tcp.create(**creation_params)
@@ -984,8 +984,8 @@ def setup_tcp_test(request, bigip, partition, name):
 
 
 class TestMonitorTCP(object):
-    def test_tcp_create_refresh_update_delete_load(self, request, bigip):
-        tcp1, hc1 = setup_tcp_test(request, bigip, 'Common', 'tcptest')
+    def test_tcp_create_refresh_update_delete_load(self, request, mgmt_root):
+        tcp1, hc1 = setup_tcp_test(request, mgmt_root, 'Common', 'tcptest')
         assert tcp1.name == 'tcptest'
         tcp1.description = TESTDESCRIPTION
         tcp1.update()
@@ -1000,11 +1000,11 @@ class TestMonitorTCP(object):
 # End TCP
 # Begin TCP_Echo
 
-def setup_tcp_echo_test(request, bigip, partition, name):
+def setup_tcp_echo_test(request, mgmt_root, partition, name):
     def teardown():
         delete_resource(hc1)
     request.addfinalizer(teardown)
-    hc1 = bigip.ltm.monitor.tcp_echos
+    hc1 = mgmt_root.tm.ltm.monitor.tcp_echos
     creation_params = {'name': name,
                        'partition': partition}
     tcp_echo1 = hc1.tcp_echo.create(**creation_params)
@@ -1012,9 +1012,9 @@ def setup_tcp_echo_test(request, bigip, partition, name):
 
 
 class TestMonitorTCP_Echo(object):
-    def test_tcp_echo_create_refresh_update_delete_load(self, request, bigip):
+    def test_tcp_echo_create_refresh_update_delete_load(self, request, mgmt_root):
         tcp_echo1, hc1 =\
-            setup_tcp_echo_test(request, bigip, 'Common', 'tcp_echotest')
+            setup_tcp_echo_test(request, mgmt_root, 'Common', 'tcp_echotest')
         assert tcp_echo1.name == 'tcp_echotest'
         tcp_echo1.description = TESTDESCRIPTION
         tcp_echo1.update()
@@ -1029,11 +1029,11 @@ class TestMonitorTCP_Echo(object):
 # End TCP_Echo
 # Begin TCP_Half_Open
 
-def setup_tcp_half_open_test(request, bigip, partition, name):
+def setup_tcp_half_open_test(request, mgmt_root, partition, name):
     def teardown():
         delete_resource(hc1)
     request.addfinalizer(teardown)
-    hc1 = bigip.ltm.monitor.tcp_half_opens
+    hc1 = mgmt_root.tm.ltm.monitor.tcp_half_opens
     creation_params = {'name': name,
                        'partition': partition}
     tcp_half_open1 = hc1.tcp_half_open.create(**creation_params)
@@ -1042,10 +1042,10 @@ def setup_tcp_half_open_test(request, bigip, partition, name):
 
 class TestMonitorTCP_Half_Open(object):
     def test_tcp_half_open_create_refresh_update_delete_load(self, request,
-                                                             bigip):
+                                                             mgmt_root):
         tcp_half_open1, hc1 =\
             setup_tcp_half_open_test(request,
-                                     bigip,
+                                     mgmt_root,
                                      'Common',
                                      'tcp_half_opentest')
         assert tcp_half_open1.name == 'tcp_half_opentest'
@@ -1063,11 +1063,11 @@ class TestMonitorTCP_Half_Open(object):
 # End TCP_Half_Open
 # Begin UDP
 
-def setup_udp_test(request, bigip, partition, name):
+def setup_udp_test(request, mgmt_root, partition, name):
     def teardown():
         delete_resource(hc1)
     request.addfinalizer(teardown)
-    hc1 = bigip.ltm.monitor.udps
+    hc1 = mgmt_root.tm.ltm.monitor.udps
     creation_params = {'name': name,
                        'partition': partition}
     udp1 = hc1.udp.create(**creation_params)
@@ -1075,8 +1075,8 @@ def setup_udp_test(request, bigip, partition, name):
 
 
 class TestMonitorUDP(object):
-    def test_udp_create_refresh_update_delete_load(self, request, bigip):
-        udp1, hc1 = setup_udp_test(request, bigip, 'Common', 'udptest')
+    def test_udp_create_refresh_update_delete_load(self, request, mgmt_root):
+        udp1, hc1 = setup_udp_test(request, mgmt_root, 'Common', 'udptest')
         assert udp1.name == 'udptest'
         udp1.description = TESTDESCRIPTION
         udp1.update()
@@ -1091,11 +1091,11 @@ class TestMonitorUDP(object):
 # End UDP
 # Begin Virtual_Location
 
-def setup_virtual_location_test(request, bigip, partition, name, pool='tp1'):
+def setup_virtual_location_test(request, mgmt_root, partition, name, pool='tp1'):
     def teardown():
         delete_resource(hc1)
     request.addfinalizer(teardown)
-    hc1 = bigip.ltm.monitor.virtual_locations
+    hc1 = mgmt_root.tm.ltm.monitor.virtual_locations
     creation_params = {'name': name,
                        'partition': partition,
                        'pool': pool}
@@ -1105,10 +1105,10 @@ def setup_virtual_location_test(request, bigip, partition, name, pool='tp1'):
 
 class TestMonitorVirtual_Location(object):
     def test_virtual_location_create_refresh_update_delete_load(self, request,
-                                                                bigip):
+                                                                mgmt_root):
         virtual_location1, hc1 =\
             setup_virtual_location_test(request,
-                                        bigip,
+                                        mgmt_root,
                                         'Common',
                                         'virtual_locationtest')
         assert virtual_location1.name == 'virtual_locationtest'
@@ -1127,11 +1127,11 @@ class TestMonitorVirtual_Location(object):
 # End Virtual_Location
 # Begin WAP
 
-def setup_wap_test(request, bigip, partition, name):
+def setup_wap_test(request, mgmt_root, partition, name):
     def teardown():
         delete_resource(hc1)
     request.addfinalizer(teardown)
-    hc1 = bigip.ltm.monitor.waps
+    hc1 = mgmt_root.tm.ltm.monitor.waps
     creation_params = {'name': name,
                        'partition': partition}
     wap1 = hc1.wap.create(**creation_params)
@@ -1139,8 +1139,8 @@ def setup_wap_test(request, bigip, partition, name):
 
 
 class TestMonitorWAP(object):
-    def test_wap_create_refresh_update_delete_load(self, request, bigip):
-        wap1, hc1 = setup_wap_test(request, bigip, 'Common', 'waptest')
+    def test_wap_create_refresh_update_delete_load(self, request, mgmt_root):
+        wap1, hc1 = setup_wap_test(request, mgmt_root, 'Common', 'waptest')
         assert wap1.name == 'waptest'
         wap1.description = TESTDESCRIPTION
         wap1.update()
@@ -1155,11 +1155,11 @@ class TestMonitorWAP(object):
 # End WAP
 # Begin WMI
 
-def setup_wmi_test(request, bigip, partition, name):
+def setup_wmi_test(request, mgmt_root, partition, name):
     def teardown():
         delete_resource(hc1)
     request.addfinalizer(teardown)
-    hc1 = bigip.ltm.monitor.wmis
+    hc1 = mgmt_root.tm.ltm.monitor.wmis
     creation_params = {'name': name,
                        'partition': partition}
     wmi1 = hc1.wmi.create(**creation_params)
@@ -1167,8 +1167,8 @@ def setup_wmi_test(request, bigip, partition, name):
 
 
 class TestMonitorWMI(object):
-    def test_wmi_create_refresh_update_delete_load(self, request, bigip):
-        wmi1, hc1 = setup_wmi_test(request, bigip, 'Common', 'wmitest')
+    def test_wmi_create_refresh_update_delete_load(self, request, mgmt_root):
+        wmi1, hc1 = setup_wmi_test(request, mgmt_root, 'Common', 'wmitest')
         assert wmi1.name == 'wmitest'
         wmi1.description = TESTDESCRIPTION
         wmi1.update()

--- a/f5/bigip/tm/ltm/test/functional/test_nat.py
+++ b/f5/bigip/tm/ltm/test/functional/test_nat.py
@@ -19,9 +19,9 @@ from f5.sdk_exception import MissingRequiredCreationParameter
 from requests.exceptions import HTTPError
 
 
-def delete_nat(bigip, name, partition):
+def delete_nat(mgmt_root, name, partition):
     try:
-        nat = bigip.ltm.nats.nat.load(name=name, partition=partition)
+        nat = mgmt_root.tm.ltm.nats.nat.load(name=name, partition=partition)
     except HTTPError as err:
         if err.response.status_code != 404:
             raise
@@ -29,9 +29,9 @@ def delete_nat(bigip, name, partition):
     nat.delete()
 
 
-def setup_loadable_nat_test(request, bigip, nat):
+def setup_loadable_nat_test(request, mgmt_root, nat):
     def teardown():
-        delete_nat(bigip, 'nat1', 'Common')
+        delete_nat(mgmt_root, 'nat1', 'Common')
 
     request.addfinalizer(teardown)
 
@@ -41,28 +41,28 @@ def setup_loadable_nat_test(request, bigip, nat):
     assert nat1.name == 'nat1'
 
 
-def setup_create_test(request, bigip):
+def setup_create_test(request, mgmt_root):
     def teardown():
-        delete_nat(bigip, 'nat1', 'Common')
+        delete_nat(mgmt_root, 'nat1', 'Common')
     request.addfinalizer(teardown)
 
 
-def setup_create_two(request, bigip):
+def setup_create_two(request, mgmt_root):
     def teardown():
         for name in ['nat1', 'nat2']:
-            delete_nat(bigip, name, 'Common')
+            delete_nat(mgmt_root, name, 'Common')
     request.addfinalizer(teardown)
 
 
 class TestCreate(object):
-    def test_create_two(self, request, bigip):
-        setup_create_two(request, bigip)
+    def test_create_two(self, request, mgmt_root):
+        setup_create_two(request, mgmt_root)
 
-        n1 = bigip.ltm.nats.nat.create(
+        n1 = mgmt_root.tm.ltm.nats.nat.create(
             name='nat1', partition='Common',
             translationAddress='192.168.1.1',
             originatingAddress='192.168.2.1')
-        n2 = bigip.ltm.nats.nat.create(
+        n2 = mgmt_root.tm.ltm.nats.nat.create(
             name='nat2', partition='Common',
             translationAddress='192.168.1.2',
             originatingAddress='192.168.2.2')
@@ -70,20 +70,20 @@ class TestCreate(object):
         assert n1 is not n2
         assert n2.name != n1.name
 
-    def test_create_no_args(self, bigip):
+    def test_create_no_args(self, mgmt_root):
         '''Test that nat.create() with no options throws a ValueError '''
         with pytest.raises(MissingRequiredCreationParameter):
-            bigip.ltm.nats.nat.create()
+            mgmt_root.tm.ltm.nats.nat.create()
 
-    def test_create_min_args(self, request, bigip):
+    def test_create_min_args(self, request, mgmt_root):
         '''Test that nat.create() with only required arguments work.
 
         This will also test that the default values are set correctly and are
-        part of the nat object after creating the instance on the BigIP
+        part of the nat object after creating the instance on the mgmt_root
         '''
-        setup_create_test(request, bigip)
+        setup_create_test(request, mgmt_root)
 
-        nat1 = bigip.ltm.nats.nat.create(
+        nat1 = mgmt_root.tm.ltm.nats.nat.create(
             name='nat1', partition='Common',
             translationAddress='192.168.1.1',
             originatingAddress='192.168.2.1')
@@ -105,84 +105,84 @@ class TestCreate(object):
         assert nat1.unit is not None and isinstance(nat1.unit, int)
         assert nat1.vlansDisabled is True
 
-    def test_create_arp_enabled(self, request, bigip, NAT):
-        setup_create_test(request, bigip)
+    def test_create_arp_enabled(self, request, mgmt_root, NAT):
+        setup_create_test(request, mgmt_root)
         n1 = NAT.create(name='nat1', partition='Common',
                         translationAddress='192.168.1.1',
                         originatingAddress='192.168.2.1',
                         arp='enabled')
         assert n1.arp == 'enabled'
 
-    def test_create_arp_disabled(self, request, bigip, NAT):
-        setup_create_test(request, bigip)
+    def test_create_arp_disabled(self, request, mgmt_root, NAT):
+        setup_create_test(request, mgmt_root)
         n1 = NAT.create(name='nat1', partition='Common',
                         translationAddress='192.168.1.1',
                         originatingAddress='192.168.2.1',
                         arp='disabled')
         assert n1.arp == 'disabled'
 
-    def test_create_autolasthop_default(self, request, bigip, NAT):
-        setup_create_test(request, bigip)
+    def test_create_autolasthop_default(self, request, mgmt_root, NAT):
+        setup_create_test(request, mgmt_root)
         n1 = NAT.create(name='nat1', partition='Common',
                         translationAddress='192.168.1.1',
                         originatingAddress='192.168.2.1',
                         autoLasthop='default')
         assert n1.autoLasthop == 'default'
 
-    def test_create_autolasthop_enabled(self, request, bigip, NAT):
-        setup_create_test(request, bigip)
+    def test_create_autolasthop_enabled(self, request, mgmt_root, NAT):
+        setup_create_test(request, mgmt_root)
         n1 = NAT.create(name='nat1', partition='Common',
                         translationAddress='192.168.1.1',
                         originatingAddress='192.168.2.1',
                         autoLasthop='enabled')
         assert n1.autoLasthop == 'enabled'
 
-    def test_create_autolasthop_disabled(self, request, bigip, NAT):
-        setup_create_test(request, bigip)
+    def test_create_autolasthop_disabled(self, request, mgmt_root, NAT):
+        setup_create_test(request, mgmt_root)
         n1 = NAT.create(name='nat1', partition='Common',
                         translationAddress='192.168.1.1',
                         originatingAddress='192.168.2.1',
                         autoLasthop='disabled')
         assert n1.autoLasthop == 'disabled'
 
-    def test_create_enabled_true(self, request, bigip, NAT):
-        setup_create_test(request, bigip)
+    def test_create_enabled_true(self, request, mgmt_root, NAT):
+        setup_create_test(request, mgmt_root)
         n1 = NAT.create(name='nat1', partition='Common',
                         translationAddress='192.168.1.1',
                         originatingAddress='192.168.2.1',
                         enabled=True)
         assert n1.enabled is True
 
-    def itest_create_enabled_false(self, request, bigip, NAT):
+    def itest_create_enabled_false(self, request, mgmt_root, NAT):
         '''Test that you can set enabled to false and create nat as disabled
 
         This will fail until some fixups are made to the create function for
-        nat because in BIGIP you need to set disabled to True to disable it
+        nat because in mgmt_root you need to set disabled to True to disable it
         and not use enable at all.
         '''
-        setup_create_test(request, bigip)
+        setup_create_test(request, mgmt_root)
         n1 = NAT.create(name='nat1', partition='Common',
                         translationAddress='192.168.1.1',
                         originatingAddress='192.168.2.1',
                         enabled=False)
         assert n1.enabled is False
 
-    def test_create_disabled_true(self, request, bigip, NAT):
-        setup_create_test(request, bigip)
+    def test_create_disabled_true(self, request, mgmt_root, NAT):
+        setup_create_test(request, mgmt_root)
         n1 = NAT.create(name='nat1', partition='Common',
                         translationAddress='192.168.1.1',
                         originatingAddress='192.168.2.1',
                         disabled=True)
         assert n1.disabled is True
 
-    def test_create_disabled_false(self, request, bigip, NAT):
+    def test_create_disabled_false(self, request, mgmt_root, NAT):
         '''Test that you can set enabled to false and create nat as disabled
 
         This will fail until some fixups are made to the create function for
-        nat because in BIGIP you need to set disabled to True to disable it
+        nat because in mgmt_root you need to set disabled to True to disable it
         and not use enable at all.
         '''
-        setup_create_test(request, bigip)
+        setup_create_test(request, mgmt_root)
         n1 = NAT.create(name='nat1', partition='Common',
                         translationAddress='192.168.1.1',
                         originatingAddress='192.168.2.1',
@@ -199,21 +199,21 @@ class TestCreate(object):
         assert 'disabled' not in n1.raw
         assert n1.enabled is True
 
-    def test_create_inheritedtrafficgroup_true(self, request, bigip, NAT):
+    def test_create_inheritedtrafficgroup_true(self, request, mgmt_root, NAT):
         '''Test that you can set inheritedTrafficGroup to True on create
 
         This MUST be the string 'true' not the built-in True that you would
         think makes sense for a true/false setting like the other properties
         of NAT.
         '''
-        setup_create_test(request, bigip)
+        setup_create_test(request, mgmt_root)
         n1 = NAT.create(name='nat1', partition='Common',
                         translationAddress='192.168.1.1',
                         originatingAddress='192.168.2.1',
                         inheritedTrafficGroup='true')
         assert n1.inheritedTrafficGroup == 'true'
 
-    def test_create_inheritedtrafficgroup_false(self, request, bigip, NAT):
+    def test_create_inheritedtrafficgroup_false(self, request, mgmt_root, NAT):
         '''Test that you can set inheritedTrafficGroup to True on create
 
         This MUST be the string 'false' not the built-in True that you would
@@ -223,7 +223,7 @@ class TestCreate(object):
         This also requires that the trafficGroup parameter also be set or the
         setting will not take effect on the system and silently be ignored.
         '''
-        setup_create_test(request, bigip)
+        setup_create_test(request, mgmt_root)
         n1 = NAT.create(name='nat1', partition='Common',
                         translationAddress='192.168.1.1',
                         originatingAddress='192.168.2.1',
@@ -231,26 +231,26 @@ class TestCreate(object):
                         trafficGroup='/Common/traffic-group-1')
         assert n1.inheritedTrafficGroup == 'false'
 
-    def test_create_trafficgroup(self, request, bigip, NAT):
+    def test_create_trafficgroup(self, request, mgmt_root, NAT):
         '''Test that you can set the trafficgroup on create.
 
         Using the existing default group because we don't have the TG object
         done yet.
         '''
-        setup_create_test(request, bigip)
+        setup_create_test(request, mgmt_root)
         n1 = NAT.create(name='nat1', partition='Common',
                         translationAddress='192.168.1.1',
                         originatingAddress='192.168.2.1',
                         trafficGroup='/Common/traffic-group-1')
         assert n1.trafficGroup == '/Common/traffic-group-1'
 
-    def test_create_vlans_disabled(self, request, bigip, NAT):
+    def test_create_vlans_disabled(self, request, mgmt_root, NAT):
         '''Test that you can set the VLANs that you want to disable
 
         The default setting is disabled so we want to add some VLANs to the
         disabled list.  We are using one of the built in VLAN lists.
         '''
-        setup_create_test(request, bigip)
+        setup_create_test(request, mgmt_root)
         n1 = NAT.create(name='nat1', partition='Common',
                         translationAddress='192.168.1.1',
                         originatingAddress='192.168.2.1',
@@ -259,8 +259,8 @@ class TestCreate(object):
         assert '/Common/http-tunnel' in n1.vlans
         assert n1.vlansDisabled is True
 
-    def test_create_vlans_enabled(self, request, bigip, NAT):
-        setup_create_test(request, bigip)
+    def test_create_vlans_enabled(self, request, mgmt_root, NAT):
+        setup_create_test(request, mgmt_root)
         n1 = NAT.create(name='nat1', partition='Common',
                         translationAddress='192.168.1.1',
                         originatingAddress='192.168.2.1',
@@ -270,21 +270,21 @@ class TestCreate(object):
         assert '/Common/http-tunnel' in n1.vlans
         assert n1.vlansEnabled is True
 
-    def test_create_vlansenabled_true(self, request, bigip, NAT):
-        setup_create_test(request, bigip)
+    def test_create_vlansenabled_true(self, request, mgmt_root, NAT):
+        setup_create_test(request, mgmt_root)
         n1 = NAT.create(name='nat1', partition='Common',
                         translationAddress='192.168.1.1',
                         originatingAddress='192.168.2.1',
                         vlansEnabled=True)
         assert n1.vlansEnabled is True
 
-    def itest_create_vlansenabled_false(self, request, bigip, NAT):
+    def itest_create_vlansenabled_false(self, request, mgmt_root, NAT):
         '''Test setting vlansEnabled to False on create
 
         This has the same issue as the enable/disable properties for the nat
         object.  You need to use the vlansEnabled property to enable them.
         '''
-        setup_create_test(request, bigip)
+        setup_create_test(request, mgmt_root)
         n1 = NAT.create(name='nat1', partition='Common',
                         translationAddress='192.168.1.1',
                         originatingAddress='192.168.2.1',
@@ -300,9 +300,9 @@ class TestLoad(object):
             NAT.load(name='mynat', partition='Common')
             assert err.response.status == 404
 
-    def test_load(self, request, bigip, NAT):
-        setup_loadable_nat_test(request, bigip, NAT)
-        n1 = bigip.ltm.nats.nat.load(name='nat1', partition='Common')
+    def test_load(self, request, mgmt_root, NAT):
+        setup_loadable_nat_test(request, mgmt_root, NAT)
+        n1 = mgmt_root.tm.ltm.nats.nat.load(name='nat1', partition='Common')
         assert n1.name == 'nat1'
         assert n1.partition == 'Common'
         assert isinstance(n1.generation, int)
@@ -310,11 +310,11 @@ class TestLoad(object):
 
 class TestRefresh(object):
 
-    def test_refresh(self, request, bigip, NAT):
-        setup_loadable_nat_test(request, bigip, NAT)
+    def test_refresh(self, request, mgmt_root, NAT):
+        setup_loadable_nat_test(request, mgmt_root, NAT)
 
-        n1 = bigip.ltm.nats.nat.load(name='nat1', partition='Common')
-        n2 = bigip.ltm.nats.nat.load(name='nat1', partition='Common')
+        n1 = mgmt_root.tm.ltm.nats.nat.load(name='nat1', partition='Common')
+        n2 = mgmt_root.tm.ltm.nats.nat.load(name='nat1', partition='Common')
         assert n1.arp == 'enabled'
         assert n2.arp == 'enabled'
 
@@ -328,27 +328,27 @@ class TestRefresh(object):
 
 class TestDelete(object):
 
-    def test_delete(self, request, bigip, NAT):
-        setup_loadable_nat_test(request, bigip, NAT)
-        n1 = bigip.ltm.nats.nat.load(name='nat1', partition='Common')
+    def test_delete(self, request, mgmt_root, NAT):
+        setup_loadable_nat_test(request, mgmt_root, NAT)
+        n1 = mgmt_root.tm.ltm.nats.nat.load(name='nat1', partition='Common')
         n1.delete()
         del(n1)
         with pytest.raises(HTTPError) as err:
-            bigip.ltm.nats.nat.load(name='nat1', partition='Common')
+            mgmt_root.tm.ltm.nats.nat.load(name='nat1', partition='Common')
             assert err.response.status_code == 404
 
 
 class TestUpdate(object):
-    def test_update_with_args(self, request, bigip, NAT):
-        setup_loadable_nat_test(request, bigip, NAT)
-        n1 = bigip.ltm.nats.nat.load(name='nat1', partition='Common')
+    def test_update_with_args(self, request, mgmt_root, NAT):
+        setup_loadable_nat_test(request, mgmt_root, NAT)
+        n1 = mgmt_root.tm.ltm.nats.nat.load(name='nat1', partition='Common')
         assert n1.arp == 'enabled'
         n1.update(arp='disabled')
         assert n1.arp == 'disabled'
 
-    def test_update_parameters(self, request, bigip, NAT):
-        setup_loadable_nat_test(request, bigip, NAT)
-        n1 = bigip.ltm.nats.nat.load(name='nat1', partition='Common')
+    def test_update_parameters(self, request, mgmt_root, NAT):
+        setup_loadable_nat_test(request, mgmt_root, NAT)
+        n1 = mgmt_root.tm.ltm.nats.nat.load(name='nat1', partition='Common')
         assert n1.arp == 'enabled'
         n1.arp = 'disabled'
         n1.update()

--- a/f5/bigip/tm/ltm/test/functional/test_snat_translation.py
+++ b/f5/bigip/tm/ltm/test/functional/test_snat_translation.py
@@ -14,32 +14,32 @@
 #
 
 
-def setup(request, bigip, name, partition, ipaddr):
+def setup(request, mgmt_root, name, partition, ipaddr):
     def teardown():
         if st.exists(name=name, partition=partition):
             st.delete()
     request.addfinalizer(teardown)
 
-    stc = bigip.ltm.snat_translations
+    stc = mgmt_root.tm.ltm.snat_translations
     st = stc.snat_translation.create(
         name=name, partition=partition, address=ipaddr)
     return stc, st
 
 
 class TestSnatTranslations(object):
-    def test_get_collection(self, request, bigip):
+    def test_get_collection(self, request, mgmt_root):
         stc, st = setup(
-            request, bigip, 'test-snatxlate', 'Common', '192.168.50.51')
+            request, mgmt_root, 'test-snatxlate', 'Common', '192.168.50.51')
         sts = stc.get_collection()
         assert len(sts) >= 1
         assert [s for s in sts if s.name == 'test-snatxlate']
 
 
 class TestSnatTranslation(object):
-    def test_CURDLE(self, request, bigip):
+    def test_CURDLE(self, request, mgmt_root):
         # Assume create and delete are tested by setup/teardown
         stc, st1 = setup(
-            request, bigip, 'test-snatxlate', 'Common', '192.168.101.1')
+            request, mgmt_root, 'test-snatxlate', 'Common', '192.168.101.1')
 
         # Exists
         assert stc.snat_translation.exists(

--- a/f5/bigip/tm/ltm/test/functional/test_snatpool.py
+++ b/f5/bigip/tm/ltm/test/functional/test_snatpool.py
@@ -14,31 +14,31 @@
 #
 
 
-def setup(request, bigip, name, partition, ipaddr):
+def setup(request, mgmt_root, name, partition, ipaddr):
     def teardown():
         if sp.exists(name=name, partition=partition):
             sp.delete()
     request.addfinalizer(teardown)
 
-    spc = bigip.ltm.snatpools
+    spc = mgmt_root.tm.ltm.snatpools
     sp = spc.snatpool.create(name=name, partition=partition, members=[ipaddr])
     return spc, sp
 
 
 class TestSnatpools(object):
-    def test_get_collection(self, request, bigip):
+    def test_get_collection(self, request, mgmt_root):
         spc, sp = setup(
-            request, bigip, 'test-snatpool', 'Common', '192.168.101.1')
+            request, mgmt_root, 'test-snatpool', 'Common', '192.168.101.1')
         sps = spc.get_collection()
         assert len(sps) >= 1
         assert [s for s in sps if s.name == 'test-snatpool']
 
 
 class TestSnatpool(object):
-    def test_CURDLE(self, request, bigip):
+    def test_CURDLE(self, request, mgmt_root):
         # Assume create and delete are tested by setup/teardown
         spc, sp1 = setup(
-            request, bigip, 'test-snatpool', 'Common', '192.168.101.1')
+            request, mgmt_root, 'test-snatpool', 'Common', '192.168.101.1')
 
         # Exists
         assert spc.snatpool.exists(name='test-snatpool', partition='Common')

--- a/f5/bigip/tm/ltm/test/functional/test_virtual_address.py
+++ b/f5/bigip/tm/ltm/test/functional/test_virtual_address.py
@@ -14,18 +14,17 @@
 #
 
 
-def setup_virtual_address_s_test(request, bigip, vs_name, vs_partion):
+def setup_virtual_address_s_test(request, mgmt_root, vs_name, vs_partion):
     def teardown():
-        if bigip.ltm.virtuals.virtual.exists(name=vs_name,
-                                             partition=vs_partion):
+        if mgmt_root.tm.ltm.virtuals.virtual.exists(name=vs_name, partition=vs_partion):
             vs.delete()
     request.addfinalizer(teardown)
 
-    vs = bigip.ltm.virtuals.virtual.create(name=vs_name, partition=vs_partion)
+    vs = mgmt_root.tm.ltm.virtuals.virtual.create(name=vs_name, partition=vs_partion)
 
 
-def setup_virtual_address_test(request, bigip, va_name, va_partition):
-    vac = bigip.ltm.virtual_address_s
+def setup_virtual_address_test(request, mgmt_root, va_name, va_partition):
+    vac = mgmt_root.tm.ltm.virtual_address_s
     if vac.virtual_address.exists(name=va_name, partition=va_partition):
             vac.virtual_address.load(
                 name=va_name, partition=va_partition).delete()
@@ -35,18 +34,18 @@ def setup_virtual_address_test(request, bigip, va_name, va_partition):
 
 
 class TestVirtualAddress_s(object):
-    def test_get_collection(self, request, bigip):
-        setup_virtual_address_s_test(request, bigip, 'va_vs_test-1', 'Common')
-        vas = bigip.ltm.virtual_address_s
+    def test_get_collection(self, request, mgmt_root):
+        setup_virtual_address_s_test(request, mgmt_root, 'va_vs_test-1', 'Common')
+        vas = mgmt_root.tm.ltm.virtual_address_s
         vac = vas.get_collection()
         assert len(vac) >= 1
         assert [va for va in vac if va.name == '0.0.0.0']
 
 
 class TestVirtualAddress(object):
-    def test_CURDLE(self, request, bigip):
+    def test_CURDLE(self, request, mgmt_root):
         # Create and delete are handled by setup/teardown
-        vac, va1 = setup_virtual_address_test(request, bigip, 'va-1', 'Common')
+        vac, va1 = setup_virtual_address_test(request, mgmt_root, 'va-1', 'Common')
         assert va1.name == 'va-1'
 
         # Exists

--- a/f5/bigip/tm/net/test/functional/test_arp.py
+++ b/f5/bigip/tm/net/test/functional/test_arp.py
@@ -31,29 +31,29 @@ def delete_resource(resources):
                 raise
 
 
-def setup_arp_test(request, bigip, partition, name, ip, mac):
+def setup_arp_test(request, mgmt_root, partition, name, ip, mac):
     def teardown():
         delete_resource(ac1)
     request.addfinalizer(teardown)
 
-    ac1 = bigip.net.arps
+    ac1 = mgmt_root.tm.net.arps
     a1 = ac1.arp.create(
         partition=partition, name=name, ipAddress=ip, macAddress=mac)
     return a1, ac1
 
 
 class TestArp(object):
-    def test_create_missing_args(self, request, bigip):
+    def test_create_missing_args(self, request, mgmt_root):
         with pytest.raises(MissingRequiredCreationParameter):
-            bigip.net.arps.arp.create(name='s1', partition='Common')
+            mgmt_root.tm.net.arps.arp.create(name='s1', partition='Common')
 
-    def test_CURDL(self, request, bigip):
+    def test_CURDL(self, request, mgmt_root):
         # We assume that setup and teardown will create/delete
         name = 'arp_test'
         partition = 'Common'
         a1, ac1 = setup_arp_test(
-            request, bigip, partition, name, TEST_IP, TEST_MAC)
-        a2 = bigip.net.arps.arp.load(name=name, partition=partition)
+            request, mgmt_root, partition, name, TEST_IP, TEST_MAC)
+        a2 = mgmt_root.tm.net.arps.arp.load(name=name, partition=partition)
         assert a1.name == name
         assert a1.ipAddress == TEST_IP
         assert a1.macAddress == TEST_MAC

--- a/f5/bigip/tm/net/test/functional/test_dns_resolver.py
+++ b/f5/bigip/tm/net/test/functional/test_dns_resolver.py
@@ -14,23 +14,23 @@
 #
 
 
-def setup_test(request, bigip, name):
+def setup_test(request, mgmt_root, name):
     def teardown():
         if dns1.exists(name=name):
             dns1.delete()
 
     request.addfinalizer(teardown)
-    dc1 = bigip.net.dns_resolvers
+    dc1 = mgmt_root.tm.net.dns_resolvers
     dr1 = dc1.dns_resolver
     dns1 = dr1.create(name=name)
     return dc1, dns1
 
 
 class TestDnsResolver(object):
-    def test_CURDL(self, request, bigip):
+    def test_CURDL(self, request, mgmt_root):
 
         # Test create
-        dc1, dns1 = setup_test(request, bigip, name='test_dns_resolver')
+        dc1, dns1 = setup_test(request, mgmt_root, name='test_dns_resolver')
         assert dns1.name == 'test_dns_resolver'
 
         # Test update

--- a/f5/bigip/tm/net/test/functional/test_interface.py
+++ b/f5/bigip/tm/net/test/functional/test_interface.py
@@ -15,17 +15,17 @@
 import pytest
 
 
-def cleanup_test(request, bigip):
+def cleanup_test(request, mgmt_root):
     def teardown():
-        for ifc in bigip.net.interfaces.get_collection():
+        for ifc in mgmt_root.tm.net.interfaces.get_collection():
             ifc.enabled = True
             ifc.update()
     request.addfinalizer(teardown)
 
 
 class TestInterfaces(object):
-    def test_interfaces_list(self, bigip):
-        ifcs = bigip.net.interfaces.get_collection()
+    def test_interfaces_list(self, mgmt_root):
+        ifcs = mgmt_root.tm.net.interfaces.get_collection()
         assert len(ifcs)
         for ifc in ifcs:
             assert ifc.generation
@@ -36,11 +36,11 @@ class TestInterface(object):
         'A known issue with generation number. '
         'See: https://github.com/F5Networks/f5-common-python/issues/334'
     )
-    def test_RUL(self, request, bigip):
-        cleanup_test(request, bigip)
+    def test_RUL(self, request, mgmt_root):
+        cleanup_test(request, mgmt_root)
         # We can't create or delete interfaces so we will load them to start
-        ifc1 = bigip.net.interfaces.interface.load(name='1.1')
-        ifc2 = bigip.net.interfaces.interface.load(name='1.1')
+        ifc1 = mgmt_root.tm.net.interfaces.interface.load(name='1.1')
+        ifc2 = mgmt_root.tm.net.interfaces.interface.load(name='1.1')
         assert ifc1.generation == ifc2.generation
         assert ifc1.name == ifc2.name
 

--- a/f5/bigip/tm/net/test/functional/test_tunnels.py
+++ b/f5/bigip/tm/net/test/functional/test_tunnels.py
@@ -27,54 +27,54 @@ def delete_resource(resource):
             raise
 
 
-def setup_tunnel_test(request, bigip, name, partition, ip, profile):
+def setup_tunnel_test(request, mgmt_root, name, partition, ip, profile):
     def teardown():
         delete_resource(tunnel)
     request.addfinalizer(teardown)
 
-    tunnel = bigip.net.tunnels.tunnels.tunnel.create(
+    tunnel = mgmt_root.tm.net.tunnels.tunnels.tunnel.create(
         name=name, partition=partition, localAddress=ip, profile=profile)
     return tunnel
 
 
-def setup_gre_test(request, bigip, name, partition):
+def setup_gre_test(request, mgmt_root, name, partition):
     def teardown():
         delete_resource(gre)
     request.addfinalizer(teardown)
 
-    gre = bigip.net.tunnels.gres.gre.create(
+    gre = mgmt_root.tm.net.tunnels.gres.gre.create(
         name=name, partition=partition)
     return gre
 
 
-def setup_vxlan_test(request, bigip, name, partition):
+def setup_vxlan_test(request, mgmt_root, name, partition):
     def teardown():
         delete_resource(vxlan)
     request.addfinalizer(teardown)
 
-    vxlan = bigip.net.tunnels.vxlans.vxlan.create(
+    vxlan = mgmt_root.tm.net.tunnels.vxlans.vxlan.create(
         name=name, partition=partition)
     return vxlan
 
 
 class TestTunnels(object):
-    def test_tunnel_list(self, bigip):
-        tunnels = bigip.net.tunnels.tunnels.get_collection()
+    def test_tunnel_list(self, mgmt_root):
+        tunnels = mgmt_root.tm.net.tunnels.tunnels.get_collection()
         assert len(tunnels)
         for tunnel in tunnels:
             assert tunnel.generation
 
 
 class TestTunnel(object):
-    def test_tunnel_CURDL(self, request, bigip):
+    def test_tunnel_CURDL(self, request, mgmt_root):
         # Create and Delete are tested by the setup/teardown
         t1 = setup_tunnel_test(
-            request, bigip, 'tunnel-test', 'Common',
+            request, mgmt_root, 'tunnel-test', 'Common',
             '192.168.1.1', '/Common/gre'
         )
 
         # Load
-        t2 = bigip.net.tunnels.tunnels.tunnel.load(
+        t2 = mgmt_root.tm.net.tunnels.tunnels.tunnel.load(
             name='tunnel-test', partition='Common')
         assert t1.name == 'tunnel-test'
         assert t1.name == t2.name
@@ -93,13 +93,13 @@ class TestTunnel(object):
 
 
 class TestGre(object):
-    def test_gre_CURDL(self, request, bigip):
+    def test_gre_CURDL(self, request, mgmt_root):
         # Create and Delete are tested by the setup/teardown
-        g1 = setup_gre_test(request, bigip, 'gre-test', 'Common')
+        g1 = setup_gre_test(request, mgmt_root, 'gre-test', 'Common')
         assert g1.name == 'gre-test'
 
         # Load
-        g2 = bigip.net.tunnels.gres.gre.load(
+        g2 = mgmt_root.tm.net.tunnels.gres.gre.load(
             name='gre-test', partition='Common')
         assert g1.name == g2.name
         assert g1.generation == g2.generation
@@ -117,13 +117,13 @@ class TestGre(object):
 
 
 class TestVxlan(object):
-    def test_vxlan_CURDL(self, request, bigip):
+    def test_vxlan_CURDL(self, request, mgmt_root):
         # Create and Delete are tested by the setup/teardown
-        vx1 = setup_vxlan_test(request, bigip, 'vxlan-test', 'Common')
+        vx1 = setup_vxlan_test(request, mgmt_root, 'vxlan-test', 'Common')
         assert vx1.name == 'vxlan-test'
 
         # Load
-        vx2 = bigip.net.tunnels.vxlans.vxlan.load(
+        vx2 = mgmt_root.tm.net.tunnels.vxlans.vxlan.load(
             name='vxlan-test', partition='Common')
         assert vx1.name == vx2.name
         assert vx1.generation == vx2.generation

--- a/f5/bigip/tm/sys/software/test/functional/test_update.py
+++ b/f5/bigip/tm/sys/software/test/functional/test_update.py
@@ -17,8 +17,8 @@ import pytest
 
 
 @pytest.fixture
-def cleaner(request, bigip):
-    initial = bigip.sys.software.update.load()
+def cleaner(request, mgmt_root):
+    initial = mgmt_root.tm.sys.software.update.load()
 
     def teardown():
         initial.update()
@@ -26,22 +26,22 @@ def cleaner(request, bigip):
 
 
 class TestUpdate(object):
-    def test_load(self, cleaner, bigip):
-        su = bigip.sys.software.update.load()
+    def test_load(self, cleaner, mgmt_root):
+        su = mgmt_root.tm.sys.software.update.load()
         assert su.autoCheck == 'enabled'
         su.refresh()
         assert su.autoCheck == 'enabled'
 
-    def test_update_autocheck(self, cleaner, bigip):
-        su = bigip.sys.software.update.load()
+    def test_update_autocheck(self, cleaner, mgmt_root):
+        su = mgmt_root.tm.sys.software.update.load()
         su.update(autoCheck='disabled')
         assert su.autoCheck == 'disabled'
         su.update(autoCheck='enabled')
         assert su.autoCheck == 'enabled'
 
-    def test_update_frequency(self, cleaner, bigip):
+    def test_update_frequency(self, cleaner, mgmt_root):
         frequencies = ['daily', 'monthly', 'weekly']
-        su = bigip.sys.software.update.load()
+        su = mgmt_root.tm.sys.software.update.load()
 
         for frequency in frequencies:
             su.update(frequency=frequency)

--- a/f5/bigip/tm/sys/test/functional/test_db.py
+++ b/f5/bigip/tm/sys/test/functional/test_db.py
@@ -15,14 +15,14 @@
 
 
 class TestDb(object):
-    def test_RL(self, bigip):
-        db = bigip.sys.dbs.db.load(name='license.operational')
+    def test_RL(self, mgmt_root):
+        db = mgmt_root.tm.sys.dbs.db.load(name='license.operational')
         assert db.value == 'true'
         db.refresh()
         assert db.value == 'true'
 
-    def test_update(self, bigip):
-        db1 = bigip.sys.dbs.db.load(name='iptunnel.configsync')
+    def test_update(self, mgmt_root):
+        db1 = mgmt_root.tm.sys.dbs.db.load(name='iptunnel.configsync')
         db1.update(value='enable')
         assert db1.value == 'enable'
         db1.update(value='disable')

--- a/f5/bigip/tm/sys/test/functional/test_dns.py
+++ b/f5/bigip/tm/sys/test/functional/test_dns.py
@@ -14,22 +14,22 @@
 #
 
 
-def setup_dns_test(request, bigip):
+def setup_dns_test(request, mgmt_root):
     def teardown():
         d.nameServers = servers
         d.update()
     request.addfinalizer(teardown)
-    d = bigip.sys.dns.load()
+    d = mgmt_root.tm.sys.dns.load()
     servers = d.nameServers
     return d, servers
 
 
 class TestDns(object):
-    def test_RUL(self, request, bigip):
+    def test_RUL(self, request, mgmt_root):
         # Load
         ip = '192.168.100.85'
-        dns1, orig_servers = setup_dns_test(request, bigip)
-        dns2 = bigip.sys.dns.load()
+        dns1, orig_servers = setup_dns_test(request, mgmt_root)
+        dns2 = mgmt_root.tm.sys.dns.load()
         assert len(dns1.nameServers) == len(dns2.nameServers)
 
         # Update

--- a/f5/bigip/tm/sys/test/functional/test_failover.py
+++ b/f5/bigip/tm/sys/test/functional/test_failover.py
@@ -45,7 +45,7 @@ def teardown_device_failover_state(request, mgmt_root):
 
 
 class TestFailover(object):
-    def test_failover_LR(self, bigip):
+    def test_failover_LR(self, mgmt_root):
         """Test failover refresh and load.
 
         Test that the failover object can be refreshed and loaded. The object
@@ -55,13 +55,13 @@ class TestFailover(object):
         it here.
         """
 
-        f = bigip.sys.failover.load()
+        f = mgmt_root.tm.sys.failover.load()
         assert 'Failover active' in f.apiRawValues['apiAnonymous']
         f.refresh()
         assert 'Failover active' in f.apiRawValues['apiAnonymous']
 
-    def test_toggle_standby(self, bigip):
-        f = bigip.sys.failover
+    def test_toggle_standby(self, mgmt_root):
+        f = mgmt_root.tm.sys.failover
         fl = f.toggle_standby(trafficgroup="traffic-group-1", state=None)
         assert fl.standby is None
         assert fl.command == "run"
@@ -78,8 +78,8 @@ class TestFailover(object):
                              state=None, foo="bar")
         assert "Unexpected **kwargs" in str(ex.value)
 
-    def test_attribute_values(self, bigip):
-        fl = bigip.sys.failover
+    def test_attribute_values(self, mgmt_root):
+        fl = mgmt_root.tm.sys.failover
         # Testing both conditions
         with pytest.raises(BooleansToReduceHaveSameValue) as ex1:
             fl.exec_cmd('run', online=True, offline=True)

--- a/f5/bigip/tm/sys/test/functional/test_folder.py
+++ b/f5/bigip/tm/sys/test/functional/test_folder.py
@@ -19,7 +19,7 @@ from requests import HTTPError
 TESTDESCRIPTION = "TESTDESCRIPTION"
 
 
-def setup_folder_test(request, bigip, name, subpath):
+def setup_folder_test(request, mgmt_root, name, subpath):
     def teardown():
         '''Remove the f1 folder only.
 
@@ -33,15 +33,15 @@ def setup_folder_test(request, bigip, name, subpath):
                 raise
     request.addfinalizer(teardown)
 
-    fc1 = bigip.sys.folders
+    fc1 = mgmt_root.tm.sys.folders
     f1 = fc1.folder.create(name=name, subPath=subpath)
     return f1, fc1
 
 
 class TestFolder(object):
-    def test_CURDL(self, request, bigip):
+    def test_CURDL(self, request, mgmt_root):
         # Create
-        f1, fc1 = setup_folder_test(request, bigip, 'testfolder', '/')
+        f1, fc1 = setup_folder_test(request, mgmt_root, 'testfolder', '/')
         assert f1.name == 'testfolder'
         assert f1.subPath == '/'
         assert f1.fullPath == '/testfolder'
@@ -67,29 +67,29 @@ class TestFolder(object):
 
         # We assume delete is taken care of by teardown
 
-    def test_load_root_folder_by_name(self, bigip):
-        fc = bigip.sys.folders
+    def test_load_root_folder_by_name(self, mgmt_root):
+        fc = mgmt_root.tm.sys.folders
         f = fc.folder.load(name='/')
         assert f.name == '/'
         assert f.fullPath == '/'
 
-    def test_load_root_folder_by_partition(self, bigip):
-        fc = bigip.sys.folders
+    def test_load_root_folder_by_partition(self, mgmt_root):
+        fc = mgmt_root.tm.sys.folders
         f = fc.folder.load(partition='/')
         assert f.name == '/'
         assert f.fullPath == '/'
 
-    def test_load_root_no_attributes(self, bigip):
-        fc = bigip.sys.folders
+    def test_load_root_no_attributes(self, mgmt_root):
+        fc = mgmt_root.tm.sys.folders
         f = fc.folder.load()
         assert f.name == '/'
         assert f.fullPath == '/'
 
 
 class TestFolderCollection(object):
-    def test_get_collection(self, request, bigip):
-        setup_folder_test(request, bigip, 'testfolder', '/')
-        fc = bigip.sys.folders
+    def test_get_collection(self, request, mgmt_root):
+        setup_folder_test(request, mgmt_root, 'testfolder', '/')
+        fc = mgmt_root.tm.sys.folders
         folders = fc.get_collection()
 
         assert len(folders)

--- a/f5/bigip/tm/sys/test/functional/test_global_settings.py
+++ b/f5/bigip/tm/sys/test/functional/test_global_settings.py
@@ -14,20 +14,20 @@
 #
 
 
-def set_global_settings_test(request, bigip):
+def set_global_settings_test(request, mgmt_root):
     def teardown():
         gs.usernamePrompt = 'Username'
         gs.update()
     request.addfinalizer(teardown)
-    gs = bigip.sys.global_settings.load()
+    gs = mgmt_root.tm.sys.global_settings.load()
     return gs
 
 
 class TestGlobal_Setting(object):
-    def test_RUL(self, request, bigip):
+    def test_RUL(self, request, mgmt_root):
         # Load
-        gs1 = set_global_settings_test(request, bigip)
-        gs2 = bigip.sys.global_settings.load()
+        gs1 = set_global_settings_test(request, mgmt_root)
+        gs2 = mgmt_root.tm.sys.global_settings.load()
         assert gs1.usernamePrompt == 'Username'
         assert gs1.usernamePrompt == gs2.usernamePrompt
 

--- a/f5/bigip/tm/sys/test/functional/test_httpd.py
+++ b/f5/bigip/tm/sys/test/functional/test_httpd.py
@@ -17,8 +17,8 @@ import pytest
 
 
 @pytest.fixture
-def cleaner(request, bigip):
-    initial_httpd = bigip.sys.httpd.load()
+def cleaner(request, mgmt_root):
+    initial_httpd = mgmt_root.tm.sys.httpd.load()
 
     def teardown():
         # There is a difference in 11.6.0 and 12.0.0 default for max clients.
@@ -28,14 +28,14 @@ def cleaner(request, bigip):
 
 
 class TestHttpd(object):
-    def test_load(self, cleaner, bigip):
-        httpd = bigip.sys.httpd.load()
+    def test_load(self, cleaner, mgmt_root):
+        httpd = mgmt_root.tm.sys.httpd.load()
         assert httpd.maxClients == 10
         httpd.refresh()
         assert httpd.maxClients == 10
 
-    def test_update(self, cleaner, bigip):
-        httpd = bigip.sys.httpd.load()
+    def test_update(self, cleaner, mgmt_root):
+        httpd = mgmt_root.tm.sys.httpd.load()
         httpd.update(maxClients=10)
         assert httpd.maxClients == 10
         httpd.update(maxClients=20)

--- a/f5/bigip/tm/sys/test/functional/test_performance.py
+++ b/f5/bigip/tm/sys/test/functional/test_performance.py
@@ -15,8 +15,8 @@
 
 
 class TestAllStats(object):
-    def test_RL(self, bigip):
-        allstats = bigip.sys.performances.all_stats.load()
+    def test_RL(self, mgmt_root):
+        allstats = mgmt_root.tm.sys.performances.all_stats.load()
         assert hasattr(allstats, 'apiRawValues')
         allstats.refresh()
         assert hasattr(allstats, 'apiRawValues')

--- a/f5/bigip/tm/sys/test/functional/test_sshd.py
+++ b/f5/bigip/tm/sys/test/functional/test_sshd.py
@@ -19,7 +19,7 @@ V11_SUPPORTED = ['11.5.4', '11.6.0', '11.6.1', '11.6.2']
 V12_SUPPORTED = ['12.0.0', '12.1.0']
 
 
-def setup_sshd_test(request, bigip):
+def setup_sshd_test(request, mgmt_root):
     def teardown():
         d.allow = ['ALL']
         d.banner = 'disabled'
@@ -33,16 +33,16 @@ def setup_sshd_test(request, bigip):
 
         d.update()
     request.addfinalizer(teardown)
-    d = bigip.sys.sshd.load()
+    d = mgmt_root.tm.sys.sshd.load()
     return d
 
 
 @pytest.mark.skipif(pytest.config.getoption('--release') not in V11_SUPPORTED,
                     reason='Needs v11 TMOS to pass')
 class TestSshd11(object):
-    def test_load(self, request, bigip):
-        ssh1 = setup_sshd_test(request, bigip)
-        ssh2 = setup_sshd_test(request, bigip)
+    def test_load(self, request, mgmt_root):
+        ssh1 = setup_sshd_test(request, mgmt_root)
+        ssh2 = setup_sshd_test(request, mgmt_root)
 
         assert ssh1.allow == ssh2.allow
         assert ssh1.banner == ssh2.banner
@@ -50,9 +50,9 @@ class TestSshd11(object):
         assert ssh1.logLevel == ssh2.logLevel
         assert ssh1.login == ssh2.login
 
-    def test_update_allow(self, request, bigip):
-        ssh1 = setup_sshd_test(request, bigip)
-        ssh2 = setup_sshd_test(request, bigip)
+    def test_update_allow(self, request, mgmt_root):
+        ssh1 = setup_sshd_test(request, mgmt_root)
+        ssh2 = setup_sshd_test(request, mgmt_root)
 
         ssh1.allow = ['192.168.1.1']
         ssh1.update()
@@ -63,9 +63,9 @@ class TestSshd11(object):
         ssh2.refresh()
         assert ['192.168.1.1'] == ssh2.allow
 
-    def test_update_banner(self, request, bigip):
-        ssh1 = setup_sshd_test(request, bigip)
-        ssh2 = setup_sshd_test(request, bigip)
+    def test_update_banner(self, request, mgmt_root):
+        ssh1 = setup_sshd_test(request, mgmt_root)
+        ssh2 = setup_sshd_test(request, mgmt_root)
 
         banners = ['enabled', 'disabled']
 
@@ -79,9 +79,9 @@ class TestSshd11(object):
             ssh2.refresh()
             assert banner == ssh2.banner
 
-    def test_update_bannerText(self, request, bigip):
-        ssh1 = setup_sshd_test(request, bigip)
-        ssh2 = setup_sshd_test(request, bigip)
+    def test_update_bannerText(self, request, mgmt_root):
+        ssh1 = setup_sshd_test(request, mgmt_root)
+        ssh2 = setup_sshd_test(request, mgmt_root)
 
         ssh1.bannerText = 'foo banner'
         ssh1.update()
@@ -92,9 +92,9 @@ class TestSshd11(object):
         ssh2.refresh()
         assert 'foo banner' == ssh2.bannerText
 
-    def test_update_inactivityTimeout(self, request, bigip):
-        ssh1 = setup_sshd_test(request, bigip)
-        ssh2 = setup_sshd_test(request, bigip)
+    def test_update_inactivityTimeout(self, request, mgmt_root):
+        ssh1 = setup_sshd_test(request, mgmt_root)
+        ssh2 = setup_sshd_test(request, mgmt_root)
 
         ssh1.inactivityTimeout = 10
         ssh1.update()
@@ -105,9 +105,9 @@ class TestSshd11(object):
         ssh2.refresh()
         assert 10 == ssh2.inactivityTimeout
 
-    def test_update_logLevel(self, request, bigip):
-        ssh1 = setup_sshd_test(request, bigip)
-        ssh2 = setup_sshd_test(request, bigip)
+    def test_update_logLevel(self, request, mgmt_root):
+        ssh1 = setup_sshd_test(request, mgmt_root)
+        ssh2 = setup_sshd_test(request, mgmt_root)
 
         levels = ['debug', 'debug1', 'debug2', 'debug3', 'error', 'fatal',
                   'info', 'quiet', 'verbose']
@@ -122,9 +122,9 @@ class TestSshd11(object):
             ssh2.refresh()
             assert level == ssh2.logLevel
 
-    def test_update_login(self, request, bigip):
-        ssh1 = setup_sshd_test(request, bigip)
-        ssh2 = setup_sshd_test(request, bigip)
+    def test_update_login(self, request, mgmt_root):
+        ssh1 = setup_sshd_test(request, mgmt_root)
+        ssh2 = setup_sshd_test(request, mgmt_root)
 
         logins = ['disabled', 'enabled']
 
@@ -142,9 +142,9 @@ class TestSshd11(object):
 @pytest.mark.skipif(pytest.config.getoption('--release') not in V12_SUPPORTED,
                     reason='Needs v12 TMOS to pass')
 class TestSshd12(object):
-    def test_load(self, request, bigip):
-        ssh1 = setup_sshd_test(request, bigip)
-        ssh2 = setup_sshd_test(request, bigip)
+    def test_load(self, request, mgmt_root):
+        ssh1 = setup_sshd_test(request, mgmt_root)
+        ssh2 = setup_sshd_test(request, mgmt_root)
 
         assert ssh1.allow == ssh2.allow
         assert ssh1.banner == ssh2.banner
@@ -153,9 +153,9 @@ class TestSshd12(object):
         assert ssh1.login == ssh2.login
         assert ssh1.port == ssh2.port
 
-    def test_update_allow(self, request, bigip):
-        ssh1 = setup_sshd_test(request, bigip)
-        ssh2 = setup_sshd_test(request, bigip)
+    def test_update_allow(self, request, mgmt_root):
+        ssh1 = setup_sshd_test(request, mgmt_root)
+        ssh2 = setup_sshd_test(request, mgmt_root)
 
         ssh1.allow = ['192.168.1.1']
         ssh1.update()
@@ -166,9 +166,9 @@ class TestSshd12(object):
         ssh2.refresh()
         assert ['192.168.1.1'] == ssh2.allow
 
-    def test_update_banner(self, request, bigip):
-        ssh1 = setup_sshd_test(request, bigip)
-        ssh2 = setup_sshd_test(request, bigip)
+    def test_update_banner(self, request, mgmt_root):
+        ssh1 = setup_sshd_test(request, mgmt_root)
+        ssh2 = setup_sshd_test(request, mgmt_root)
 
         banners = ['enabled', 'disabled']
 
@@ -182,9 +182,9 @@ class TestSshd12(object):
             ssh2.refresh()
             assert banner == ssh2.banner
 
-    def test_update_bannerText(self, request, bigip):
-        ssh1 = setup_sshd_test(request, bigip)
-        ssh2 = setup_sshd_test(request, bigip)
+    def test_update_bannerText(self, request, mgmt_root):
+        ssh1 = setup_sshd_test(request, mgmt_root)
+        ssh2 = setup_sshd_test(request, mgmt_root)
 
         ssh1.bannerText = 'foo banner'
         ssh1.update()
@@ -195,9 +195,9 @@ class TestSshd12(object):
         ssh2.refresh()
         assert 'foo banner' == ssh2.bannerText
 
-    def test_update_inactivityTimeout(self, request, bigip):
-        ssh1 = setup_sshd_test(request, bigip)
-        ssh2 = setup_sshd_test(request, bigip)
+    def test_update_inactivityTimeout(self, request, mgmt_root):
+        ssh1 = setup_sshd_test(request, mgmt_root)
+        ssh2 = setup_sshd_test(request, mgmt_root)
 
         ssh1.inactivityTimeout = 10
         ssh1.update()
@@ -208,9 +208,9 @@ class TestSshd12(object):
         ssh2.refresh()
         assert 10 == ssh2.inactivityTimeout
 
-    def test_update_logLevel(self, request, bigip):
-        ssh1 = setup_sshd_test(request, bigip)
-        ssh2 = setup_sshd_test(request, bigip)
+    def test_update_logLevel(self, request, mgmt_root):
+        ssh1 = setup_sshd_test(request, mgmt_root)
+        ssh2 = setup_sshd_test(request, mgmt_root)
 
         levels = ['debug', 'debug1', 'debug2', 'debug3', 'error', 'fatal',
                   'info', 'quiet', 'verbose']
@@ -225,9 +225,9 @@ class TestSshd12(object):
             ssh2.refresh()
             assert level == ssh2.logLevel
 
-    def test_update_login(self, request, bigip):
-        ssh1 = setup_sshd_test(request, bigip)
-        ssh2 = setup_sshd_test(request, bigip)
+    def test_update_login(self, request, mgmt_root):
+        ssh1 = setup_sshd_test(request, mgmt_root)
+        ssh2 = setup_sshd_test(request, mgmt_root)
 
         logins = ['disabled', 'enabled']
 
@@ -241,9 +241,9 @@ class TestSshd12(object):
             ssh2.refresh()
             assert login == ssh2.login
 
-    def test_update_port(self, request, bigip):
-        ssh1 = setup_sshd_test(request, bigip)
-        ssh2 = setup_sshd_test(request, bigip)
+    def test_update_port(self, request, mgmt_root):
+        ssh1 = setup_sshd_test(request, mgmt_root)
+        ssh2 = setup_sshd_test(request, mgmt_root)
 
         ssh1.port = 1234
         ssh1.update()

--- a/f5/bigip/tm/sys/test/functional/test_ucs.py
+++ b/f5/bigip/tm/sys/test/functional/test_ucs.py
@@ -21,20 +21,20 @@ import time
 @pytest.mark.skipif(pytest.config.getoption('--release') != '12.1.0',
                     reason='Needs v12.1 TMOS to pass')
 class TestUcs(object):
-    def test_ucs_LR(self, bigip):
-        f = bigip.sys.ucs.load()
+    def test_ucs_LR(self, mgmt_root):
+        f = mgmt_root.tm.sys.ucs.load()
 
         # Just in case our test unit does not have any ucs we create one
         try:
             f.items
         except LazyAttributesRequired:
-            bigip.sys.ucs.exec_cmd('save', name='dummyucs.ucs')
+            mgmt_root.tm.sys.ucs.exec_cmd('save', name='dummyucs.ucs')
             time.sleep(1)
             f.refresh()
         finally:
             ucs1 = len(f.items)
         assert ucs1 >= 0
-        bigip.sys.ucs.exec_cmd('save', name='foobar.ucs')
+        mgmt_root.tm.sys.ucs.exec_cmd('save', name='foobar.ucs')
         time.sleep(1)
         f.refresh()
         ucs2 = len(f.items)

--- a/f5/bigiq/tm/sys/software/test/functional/test_update.py
+++ b/f5/bigiq/tm/sys/software/test/functional/test_update.py
@@ -17,8 +17,8 @@ import pytest
 
 
 @pytest.fixture
-def cleaner(request, bigip):
-    initial = bigip.sys.software.update.load()
+def cleaner(request, mgmt_root):
+    initial = mgmt_root.tm.sys.software.update.load()
 
     def teardown():
         initial.update()
@@ -26,22 +26,22 @@ def cleaner(request, bigip):
 
 
 class TestUpdate(object):
-    def test_load(self, cleaner, bigip):
-        su = bigip.sys.software.update.load()
+    def test_load(self, cleaner, mgmt_root):
+        su = mgmt_root.tm.sys.software.update.load()
         assert su.autoCheck == 'enabled'
         su.refresh()
         assert su.autoCheck == 'enabled'
 
-    def test_update_autocheck(self, cleaner, bigip):
-        su = bigip.sys.software.update.load()
+    def test_update_autocheck(self, cleaner, mgmt_root):
+        su = mgmt_root.tm.sys.software.update.load()
         su.update(autoCheck='disabled')
         assert su.autoCheck == 'disabled'
         su.update(autoCheck='enabled')
         assert su.autoCheck == 'enabled'
 
-    def test_update_frequency(self, cleaner, bigip):
+    def test_update_frequency(self, cleaner, mgmt_root):
         frequencies = ['daily', 'monthly', 'weekly']
-        su = bigip.sys.software.update.load()
+        su = mgmt_root.tm.sys.software.update.load()
 
         for frequency in frequencies:
             su.update(frequency=frequency)


### PR DESCRIPTION
Issues:
Fixes #1334

Problem: Many old tests still reference the bigip object.

Analysis: Refactored all functional tests that use the bigip object to use the mgmt_root object instead