### PR TITLE
Add support for auth_provider to iWorkflow ManagementRoot

### DIFF
--- a/f5/iworkflow/__init__.py
+++ b/f5/iworkflow/__init__.py
@@ -70,7 +70,7 @@ class BaseManagement(object):
         result = iControlRESTSession(**params)
         result.debug = kwargs['debug']
         return result
-    
+
     def configure_meta_data(self, *args, **kwargs):
         self._meta_data = {
             'allowed_lazy_attributes': [Tm, Cm, Shared],

--- a/f5/iworkflow/__init__.py
+++ b/f5/iworkflow/__init__.py
@@ -130,7 +130,6 @@ class RegularManagementRoot(BaseManagement, PathElement):
 
 class ManagementProxy(object):
     def __new__(cls, *args, **kwargs):
-        print 'Creating management proxy'
         proxy_to = kwargs.pop('proxy_to', None)
         device_group = kwargs.pop('device_group', 'cm-cloud-managed-devices')
 


### PR DESCRIPTION
Small change to enable auth_provider (e.g. LDAP/AD authentication for iWorkflow + REST proxy).
Cloning behaviour (if auth_provider else token) from f5.bigip.BaseManagement.

Tested with iWorkflow 2.3.0 (as REST proxy) and BIG-IP 13.0 (being proxied to).