### PR TITLE
method to get version details of a bigip

### DIFF
--- a/f5/bigip/tm/sys/__init__.py
+++ b/f5/bigip/tm/sys/__init__.py
@@ -55,6 +55,7 @@ from f5.bigip.tm.sys.syslog import Syslog
 from f5.bigip.tm.sys.ucs import Ucs
 from f5.bigip.tm.sys.version import Version
 
+
 class Sys(OrganizingCollection):
     """BIG-IP® System (sys) organizing collection."""
     def __init__(self, tm):

--- a/f5/bigip/tm/sys/__init__.py
+++ b/f5/bigip/tm/sys/__init__.py
@@ -53,7 +53,7 @@ from f5.bigip.tm.sys.software import Software
 from f5.bigip.tm.sys.sshd import Sshd
 from f5.bigip.tm.sys.syslog import Syslog
 from f5.bigip.tm.sys.ucs import Ucs
-
+from f5.bigip.tm.sys.version import Version
 
 class Sys(OrganizingCollection):
     """BIG-IP® System (sys) organizing collection."""
@@ -84,5 +84,6 @@ class Sys(OrganizingCollection):
             Software,
             Sshd,
             Syslog,
-            Ucs
+            Ucs,
+            Version
         ]

--- a/f5/bigip/tm/sys/test/functional/test_version.py
+++ b/f5/bigip/tm/sys/test/functional/test_version.py
@@ -27,6 +27,6 @@ def setup_version_test(request, mgmt_root):
 class TestVersion(object):
     def test_entry(self, request, mgmt_root):
         # Load
-        ver1, orig_entries = setup_dns_test(request, mgmt_root)
+        ver1, orig_entries = setup_version_test(request, mgmt_root)
         ver2 = mgmt_root.tm.sys.version.load()
         assert len(ver1.entries) == len(ver2.entries)

--- a/f5/bigip/tm/sys/test/functional/test_version.py
+++ b/f5/bigip/tm/sys/test/functional/test_version.py
@@ -15,14 +15,17 @@
 
 
 def setup_version_test(request, mgmt_root):
+    def teardown():
+        v.selfLink = selflink
+    request.addfinalizer(teardown)
     v = mgmt_root.tm.sys.version.load()
-    entries = v.entries
-    return v, entries
+    selflink = v.selfLink
+    return v, selflink
 
 
 class TestVersion(object):
     def test_entry(self, request, mgmt_root):
         # Load
-        ver1, orig_entries = setup_version_test(request, mgmt_root)
+        ver1, orig_link = setup_version_test(request, mgmt_root)
         ver2 = mgmt_root.tm.sys.version.load()
-        assert len(ver1.entries) == len(ver2.entries)
+        assert len(ver1.selfLink) == len(ver2.selfLink)

--- a/f5/bigip/tm/sys/test/functional/test_version.py
+++ b/f5/bigip/tm/sys/test/functional/test_version.py
@@ -1,0 +1,32 @@
+# Copyright 2016 F5 Networks Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+
+
+def setup_version_test(request, mgmt_root):
+    def teardown():
+        v.entries = entries
+        v.update()
+    request.addfinalizer(teardown)
+    v = mgmt_root.tm.sys.version.load()
+    entries = v.entries
+    return v, entries
+
+
+class TestVersion(object):
+    def test_entry(self, request, mgmt_root):
+        # Load
+        ver1, orig_entries = setup_dns_test(request, mgmt_root)
+        ver2 = mgmt_root.tm.sys.version.load()
+        assert len(ver1.entries) == len(ver2.entries)

--- a/f5/bigip/tm/sys/test/functional/test_version.py
+++ b/f5/bigip/tm/sys/test/functional/test_version.py
@@ -15,12 +15,8 @@
 
 
 def setup_version_test(request, mgmt_root):
-    def teardown():
-        v.entries = entries
-        v.update()
-    request.addfinalizer(teardown)
     v = mgmt_root.tm.sys.version.load()
-    entries = v.entries
+    entries = v.entries    
     return v, entries
 
 

--- a/f5/bigip/tm/sys/test/functional/test_version.py
+++ b/f5/bigip/tm/sys/test/functional/test_version.py
@@ -16,7 +16,7 @@
 
 def setup_version_test(request, mgmt_root):
     v = mgmt_root.tm.sys.version.load()
-    entries = v.entries    
+    entries = v.entries
     return v, entries
 
 

--- a/f5/bigip/tm/sys/test/unit/test_version.py
+++ b/f5/bigip/tm/sys/test/unit/test_version.py
@@ -1,0 +1,39 @@
+# Copyright 2016 F5 Networks Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import mock
+import pytest
+
+
+from f5.bigip.tm.sys.version import Version
+from f5.sdk_exception import UnsupportedMethod
+
+
+@pytest.fixture
+def FakeVersion():
+    fake_sys = mock.MagicMock()
+    return Version(fake_sys)
+
+
+def test_create_raises(FakeVersion):
+    with pytest.raises(UnsupportedMethod) as EIO:
+        FakeVersion.create()
+    assert str(EIO.value) == "Version does not support the create method"
+
+
+def test_delete_raises(FakeVersion):
+    with pytest.raises(UnsupportedMethod) as EIO:
+        FakeVersion.delete()
+    assert str(EIO.value) == "Version does not support the delete method"

--- a/f5/bigip/tm/sys/version.py
+++ b/f5/bigip/tm/sys/version.py
@@ -1,0 +1,44 @@
+# coding=utf-8
+#
+# Copyright 2016 F5 Networks Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+
+"""BIG-IP® system dns module
+
+REST URI
+    ``http://localhost/mgmt/tm/sys/dns``
+
+GUI Path
+    ``System --> Configuration --> Device --> DNS``
+
+REST Kind
+    ``tm:sys:dns:*``
+"""
+
+from f5.bigip.resource import UnnamedResource
+
+
+class Version(UnnamedResource):
+    """BIG-IP® system Version unnamed resource
+
+        .. note::
+
+        This is an unnamed resource so it has not ~Partition~Name pattern
+        at the end of its URI.
+    """
+    def __init__(self, sys):
+        super(Version, self).__init__(sys)
+        self._meta_data['required_load_parameters'] = set()
+        self._meta_data['required_json_kind'] = 'tm:sys:version:versionstats'


### PR DESCRIPTION
#### What issues does this address?
Fixes #1386 
WIP #1386
...

#### What's this change do?
This change is to add support for getting version details of a bigip using f5-sdk. the icontrol rest /mgmt/tm/sys/version has version specific details and this change adds the code to get those details using f5-sdk.

#### Where should the reviewer start?
The reviewer can find a new file called version.py under f5/bigip/tm/sys/ and the tests for the same can be found in the corresponding unit and functional folders.
