### PR TITLE
Adds transforms for GTM virtual servers

### DIFF
--- a/f5/bigip/tm/gtm/server.py
+++ b/f5/bigip/tm/gtm/server.py
@@ -69,7 +69,22 @@ class Virtual_Server(Resource):
     """BIG-IP® GTM virtual server resource"""
     def __init__(self, virtual_servers_s):
         super(Virtual_Server, self).__init__(virtual_servers_s)
-        self._meta_data['required_creation_parameters'].update((
-            'destination',))
+        self._meta_data['required_creation_parameters'].update(('destination',))
         self._meta_data['required_json_kind'] = \
             'tm:gtm:server:virtual-servers:virtual-serversstate'
+
+    def load(self, **kwargs):
+        kwargs['transform_name'] = True
+        return self._load(**kwargs)
+
+    def exists(self, **kwargs):
+        kwargs['transform_name'] = True
+        return self._exists(**kwargs)
+
+    def refresh(self, **kwargs):
+        kwargs['transform_name'] = True
+        return self._refresh(**kwargs)
+
+    def delete(self, **kwargs):
+        kwargs['transform_name'] = True
+        return self._delete(**kwargs)


### PR DESCRIPTION
Issues:
Fixes #1418

Problem:
GTM virtual server names can include forward slashes. These were
not being escaped properly

Analysis:
This patch adds the necessary transformations

Tests: