### PR TITLE
Adds the possibility to use verified SSL connections

### DIFF
--- a/f5/bigip/__init__.py
+++ b/f5/bigip/__init__.py
@@ -65,6 +65,7 @@ class BaseManagement(PathElement):
             port=kwargs.pop('port', 443),
             icontrol_version=kwargs.pop('icontrol_version', ''),
             token=kwargs.pop('token', False),
+            verify=kwargs.pop('verify', False),
             auth_provider=kwargs.pop('auth_provider', None)
         )
         if kwargs:
@@ -80,7 +81,8 @@ class BaseManagement(PathElement):
         params = dict(
             username=kwargs['username'],
             password=kwargs['password'],
-            timeout=kwargs['timeout']
+            timeout=kwargs['timeout'],
+            verify=kwargs['verify']
         )
         if kwargs['auth_provider']:
             params['auth_provider'] = kwargs['auth_provider']

--- a/f5/bigiq/__init__.py
+++ b/f5/bigiq/__init__.py
@@ -32,11 +32,12 @@ class ManagementRoot(PathElement):
         # The BIG-IQ token is called "local", as opposed to BIG-IP's which
         # is called "tmos"
         auth_provider = kwargs.pop('auth_provider', 'local')
+        verify = kwargs.pop('verify', False)
         if kwargs:
             raise TypeError('Unexpected **kwargs: %r' % kwargs)
         # _meta_data variable values
         iCRS = iControlRESTSession(
-            username, password, timeout=timeout, auth_provider=auth_provider
+            username, password, timeout=timeout, auth_provider=auth_provider, verify=verify
         )
         # define _meta_data
         self._meta_data = {

--- a/f5/iworkflow/__init__.py
+++ b/f5/iworkflow/__init__.py
@@ -41,6 +41,7 @@ class BaseManagement(object):
             timeout=kwargs.pop('timeout', 30),
             port=kwargs.pop('port', 443),
             icontrol_version=kwargs.pop('icontrol_version', ''),
+            verify=kwargs.pop('verify', False),
             token=kwargs.pop('token', False)
         )
         if kwargs:
@@ -57,6 +58,7 @@ class BaseManagement(object):
             username=kwargs['username'],
             password=kwargs['password'],
             timeout=kwargs['timeout'],
+            verify=kwargs['verify'],
             token=kwargs['token']
         )
 

--- a/setup_requirements.txt
+++ b/setup_requirements.txt
@@ -1,6 +1,6 @@
 # F5-SDK base install, python requirements
 six>=1.9.0
 six<2.0.0
-f5-icontrol-rest>=1.3.0
+f5-icontrol-rest>=1.3.2
 f5-icontrol-rest<2.0.0
 eventlet>=0.21.0


### PR DESCRIPTION
Issues:
Fixes #1093

Problem:
It was not possible to access the "verify" argument from f5-icontrol-rest, so it was not possible to use an verified SSL connection to the device.

Analysis:
This exposes the verify argument

Tests:
No new tests. This is consistent with the other arguments.