### PR TITLE
Adds service policy API to the sdk

### DIFF
--- a/f5/bigip/tm/net/__init__.py
+++ b/f5/bigip/tm/net/__init__.py
@@ -35,6 +35,7 @@ from f5.bigip.tm.net.interface import Interfaces
 from f5.bigip.tm.net.route import Routes
 from f5.bigip.tm.net.route_domain import Route_Domains
 from f5.bigip.tm.net.selfip import Selfips
+from f5.bigip.tm.net.service_policy import Service_Policys
 from f5.bigip.tm.net.timer_policy import Timer_Policys
 from f5.bigip.tm.net.trunk import Trunks
 from f5.bigip.tm.net.tunnels import TunnelS
@@ -52,6 +53,7 @@ class Net(OrganizingCollection):
             Routes,
             Route_Domains,
             Selfips,
+            Service_Policys,
             Timer_Policys,
             Trunks,
             TunnelS,

--- a/f5/bigip/tm/net/service_policy.py
+++ b/f5/bigip/tm/net/service_policy.py
@@ -15,16 +15,16 @@
 # limitations under the License.
 #
 
-"""Directory: net module: timer-policy.
+"""Directory: net module: service-policy.
 
 REST URI
-    ``https://localhost/mgmt/tm/net/timer-policy``
+    ``https://localhost/mgmt/tm/net/service-policy``
 
 GUI Path
-    ``Network --> Service Policies --> Timer Policies``
+    ``Network --> Service Policies --> Service Policies``
 
 REST Kind
-    ``tm:net:timer-policy:*``
+    ``tm:net:service-policy:*``
 """
 
 
@@ -32,18 +32,18 @@ from f5.bigip.resource import Collection
 from f5.bigip.resource import Resource
 
 
-class Timer_Policys(Collection):
+class Service_Policys(Collection):
     def __init__(self, net):
-        super(Timer_Policys, self).__init__(net)
+        super(Service_Policys, self).__init__(net)
         self._meta_data['minimum_version'] = '12.0.0'
-        self._meta_data['allowed_lazy_attributes'] = [Timer_Policy]
+        self._meta_data['allowed_lazy_attributes'] = [Service_Policy]
         self._meta_data['attribute_registry'] = {
-            'tm:net:timer-policy:timer-policystate': Timer_Policy
+            'tm:net:service-policy:service-policystate': Service_Policy
         }
 
 
-class Timer_Policy(Resource):
-    def __init__(self, timer_policys):
-        super(Timer_Policy, self).__init__(timer_policys)
+class Service_Policy(Resource):
+    def __init__(self, service_policys):
+        super(Service_Policy, self).__init__(service_policys)
         self._meta_data['minimum_version'] = '12.0.0'
-        self._meta_data['required_json_kind'] = "tm:net:timer-policy:timer-policystate"
+        self._meta_data['required_json_kind'] = "tm:net:service-policy:service-policystate"

--- a/f5/bigip/tm/net/test/functional/test_service_policy.py
+++ b/f5/bigip/tm/net/test/functional/test_service_policy.py
@@ -1,0 +1,95 @@
+# Copyright 2018 F5 Networks Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import os
+import pytest
+import tempfile
+
+from distutils.version import LooseVersion
+
+
+pytestmark = pytest.mark.skipif(
+    LooseVersion(pytest.config.getoption('--release')) < LooseVersion('12.0.0'),
+    reason='This series of tests requires BIG-IP version 12.0.0 or greater.'
+)
+
+
+@pytest.fixture
+def timer_policy(mgmt_root):
+    file = tempfile.NamedTemporaryFile()
+    name = os.path.basename(file.name)
+    resource = mgmt_root.tm.net.timer_policys.timer_policy.create(
+        name=name
+    )
+    yield resource
+    resource.delete()
+
+
+@pytest.fixture
+def service_policy_with_timer_policy(mgmt_root, timer_policy):
+    file = tempfile.NamedTemporaryFile()
+    name = os.path.basename(file.name)
+    resource = mgmt_root.tm.net.service_policys.service_policy.create(
+        name=name,
+        timerPolicy=timer_policy.name
+    )
+    yield resource
+    resource.delete()
+
+
+@pytest.fixture
+def service_policy(mgmt_root):
+    file = tempfile.NamedTemporaryFile()
+    name = os.path.basename(file.name)
+    resource = mgmt_root.tm.net.service_policys.service_policy.create(
+        name=name
+    )
+    yield resource
+    resource.delete()
+
+
+@pytest.fixture
+def service_policies(mgmt_root):
+    collection = mgmt_root.tm.net.service_policys
+    return collection
+
+
+class TestResource(object):
+    def test_get_collection(self, service_policy, service_policies):
+        assert len(list(service_policies.get_collection())) > 0
+
+    def test_create(self, mgmt_root):
+        file = tempfile.NamedTemporaryFile()
+        name = os.path.basename(file.name)
+        resource = mgmt_root.tm.net.service_policys.service_policy.create(
+            name=name
+        )
+        assert resource.name == name
+        resource.delete()
+
+    def test_update(self, timer_policy, service_policy):
+        service_policy.description = 'my description'
+        service_policy.timerPolicy = timer_policy.name
+        service_policy.update()
+        assert service_policy.description == 'my description'
+        assert service_policy.timerPolicy == '/Common/{0}'.format(timer_policy.name)
+
+    def test_refresh(self, service_policy):
+        assert not hasattr(service_policy, 'description')
+        service_policy.description = 'disabled'
+
+        # A refresh without an update should show no change
+        service_policy.refresh()
+        assert not hasattr(service_policy, 'description')


### PR DESCRIPTION
Issues:
Fixes #1392

Problem:
The service policy API did not exist

Analysis:
This adds it

Tests:
functional