### PR TITLE
Addings Stats to allowed_lazy_attributes of tm.ltm collections

### DIFF
--- a/f5/bigip/tm/ltm/node.py
+++ b/f5/bigip/tm/ltm/node.py
@@ -29,6 +29,7 @@ REST Kind
 
 from f5.bigip.resource import Collection
 from f5.bigip.resource import Resource
+from f5.bigip.resource import Stats
 from f5.sdk_exception import NodeStateModifyUnsupported
 
 
@@ -36,7 +37,7 @@ class Nodes(Collection):
     """BIG-IP® LTM node collection"""
     def __init__(self, ltm):
         super(Nodes, self).__init__(ltm)
-        self._meta_data['allowed_lazy_attributes'] = [Node]
+        self._meta_data['allowed_lazy_attributes'] = [Node, Stats]
         self._meta_data['attribute_registry'] =\
             {'tm:ltm:node:nodestate': Node}
 

--- a/f5/bigip/tm/ltm/pool.py
+++ b/f5/bigip/tm/ltm/pool.py
@@ -31,6 +31,7 @@ from requests.exceptions import HTTPError
 
 from f5.bigip.resource import Collection
 from f5.bigip.resource import Resource
+from f5.bigip.resource import Stats
 from f5.sdk_exception import MemberStateModifyUnsupported
 
 
@@ -38,7 +39,7 @@ class Pools(Collection):
     """BIG-IP® LTM pool collection"""
     def __init__(self, ltm):
         super(Pools, self).__init__(ltm)
-        self._meta_data['allowed_lazy_attributes'] = [Pool]
+        self._meta_data['allowed_lazy_attributes'] = [Pool, Stats]
         self._meta_data['attribute_registry'] =\
             {'tm:ltm:pool:poolstate': Pool}
 

--- a/f5/bigip/tm/ltm/rule.py
+++ b/f5/bigip/tm/ltm/rule.py
@@ -29,13 +29,14 @@ REST Kind
 
 from f5.bigip.resource import Collection
 from f5.bigip.resource import Resource
+from f5.bigip.resource import Stats
 
 
 class Rules(Collection):
     """BIG-IP® LTM rule collection"""
     def __init__(self, ltm):
         super(Rules, self).__init__(ltm)
-        self._meta_data['allowed_lazy_attributes'] = [Rule]
+        self._meta_data['allowed_lazy_attributes'] = [Rule, Stats]
         self._meta_data['attribute_registry'] =\
             {'tm:ltm:rule:rulestate': Rule}
 

--- a/f5/bigip/tm/ltm/virtual.py
+++ b/f5/bigip/tm/ltm/virtual.py
@@ -33,6 +33,7 @@ from f5.bigip.mixins import CheckExistenceMixin
 from f5.bigip.mixins import ExclusiveAttributesMixin
 from f5.bigip.resource import Collection
 from f5.bigip.resource import Resource
+from f5.bigip.resource import Stats
 from f5.sdk_exception import NonExtantVirtualPolicy
 from f5.sdk_exception import UnregisteredKind
 from f5.sdk_exception import URICreationCollision
@@ -44,7 +45,7 @@ class Virtuals(Collection):
     """BIG-IP® LTM virtual collection"""
     def __init__(self, ltm):
         super(Virtuals, self).__init__(ltm)
-        self._meta_data['allowed_lazy_attributes'] = [Virtual]
+        self._meta_data['allowed_lazy_attributes'] = [Virtual, Stats]
         self._meta_data['attribute_registry'] =\
             {'tm:ltm:virtual:virtualstate': Virtual}
 

--- a/f5/bigip/tm/ltm/virtual_address.py
+++ b/f5/bigip/tm/ltm/virtual_address.py
@@ -30,13 +30,14 @@ REST Kind
 
 from f5.bigip.resource import Collection
 from f5.bigip.resource import Resource
+from f5.bigip.resource import Stats
 
 
 class Virtual_Address_s(Collection):
     """BIG-IP® LTM virtual address collection."""
     def __init__(self, ltm):
         super(Virtual_Address_s, self).__init__(ltm)
-        self._meta_data['allowed_lazy_attributes'] = [Virtual_Address]
+        self._meta_data['allowed_lazy_attributes'] = [Virtual_Address, Stats]
         self._meta_data['attribute_registry'] =\
             {'tm:ltm:virtual-address:virtual-addressstate': Virtual_Address}
 

--- a/f5/iworkflow/__init__.py
+++ b/f5/iworkflow/__init__.py
@@ -70,7 +70,7 @@ class BaseManagement(object):
         result = iControlRESTSession(**params)
         result.debug = kwargs['debug']
         return result
-    
+
     def configure_meta_data(self, *args, **kwargs):
         self._meta_data = {
             'allowed_lazy_attributes': [Tm, Cm, Shared],

--- a/f5/iworkflow/__init__.py
+++ b/f5/iworkflow/__init__.py
@@ -130,7 +130,6 @@ class RegularManagementRoot(BaseManagement, PathElement):
 
 class ManagementProxy(object):
     def __new__(cls, *args, **kwargs):
-        print 'Creating management proxy'
         proxy_to = kwargs.pop('proxy_to', None)
         device_group = kwargs.pop('device_group', 'cm-cloud-managed-devices')
 


### PR DESCRIPTION
Several tm.ltm collections provide endpoints to batch obtain stats for all items in the collection.
Adding Stats to the allowed_lazy_attributes list gives access to these endpoints.

This PR covers Nodes, Pools, Rules, Virtuals and Virtual Addresses.