### PR TITLE
Fixing exclusive attributes bug in the Virtual Server resource

### DIFF
--- a/f5/bigip/test/unit/test_resource.py
+++ b/f5/bigip/test/unit/test_resource.py
@@ -291,16 +291,15 @@ class TestResourceCreate(object):
         assert 'disabled' not in kwargs['json']
 
     def test_reduce_boolean_same_value(self, fake_vs):
-        with pytest.raises(BooleansToReduceHaveSameValue) as ex:
+        with pytest.raises(ExclusiveAttributesPresent) as ex:
             fake_vs.create(
                 partition='Common',
                 name='test_create',
                 enabled=True,
                 disabled=True
             )
-        msg = 'Boolean pair, enabled and disabled, have same value: True. ' \
-            'If both are given to this method, they cannot be the same, as ' \
-            'this method cannot decide which one should be True.'
+        msg = 'Mutually exclusive arguments submitted. The following ' \
+              'arguments cannot be set together: "disabled, enabled".'
         assert msg == str(ex.value)
 
 

--- a/f5/bigip/tm/ltm/virtual.py
+++ b/f5/bigip/tm/ltm/virtual.py
@@ -30,6 +30,7 @@ REST Kind
 from distutils.version import LooseVersion
 
 from f5.bigip.mixins import CheckExistenceMixin
+from f5.bigip.mixins import ExclusiveAttributesMixin
 from f5.bigip.resource import Collection
 from f5.bigip.resource import Resource
 from f5.sdk_exception import NonExtantVirtualPolicy
@@ -48,7 +49,7 @@ class Virtuals(Collection):
             {'tm:ltm:virtual:virtualstate': Virtual}
 
 
-class Virtual(Resource):
+class Virtual(Resource, ExclusiveAttributesMixin):
     """BIG-IP® LTM virtual resource"""
     def __init__(self, virtual_s):
         super(Virtual, self).__init__(virtual_s)
@@ -57,6 +58,8 @@ class Virtual(Resource):
         self._meta_data['attribute_registry'] =\
             {'tm:ltm:virtual:profiles:profilescollectionstate': Profiles_s,
              'tm:ltm:virtual:policies:policiescollectionstate': Policies_s}
+        self._meta_data['exclusive_attributes'].append(('enabled', 'disabled'))
+        self._meta_data['exclusive_attributes'].append(('vlansEnabled', 'vlansDisabled'))
 
     def load(self, **kwargs):
         result = self._load(**kwargs)


### PR DESCRIPTION
Notified of this issue on an article on DC. Simple fix in this file:

f5/bigip/tm/ltm/virtual_server.py