### PR TITLE
Add support for tm sys cluster.

### DIFF
--- a/f5/bigip/tm/sys/__init__.py
+++ b/f5/bigip/tm/sys/__init__.py
@@ -30,6 +30,7 @@ REST Kind
 from f5.bigip.resource import OrganizingCollection
 from f5.bigip.tm.sys.application import Application
 from f5.bigip.tm.sys.clock import Clock
+from f5.bigip.tm.sys.cluster import Cluster
 from f5.bigip.tm.sys.config import Config
 from f5.bigip.tm.sys.crypto import Crypto
 from f5.bigip.tm.sys.daemon_log_settings import Daemon_Log_Settings
@@ -66,6 +67,7 @@ class Sys(OrganizingCollection):
         self._meta_data['allowed_lazy_attributes'] = [
             Application,
             Clock,
+            Cluster,
             Config,
             Crypto,
             Daemon_Log_Settings,

--- a/f5/bigip/tm/sys/cluster.py
+++ b/f5/bigip/tm/sys/cluster.py
@@ -27,7 +27,8 @@ REST Kind
     ``tm:sys:cluster:*``
 """
 
-from f5.bigip.resource import OrganizingCollection, UnnamedResource
+from f5.bigip.resource import OrganizingCollection
+from f5.bigip.resource import UnnamedResource
 
 
 class Cluster(OrganizingCollection):
@@ -37,6 +38,7 @@ class Cluster(OrganizingCollection):
         self._meta_data['required_json_kind'] =\
             "tm:sys:cluster:clustercollectionstate"
         self._meta_data['allowed_lazy_attributes'] = [Default]
+
 
 class Default(UnnamedResource):
     """BIG-IP® Analytics settings resource"""

--- a/f5/bigip/tm/sys/cluster.py
+++ b/f5/bigip/tm/sys/cluster.py
@@ -1,0 +1,46 @@
+# coding=utf-8
+#
+# Copyright 2018 F5 Networks Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+
+"""BIG-IP® system cluster module
+
+REST URI
+    ``https://localhost/mgmt/tm/sys/cluster``
+
+GUI Path
+    ``System --> Clusters``
+
+REST Kind
+    ``tm:sys:cluster:*``
+"""
+
+from f5.bigip.resource import OrganizingCollection, UnnamedResource
+
+
+class Cluster(OrganizingCollection):
+    """BIG-IP® license unnamed resource"""
+    def __init__(self, sys):
+        super(Cluster, self).__init__(sys)
+        self._meta_data['required_json_kind'] =\
+            "tm:sys:cluster:clustercollectionstate"
+        self._meta_data['allowed_lazy_attributes'] = [Default]
+
+class Default(UnnamedResource):
+    """BIG-IP® Analytics settings resource"""
+    def __init__(self, settings):
+        super(Default, self).__init__(settings)
+        self._meta_data['required_json_kind'] = \
+            'tm:sys:cluster:clusterstate'

--- a/f5/bigip/tm/sys/test/functional/test_cluster.py
+++ b/f5/bigip/tm/sys/test/functional/test_cluster.py
@@ -15,6 +15,7 @@
 
 from icontrol.exceptions import iControlUnexpectedHTTPError
 
+
 def test_cluster_load(request, mgmt_root):
         # Load will produce exception on non-cluster BIGIP.l
         # iControlUnexpectedHTTPError: 404 Unexpected Error: Not Found for uri:

--- a/f5/bigip/tm/sys/test/functional/test_cluster.py
+++ b/f5/bigip/tm/sys/test/functional/test_cluster.py
@@ -1,0 +1,24 @@
+# Copyright 2018 F5 Networks Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+from icontrol.exceptions import iControlUnexpectedHTTPError
+
+def test_cluster_load(request, mgmt_root):
+        # Load will produce exception on non-cluster BIGIP.l
+        # iControlUnexpectedHTTPError: 404 Unexpected Error: Not Found for uri:
+        try:
+                assert str(mgmt_root.tm.sys.cluster.default.load().kind) == 'tm:sys:cluster:clusterstate'
+        except iControlUnexpectedHTTPError as err:
+                assert('01020036:3: The requested cluster (default) was not found.' in err.message)

--- a/f5/bigip/tm/sys/test/unit/test_cluster.py
+++ b/f5/bigip/tm/sys/test/unit/test_cluster.py
@@ -1,0 +1,55 @@
+# Copyright 2018 F5 Networks Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+
+import mock
+import pytest
+
+from f5.bigip.tm.sys.cluster import Cluster
+from f5.bigip.tm.sys.cluster import Default
+from f5.sdk_exception import UnsupportedMethod, InvalidResource
+
+
+@pytest.fixture
+def FakeCluster():
+    fake_sys = mock.MagicMock()
+    return Cluster(fake_sys)
+
+@pytest.fixture
+def FakeClusterDefault():
+    fake_sys = mock.MagicMock()
+    return Default(fake_sys)
+
+
+def test_create_raises(FakeCluster):
+    with pytest.raises(InvalidResource) as EIO:
+        FakeCluster.create()
+    assert str(EIO.value) == "Only Resources support 'create'."
+
+
+def test_delete_raises(FakeCluster):
+    with pytest.raises(InvalidResource) as EIO:
+        FakeCluster.delete()
+    assert str(EIO.value) == "Only Resources support 'delete'."
+
+def test_default_create_raises(FakeClusterDefault):
+    with pytest.raises(UnsupportedMethod) as EIO:
+        FakeClusterDefault.create()
+    assert str(EIO.value) == "Default does not support the create method"
+
+def test_default_delete_raises(FakeClusterDefault):
+    with pytest.raises(UnsupportedMethod) as EIO:
+        FakeClusterDefault.delete()
+    assert str(EIO.value) == "Default does not support the delete method"

--- a/f5/bigip/tm/sys/test/unit/test_cluster.py
+++ b/f5/bigip/tm/sys/test/unit/test_cluster.py
@@ -19,13 +19,15 @@ import pytest
 
 from f5.bigip.tm.sys.cluster import Cluster
 from f5.bigip.tm.sys.cluster import Default
-from f5.sdk_exception import UnsupportedMethod, InvalidResource
+from f5.sdk_exception import UnsupportedMethod
+from f5.sdk_exception import InvalidResource
 
 
 @pytest.fixture
 def FakeCluster():
     fake_sys = mock.MagicMock()
     return Cluster(fake_sys)
+
 
 @pytest.fixture
 def FakeClusterDefault():
@@ -44,10 +46,12 @@ def test_delete_raises(FakeCluster):
         FakeCluster.delete()
     assert str(EIO.value) == "Only Resources support 'delete'."
 
+
 def test_default_create_raises(FakeClusterDefault):
     with pytest.raises(UnsupportedMethod) as EIO:
         FakeClusterDefault.create()
     assert str(EIO.value) == "Default does not support the create method"
+
 
 def test_default_delete_raises(FakeClusterDefault):
     with pytest.raises(UnsupportedMethod) as EIO:

--- a/f5/bigip/tm/sys/test/unit/test_cluster.py
+++ b/f5/bigip/tm/sys/test/unit/test_cluster.py
@@ -19,8 +19,8 @@ import pytest
 
 from f5.bigip.tm.sys.cluster import Cluster
 from f5.bigip.tm.sys.cluster import Default
-from f5.sdk_exception import UnsupportedMethod
 from f5.sdk_exception import InvalidResource
+from f5.sdk_exception import UnsupportedMethod
 
 
 @pytest.fixture


### PR DESCRIPTION
 In the current project, we need support for sys cluster object to be able to view a cluster config and configure a cluster device.

Two classes have been added in f5/bigip/tm/sys/cluster.py.
Cluster of kind 'tm:sys:cluster:clustercollectionstate' and inherits OrganizingCollection.
Default of kind 'tm:sys:cluster:clusterstate' and inherits UnnamedResource because a cluster object does not support create/delete commands and has only one object with name "default" on
I used this code to get cluster information, configure a members ip, enable/disable a member.
