### PR TITLE
Fixes Issue #1323 - exists method failing on GTM topology records

### DIFF
--- a/f5/bigip/tm/gtm/topology.py
+++ b/f5/bigip/tm/gtm/topology.py
@@ -146,6 +146,10 @@ class Topology(Resource):
 
         return self._load(**kwargs)
 
+    def exists(self, **kwargs):
+        kwargs['transform_name'] = True
+        return self._exists(**kwargs)
+
     def refresh(self, **kwargs):
         """Refresh is not supported for Topology
 

--- a/f5/bigip/tm/gtm/topology.py
+++ b/f5/bigip/tm/gtm/topology.py
@@ -147,6 +147,9 @@ class Topology(Resource):
         return self._load(**kwargs)
 
     def exists(self, **kwargs):
+        """Providing a partition is not necessary on topology; causes errors"""
+        if 'partition' in kwargs:
+            kwargs.pop('partition')
         kwargs['transform_name'] = True
         return self._exists(**kwargs)
 

--- a/f5/bigip/tm/gtm/topology.py
+++ b/f5/bigip/tm/gtm/topology.py
@@ -148,8 +148,7 @@ class Topology(Resource):
 
     def exists(self, **kwargs):
         """Providing a partition is not necessary on topology; causes errors"""
-        if 'partition' in kwargs:
-            kwargs.pop('partition')
+        kwargs.pop('partition', None)
         kwargs['transform_name'] = True
         return self._exists(**kwargs)
 


### PR DESCRIPTION
Problem: The / and ~ characters are disallowed in sdk URLs

Resolution: Overload the exists method for topology by applying:
  kwargs['transform_name'] = True