### PR TITLE
Fixes rh7 deps

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [bdist_rpm]
 release = 1
-requires = six>=1.9.0
-    six<2.0.0
-    f5-icontrol-rest>=1.3.0
-    f5-icontrol-rest<2.0.0
+requires = python-six >= 1.9.0
+    python-six < 2.0.0
+    f5-icontrol-rest >= 1.3.0
+    f5-icontrol-rest < 2.0.0


### PR DESCRIPTION
Issues:
Fixes #1413

Problem:
Dependencies were named wrong, causing te RPM to fail installation on centos and rhel7

Analysis:
This corrects the dependency names

Tests: