### PR TITLE
Makes PATCH allowed for a sys data group file

### DIFF
--- a/f5/bigip/shared/test/unit/test_file_uploads.py
+++ b/f5/bigip/shared/test/unit/test_file_uploads.py
@@ -48,7 +48,6 @@ def test_file_upload_70a(tmpdir, fakeicontrolsession):
     ftu.upload_file(filepath.__str__(), chunk_size=20)
     session_mock = mr._meta_data['icr_session']
     for i in range(3):
-        print(i)
         d = session_mock.post.call_args_list[i][1]['data']
         assert d == b'aaaaaaaaaaaaaaaaaaaa'
     lchunk = session_mock.post.call_args_list[3][1]['data']

--- a/f5/bigip/tm/sys/file.py
+++ b/f5/bigip/tm/sys/file.py
@@ -64,14 +64,6 @@ class Data_Group(Resource):
         self._meta_data['required_creation_parameters'].update(
             ('name', 'sourcePath', 'type'))
 
-    def modify(self, **kwargs):
-        '''Modify is not supported for iFiles
-
-        :raises: UnsupportedOperation
-        '''
-        raise UnsupportedMethod(
-            "%s does not support the update method" % self.__class__.__name__)
-
     def update(self, **kwargs):
         if LooseVersion(self._meta_data['bigip']._meta_data['tmos_version']) \
                 < LooseVersion('12.0.0'):

--- a/f5/bigip/tm/sys/test/functional/test_file.py
+++ b/f5/bigip/tm/sys/test/functional/test_file.py
@@ -95,8 +95,7 @@ def test_CURDL_datagroup(request, mgmt_root):
     # Upload the file
     mgmt_root.shared.file_transfer.uploads.upload_file(ntf.name)
     tpath_name = 'file:/var/config/rest/downloads/{0}'.format(ntf_basename)
-    dg1 = setup_datagroup_test(request, mgmt_root, ntf_basename, tpath_name,
-                               )
+    dg1 = setup_datagroup_test(request, mgmt_root, ntf_basename, tpath_name)
     assert dg1.name == ntf_basename
 
     # Load Object
@@ -115,6 +114,10 @@ def test_CURDL_datagroup(request, mgmt_root):
     # Refresh dg2 and make sure revision matches dg3
     dg2.refresh()
     assert dg2.revision == dg3.revision
+
+    dg4 = mgmt_root.tm.sys.file.data_groups.data_group.load(name=ntf_basename)
+    dg4.modify(sourcePath=tpath_name)
+    assert dg1.revision != dg4.revision
 
 
 def setup_ifile_test(request, mgmt_root, name, sourcepath, **kwargs):

--- a/f5/bigip/tm/sys/test/unit/test_file.py
+++ b/f5/bigip/tm/sys/test/unit/test_file.py
@@ -45,11 +45,6 @@ def test_dg_create_missing_arg(FakeSysDatagroup):
         assert 'type' in ex.value.message
 
 
-def test_dg_modify(FakeSysDatagroup):
-    with pytest.raises(UnsupportedMethod):
-        FakeSysDatagroup.modify(value='Fake')
-
-
 @pytest.fixture
 def FakeSysIfile():
     fake_ifile_s = mock.MagicMock()


### PR DESCRIPTION
Issues:
Fixes #1388

Problem:
PATCHing was not allowed for data groups in sys/file

Analysis:
This fixes the SDK to allow it.

Tests:
functional