### PR TITLE
More fixes for devices in DG

### DIFF
--- a/f5/bigip/tm/cm/test/functional/test_device_group.py
+++ b/f5/bigip/tm/cm/test/functional/test_device_group.py
@@ -50,6 +50,10 @@ class TestDeviceGroup(object):
         dg2 = mgmt_root.tm.cm.device_groups.device_group.load(name=dg1.name)
         assert dg1.generation == dg2.generation
 
+        # Exists
+        exists = mgmt_root.tm.cm.device_groups.device_group.exists(name=dg1.name)
+        assert exists is True
+
         # Update
         dg1.update(description=TEST_DESCR)
         assert dg1.generation > dg2.generation
@@ -69,6 +73,11 @@ class TestDeviceGroup(object):
         d1 = dg1.devices_s.devices.create(
             name=this_device.name)
         assert len(dg1.devices_s.get_collection()) == 1
+
+        # Exists
+        exists = dg1.devices_s.devices.exists(name=this_device.name)
+        assert exists is True
+
         # This needs to be in this format due to the change between
         # 11.6.0 Final and other versions.
         assert this_device.name in d1.name


### PR DESCRIPTION
Problem:
Supporting exists was not done. Still allowed for update and patch to
be called.

Analysis:
Added support for the exists method. Removed update and patch because
there is nothing reasonable to patch on a device

Tests: