### PR TITLE
Turns off debug. Adds an option to enable it.

### DIFF
--- a/docs/userguide/debugging_api_calls.rst
+++ b/docs/userguide/debugging_api_calls.rst
@@ -31,7 +31,7 @@ Consider the following SDK usage
 .. code-block:: python
 
    from f5.bigip import ManagementRoot
-   mgmt = ManagementRoot('localhost', 'admin', 'admin', port=10443, token=True)
+   mgmt = ManagementRoot('localhost', 'admin', 'admin', port=10443, token=True, debug=True)
    resource = mgmt.tm.ltm.pools.pool.create(name='foobar')
 
 This SDK call communicates with a BIG-IP to create an LTM pool. What if you needed to recreate
@@ -47,7 +47,7 @@ let's print each of them.
 
 .. code-block:: python
 
-   for x in mgmt._debug:
+   for x in mgmt.debug_output:
        print(x)
 
 When this is done, we will be presented with output that resembles the following (printed for readability).
@@ -92,3 +92,15 @@ handy is in the process of debugging errors, or, in implementing new functionali
 
 You can copy and paste the commands as they are printed and use them to issue the same API calls the the
 equivalent SDK code does.
+
+Enabling and disabling
+----------------------
+
+The debug logging can also be enabled and disabled as desired. To do this, you can set the ``debug`` property
+of the ``ManagementRoot`` object to either a truth-like or false-like value. These include,
+
+**Truth**
+'y', 'yes', 'on', '1', 'true', 't', 1, 1.0, True
+
+**False**
+'n', 'no', 'off', '0', 'false', 'f', 0, 0.0, False

--- a/f5/bigip/__init__.py
+++ b/f5/bigip/__init__.py
@@ -65,7 +65,8 @@ class BaseManagement(PathElement):
             icontrol_version=kwargs.pop('icontrol_version', ''),
             token=kwargs.pop('token', False),
             verify=kwargs.pop('verify', False),
-            auth_provider=kwargs.pop('auth_provider', None)
+            auth_provider=kwargs.pop('auth_provider', None),
+            debug=kwargs.pop('debug', False)
         )
         if kwargs:
             raise TypeError('Unexpected **kwargs: %r' % kwargs)
@@ -89,6 +90,7 @@ class BaseManagement(PathElement):
             params['token'] = kwargs['token']
 
         result = iControlRESTSession(**params)
+        result.debug = kwargs['debug']
         return result
 
     def configure_meta_data(self, *args, **kwargs):
@@ -141,10 +143,18 @@ class BaseManagement(PathElement):
         return self._meta_data['tmos_version']
 
     @property
-    def _debug(self):
+    def debug(self):
+        return self.icrs.debug
+
+    @debug.setter
+    def debug(self, value):
+        self.icrs.debug = value
+
+    @property
+    def debug_output(self):
         result = []
-        if self.icrs._debug:
-            result += self.icrs._debug
+        if self.icrs.debug_output:
+            result += self.icrs.debug_output
         return result
 
 

--- a/f5/bigip/test/functional/test__init__.py
+++ b/f5/bigip/test/functional/test__init__.py
@@ -45,6 +45,5 @@ def test_hard_timeout():
 
 
 def test_icontrol_debug_tracing(opt_bigip, opt_username, opt_password, opt_port):
-    m = ManagementRoot(opt_bigip, opt_username, opt_password, port=opt_port)
-    m._debug
-    assert len(m._debug) > 0
+    m = ManagementRoot(opt_bigip, opt_username, opt_password, port=opt_port, debug=True)
+    assert len(m.debug_output) > 0


### PR DESCRIPTION
Issues:
Fixes #1394

Problem:
Debugging could overwhelm memory on long-running sdk usage.

Analysis:
this is a problem, so by default we disable debugging and provide
and option to enable it.

Tests: