### PR TITLE
Adds LTM DNS api

### DIFF
--- a/f5/bigip/tm/ltm/__init__.py
+++ b/f5/bigip/tm/ltm/__init__.py
@@ -32,6 +32,7 @@ from f5.bigip.resource import OrganizingCollection
 from f5.bigip.tm.ltm.auth import Auth
 from f5.bigip.tm.ltm.data_group import Data_Group
 from f5.bigip.tm.ltm.default_node_monitor import Default_Node_Monitor
+from f5.bigip.tm.ltm.dns import Dns
 from f5.bigip.tm.ltm.ifile import Ifiles
 from f5.bigip.tm.ltm.lsn_pools import LSN_Log_Profiles
 from f5.bigip.tm.ltm.lsn_pools import LSN_Pools
@@ -59,6 +60,7 @@ class Ltm(OrganizingCollection):
             Auth,
             Data_Group,
             Default_Node_Monitor,
+            Dns,
             Ifiles,
             LSN_Log_Profiles,
             LSN_Pools,

--- a/f5/bigip/tm/ltm/dns.py
+++ b/f5/bigip/tm/ltm/dns.py
@@ -1,0 +1,55 @@
+# coding=utf-8
+#
+#  Copyright 2018 F5 Networks Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""BIG-IP® LTM DNS submodule.
+
+REST URI
+    ``http://localhost/mgmt/tm/ltm/dns/``
+
+GUI Path
+    ``DNS --> Delivery``
+
+REST Kind
+    ``tm:ltm:dns:*``
+"""
+
+from f5.bigip.resource import Collection
+from f5.bigip.resource import OrganizingCollection
+from f5.bigip.resource import Resource
+
+
+class Dns(OrganizingCollection):
+    def __init__(self, ltm):
+        super(Dns, self).__init__(ltm)
+        self._meta_data['allowed_lazy_attributes'] = [
+            Nameservers,
+        ]
+
+
+class Nameservers(Collection):
+    def __init__(self, dns):
+        super(Nameservers, self).__init__(dns)
+        self._meta_data['allowed_lazy_attributes'] = [Nameserver]
+        self._meta_data['attribute_registry'] = {
+            'tm:ltm:dns:nameserver:nameserverstate': Nameserver
+        }
+
+
+class Nameserver(Resource):
+    def __init__(self, nameservers):
+        super(Nameserver, self).__init__(nameservers)
+        self._meta_data['required_json_kind'] = 'tm:ltm:dns:nameserver:nameserverstate'

--- a/f5/bigip/tm/ltm/test/functional/test_dns.py
+++ b/f5/bigip/tm/ltm/test/functional/test_dns.py
@@ -1,0 +1,59 @@
+# Copyright 2018 F5 Networks Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import pytest
+
+from distutils.version import LooseVersion
+from requests.exceptions import HTTPError
+
+
+@pytest.fixture(scope='function')
+def nameserver(mgmt_root):
+    resource = mgmt_root.tm.ltm.dns.nameservers.nameserver.create(
+        name='ns1',
+        address='1.1.1.1',
+        port=53
+    )
+    yield resource
+    resource.delete()
+
+
+@pytest.mark.skipif(
+    LooseVersion(pytest.config.getoption('--release')) < LooseVersion('12.0.0'),
+    reason='This collection is fully implemented on 12.0.0 or greater.'
+)
+class TestAuditLogs(object):
+    def test_update_refresh(self, nameserver):
+        assert nameserver.kind == 'tm:ltm:dns:nameserver:nameserverstate'
+        assert nameserver.port == 53
+        nameserver.update(port=1234)
+        nameserver.refresh()
+        assert nameserver.port == 1234
+
+    def test_load_no_object(self, mgmt_root):
+        with pytest.raises(HTTPError) as err:
+            mgmt_root.tm.ltm.dns.nameservers.nameserver.load(name='not-found')
+        assert err.value.response.status_code == 404
+
+    def test_load(self, nameserver, mgmt_root):
+        r1 = mgmt_root.tm.ltm.dns.nameservers.nameserver.load(name='ns1')
+        assert r1.kind == 'tm:ltm:dns:nameserver:nameserverstate'
+        r2 = mgmt_root.tm.ltm.dns.nameservers.nameserver.load(name='ns1')
+        assert r1.kind == r2.kind
+        assert r1.selfLink == r2.selfLink
+
+    def test_collection(self, nameserver, mgmt_root):
+        collection = mgmt_root.tm.ltm.dns.nameservers.get_collection()
+        assert len(collection) == 1


### PR DESCRIPTION
Issues:
Fixes #1415

Problem:
DNS API and nameserver sub-api were not in the SDK

Analysis:
This adds them

Tests:
functional