### PR TITLE
Added f5.bigip.resource.Stats to the list of allowed_lazy_attributes …

### DIFF
--- a/f5-sdk-dist/scripts/build_exceptions.py
+++ b/f5-sdk-dist/scripts/build_exceptions.py
@@ -108,7 +108,7 @@ Raised when there is an issue producing the .rpm package for Redhat builds.
         super(RedhatError, self).__init__(*args, **kargs)
 
 
-class TestError(BuildError):
+class ErrorInTest(BuildError):
     """TestError
 
 An Error occurred during testing...
@@ -117,7 +117,7 @@ An Error occurred during testing...
 
     def __init__(self, *args, **kargs):
         # exception-specific logic here...
-        super(TestError, self).__init__(*args, **kargs)
+        super(ErrorInTest, self).__init__(*args, **kargs)
 
 
 # vim: set fileencoding=utf-8

--- a/f5-sdk-dist/scripts/install_test.py
+++ b/f5-sdk-dist/scripts/install_test.py
@@ -44,7 +44,7 @@ from inspect import getframeinfo as gfi
 from . import build_expectations
 
 from . terminal import terminal
-from . build_exceptions import TestError
+from . build_exceptions import ErrorInTest
 
 # Globals:
 builds = build_expectations.Builds()
@@ -128,7 +128,7 @@ This object attr is immutable.
         if opts:
             if not isinstance(opts, tuple) or \
                     not isinstance(opts[0][0], OperationSettings):
-                raise TestError(msg=err_msg, frame=gfi(cf()),
+                raise ErrorInTest(msg=err_msg, frame=gfi(cf()),
                                 errnum=errno.ESPIPE)
             self.__expected_opts = opts
 
@@ -180,7 +180,7 @@ tests that are lined up.
                 pkg_search = dist + "/rpms/build/*.rpm"
                 pkg_re = re.compile('el(\d+)\.noarch')
             else:
-                raise TestError(opt.os_type, frame=gfi(cf()),
+                raise ErrorInTest(opt.os_type, frame=gfi(cf()),
                                 errnum=errno.ESPIPE,
                                 msg='opt.os_type(%s) is not recognized!')
             entropy = glob.glob(pkg_search)
@@ -208,7 +208,7 @@ tests that are lined up.
                         break
                     if not found:
                         self._set_failure_reason = \
-                            TestError(opt.os_type, opt.version,
+                            ErrorInTest(opt.os_type, opt.version,
                                       frame=gfi(cf()), errno=errno.ESPIPE,
                                       msg='No pkg found built for')
                         print(str(self.failure_reason))
@@ -266,7 +266,7 @@ Outside:
             msg = "Failed to build docker container to test with"
         if frame:
             self._set_failure_reason = \
-                TestError(pkg.pkg, msg=msg, frame=frame, errnum=errno.ESPIPE)
+                ErrorInTest(pkg.pkg, msg=msg, frame=frame, errnum=errno.ESPIPE)
             raise self.failure_reason
 
 
@@ -301,13 +301,13 @@ on its own.
     try:
         tests = InstallTest()
         tests.execute_tests()
-    except TestError as Error:
+    except ErrorInTest as Error:
         print(str(Error))
         exit(1)
         traceback.print_exc()
     except Exception as Error:
         print(str(Error))
-        TestError(Error, frame=gfi(cf()), errno=-1)
+        ErrorInTest(Error, frame=gfi(cf()), errno=-1)
         print(str(Error))
         traceback.print_exc()
 

--- a/f5/bigip/cm/system.py
+++ b/f5/bigip/cm/system.py
@@ -49,18 +49,33 @@ class Providers(OrganizingCollection):
 class Tmos_s(Collection):
     def __init__(self, providers):
         super(Tmos_s, self).__init__(providers)
-        self._meta_data['required_json_kind'] = 'cm:system:authn:providers:tmos:mcpremoteprovidercollectionstate'
+        if (self._meta_data['bigip']._meta_data['tmos_version'] < '13.1.0'):
+            # Starting from bigip v13.1.0 tmos resources 'kind' was changed
+            # from 'mcpremoteproviderstate' to 'authproviderstate'
+            # and tmos collection 'kind'
+            # from 'mcpremoteprovidercollectionstate' to 'mcpremoteproviderstate"
+            self._meta_data['required_json_kind'] = 'cm:system:authn:providers:tmos:mcpremoteprovidercollectionstate'
+            self._meta_data['attribute_registry'] = {
+                'cm:system:authn:providers:tmos:mcpremoteproviderstate': Tmos
+            }
+        else:
+            self._meta_data['required_json_kind'] = 'cm:system:authn:providers:tmos:authprovidercollectionstate'
+            self._meta_data['attribute_registry'] = {
+                'cm:system:authn:providers:tmos:authproviderstate': Tmos
+            }
         self._meta_data['allowed_lazy_attributes'] = [Tmos]
-        self._meta_data['attribute_registry'] = {
-            'cm:system:authn:providers:tmos:mcpremoteproviderstate': Tmos
-        }
 
 
 class Tmos(Resource):
     def __init__(self, tokens):
         super(Tmos, self).__init__(tokens)
-        self._meta_data['required_json_kind'] = 'cm:system:authn:providers:tmos:mcpremoteproviderstate'
-        self._meta_data['required_load_parameters'] = set(('id',))
+        if (self._meta_data['bigip']._meta_data['tmos_version'] < '13.1.0'):
+            # Starting from bigip v13.1.0 tmos resource 'kind' was changed
+            # from 'mcpremoteproviderstate' to 'authproviderstate'
+            self._meta_data['required_json_kind'] = 'cm:system:authn:providers:tmos:mcpremoteproviderstate'
+        else:
+            self._meta_data['required_json_kind'] = 'ccm:system:authn:providers:tmos:authproviderstate'
+            self._meta_data['required_load_parameters'] = set(('id',))
 
     def create(self, **kwargs):
         raise UnsupportedMethod(

--- a/f5/bigip/cm/system.py
+++ b/f5/bigip/cm/system.py
@@ -47,9 +47,9 @@ class Providers(OrganizingCollection):
 
 
 class Tmos_s(Collection):
-    def __init__(self, providers):
-        super(Tmos_s, self).__init__(providers)
-        if (self._meta_data['bigip']._meta_data['tmos_version'] < '13.1.0'):
+    def __init__(self, container):
+        super(Tmos_s, self).__init__(container)
+        if container._meta_data['bigip']._meta_data['tmos_version'] < '13.1.0':
             # Starting from bigip v13.1.0 tmos resources 'kind' was changed
             # from 'mcpremoteproviderstate' to 'authproviderstate'
             # and tmos collection 'kind'
@@ -67,9 +67,9 @@ class Tmos_s(Collection):
 
 
 class Tmos(Resource):
-    def __init__(self, tokens):
-        super(Tmos, self).__init__(tokens)
-        if (self._meta_data['bigip']._meta_data['tmos_version'] < '13.1.0'):
+    def __init__(self, container):
+        super(Tmos, self).__init__(container)
+        if container._meta_data['bigip']._meta_data['tmos_version'] < '13.1.0':
             # Starting from bigip v13.1.0 tmos resource 'kind' was changed
             # from 'mcpremoteproviderstate' to 'authproviderstate'
             self._meta_data['required_json_kind'] = 'cm:system:authn:providers:tmos:mcpremoteproviderstate'

--- a/f5/bigip/cm/test/unit/test_system.py
+++ b/f5/bigip/cm/test/unit/test_system.py
@@ -23,7 +23,13 @@ import pytest
 @pytest.fixture
 def FakeTmos():
     mo = mock.MagicMock()
+    r = {'tmos_version': '11.6.0'}
+    m = mock.MagicMock()
+    m.__getitem__.side_effect = r.__getitem__
+    m.__iter__.side_effect = r.__iter__
+    mo._meta_data['bigip']._meta_data = m
     resource = Tmos(mo)
+
     return resource
 
 

--- a/f5/bigip/resource.py
+++ b/f5/bigip/resource.py
@@ -288,10 +288,10 @@ class PathElement(LazyAttributeMixin):
         response = session.get(self._meta_data['uri'])
         current_gen = response.json().get('generation', None)
         if current_gen is not None and current_gen != self.generation:
-            error_message = ("The generation of the object on the BigIP " +
-                             "(" + str(current_gen) + ")" +
-                             " does not match the current object" +
-                             "(" + str(self.generation) + ")")
+            error_message = ("The generation of the object on the BigIP "
+                             + "(" + str(current_gen) + ")"
+                             + " does not match the current object"
+                             + "(" + str(self.generation) + ")")
             raise GenerationMismatch(error_message)
 
     def _handle_requests_params(self, kwargs):
@@ -974,7 +974,7 @@ class Resource(ResourceBase):
         return result
 
     def create(self, **kwargs):
-        """Create the resource on the BIG-IP®.
+        r"""Create the resource on the BIG-IP®.
 
         Uses HTTP POST to the `collection` URI to create a resource associated
         with a new unique URI on the device.
@@ -1041,7 +1041,7 @@ class Resource(ResourceBase):
         return self._produce_instance(response)
 
     def load(self, **kwargs):
-        """Load an already configured service into this instance.
+        r"""Load an already configured service into this instance.
 
         This method uses HTTP GET to obtain a resource from the BIG-IP®.
 
@@ -1081,7 +1081,7 @@ class Resource(ResourceBase):
             self.__dict__ = {'deleted': True}
 
     def delete(self, **kwargs):
-        """Delete the resource on the BIG-IP®.
+        r"""Delete the resource on the BIG-IP®.
 
         Uses HTTP DELETE to delete the resource on the BIG-IP®.
 
@@ -1103,7 +1103,7 @@ class Resource(ResourceBase):
         # Need to implement correct teardown here.
 
     def exists(self, **kwargs):
-        """Check for the existence of the named object on the BIG-IP
+        r"""Check for the existence of the named object on the BIG-IP
 
         Sends an HTTP GET to the URI of the named object and if it fails with
         a :exc:~requests.HTTPError` exception it checks the exception for
@@ -1252,7 +1252,7 @@ class AsmResource(Resource):
         return self._produce_instance(response)
 
     def load(self, **kwargs):
-        """Load an already configured service into this instance.
+        r"""Load an already configured service into this instance.
 
         This method uses HTTP GET to obtain a resource from the BIG-IP®.
 
@@ -1303,7 +1303,7 @@ class AsmResource(Resource):
         # Need to implement correct teardown here.
 
     def exists(self, **kwargs):
-        """Check for the existence of the ASM object on the BIG-IP
+        r"""Check for the existence of the ASM object on the BIG-IP
 
         Sends an HTTP GET to the URI of the ASM object and if it fails with
         a :exc:~requests.HTTPError` exception it checks the exception for
@@ -1504,7 +1504,7 @@ class TaskResource(Resource):
         # Need to implement correct teardown here.
 
     def exists(self, **kwargs):
-        """Check for the existence of the Task object on the BIG-IP
+        r"""Check for the existence of the Task object on the BIG-IP
 
         Sends an HTTP GET to the URI of the ASM object and if it fails with
         a :exc:~requests.HTTPError` exception it checks the exception for

--- a/f5/bigip/shared/authz.py
+++ b/f5/bigip/shared/authz.py
@@ -27,7 +27,8 @@ class Authz(OrganizingCollection):
     def __init__(self, shared):
         super(Authz, self).__init__(shared)
         self._meta_data['allowed_lazy_attributes'] = [
-            Tokens_s
+            Tokens_s,
+            Users_s
         ]
 
 
@@ -38,6 +39,16 @@ class Tokens_s(Collection):
         self._meta_data['allowed_lazy_attributes'] = [Token]
         self._meta_data['attribute_registry'] = {
             'shared:authz:tokens:authtokenitemstate': Token
+        }
+
+
+class Users_s(Collection):
+    def __init__(self, authz):
+        super(Users_s, self).__init__(authz)
+        self._meta_data['required_json_kind'] = 'shared:authz:users:userscollectionstate'
+        self._meta_data['allowed_lazy_attributes'] = [User]
+        self._meta_data['attribute_registry'] = {
+            'shared:authz:tokens:usersworkerstate': User
         }
 
 
@@ -82,3 +93,10 @@ class Token(Resource):
             raise ConstraintError(
                 "The provided timeout must be a number between 1 and 36000."
             )
+
+
+class User(Resource):
+    def __init__(self, users):
+        super(User, self).__init__(users)
+        self._meta_data['required_json_kind'] = 'shared:authz:users:usersworkerstate'
+        self._meta_data['required_creation_parameters'] = {'name', 'password'}

--- a/f5/bigip/shared/test/unit/test_authz.py
+++ b/f5/bigip/shared/test/unit/test_authz.py
@@ -14,6 +14,7 @@
 #
 
 from f5.bigip.shared.authz import Token
+from f5.bigip.shared.authz import User
 from f5.sdk_exception import ConstraintError
 from f5.sdk_exception import MissingRequiredCreationParameter
 
@@ -25,6 +26,13 @@ import pytest
 def FakeToken():
     mo = mock.MagicMock()
     resource = Token(mo)
+    return resource
+
+
+@pytest.fixture
+def FakeUser():
+    mo = mock.MagicMock()
+    resource = User(mo)
     return resource
 
 
@@ -40,3 +48,9 @@ class TestToken(object):
     def test_create_no_args(self, FakeToken):
         with pytest.raises(MissingRequiredCreationParameter):
             FakeToken.create()
+
+
+class TestUser(object):
+    def test_create_user_no_args(self, FakeUser):
+        with pytest.raises(MissingRequiredCreationParameter):
+            FakeUser.create()

--- a/f5/bigip/tm/gtm/test/functional/test_server.py
+++ b/f5/bigip/tm/gtm/test/functional/test_server.py
@@ -175,9 +175,10 @@ class TestLoad(object):
                 name='fake_serv1')
         assert err.value.response.status_code == 404
 
-    @pytest.mark.skipif(LooseVersion(pytest.config.getoption('--release')) ==
-                        '11.5.4',
-                        reason='Needs > v11.5.4 TMOS to pass')
+    @pytest.mark.skipif(
+        LooseVersion(pytest.config.getoption('--release')) == '11.5.4',
+        reason='Needs > v11.5.4 TMOS to pass'
+    )
     def test_load(self, request, mgmt_root):
         setup_basic_test(request, mgmt_root, 'fake_serv1', 'Common')
         s1 = mgmt_root.tm.gtm.servers.server.load(name='fake_serv1')
@@ -191,9 +192,9 @@ class TestLoad(object):
         assert s2.disabled is True
 
     @pytest.mark.skipif(
-        LooseVersion(pytest.config.getoption('--release')) >= LooseVersion(
-            '11.6.0'),
-        reason='This test is for 11.5.4 or less.')
+        LooseVersion(pytest.config.getoption('--release')) >= LooseVersion('11.6.0'),
+        reason='This test is for 11.5.4 or less.'
+    )
     def test_load_11_5_4_and_less(self, request, mgmt_root):
         setup_basic_test(request, mgmt_root, 'fake_serv1', 'Common')
         s1 = mgmt_root.tm.gtm.servers.server.load(name='fake_serv1')
@@ -236,8 +237,7 @@ class TestDelete(object):
 class TestServerCollection(object):
     def test_server_collection(self, request, mgmt_root):
         s1 = setup_basic_test(request, mgmt_root, 'fake_serv1', 'Common')
-        if LooseVersion(pytest.config.getoption('--release')) >= \
-                LooseVersion('12.1.0'):
+        if LooseVersion(pytest.config.getoption('--release')) >= LooseVersion('12.1.0'):
             link = 'https://localhost/mgmt/tm/gtm/server/~Common~fake_serv1'
         else:
             link = 'https://localhost/mgmt/tm/gtm/server/fake_serv1'
@@ -258,8 +258,7 @@ class TestVirtualServerSubCollection(object):
         s1 = setup_basic_test(request, mgmt_root, 'fake_serv1', 'Common')
         vs = s1.virtual_servers_s
         vs1 = vs.virtual_server.create(name='vs1', destination='5.5.5.5:80')
-        if LooseVersion(pytest.config.getoption('--release')) >= \
-                LooseVersion('12.1.0'):
+        if LooseVersion(pytest.config.getoption('--release')) >= LooseVersion('12.1.0'):
             link = 'https://localhost/mgmt/tm/gtm/server/~Common~fake_serv1' \
                    '/virtual-servers/vs'
         else:
@@ -364,9 +363,10 @@ class TestVirtualServerSubCollection(object):
             elif k == limit:
                 assert vs1.__dict__[k] == 'enabled'
 
-    @pytest.mark.skipif(pytest.config.getoption('--release') == '11.6.0',
-                        reason='Due to a bug in 11.6.0 Final this test '
-                               'fails')
+    @pytest.mark.skipif(
+        pytest.config.getoption('--release') == '11.6.0',
+        reason='Due to a bug in 11.6.0 Final this test fails'
+    )
     def test_delete(self, request, mgmt_root):
         vs1 = setup_vs_basic_test(request, mgmt_root, 'vs2', '5.5.5.5:80')
         vs1.delete()
@@ -378,8 +378,7 @@ class TestVirtualServerSubCollection(object):
 
     def test_virtual_server_collection(self, request, mgmt_root):
         vs1 = setup_vs_basic_test(request, mgmt_root, 'vs1', '5.5.5.5:80')
-        if LooseVersion(pytest.config.getoption('--release')) >= \
-                LooseVersion('12.1.0'):
+        if LooseVersion(pytest.config.getoption('--release')) >= LooseVersion('12.1.0'):
             link = 'https://localhost/mgmt/tm/gtm/server/~Common~fake_serv1' \
                    '/virtual-servers/vs'
         else:

--- a/f5/bigip/tm/gtm/test/functional/test_topology.py
+++ b/f5/bigip/tm/gtm/test/functional/test_topology.py
@@ -24,6 +24,8 @@ from f5.sdk_exception import UnsupportedTmosVersion
 from pytest import symbols
 from requests.exceptions import HTTPError
 
+RELEASE_LOOSE_VERSION = LooseVersion(pytest.config.getoption('--release'))
+
 pytestmark = pytest.mark.skipif(
     symbols
     and hasattr(symbols, 'modules')
@@ -64,10 +66,10 @@ def setup_basic_test(request, mgmt_root, name):
     return top1
 
 
-@pytest.mark.skipif(LooseVersion(pytest.config.getoption('--release')) <
-                    '12.1.0' or
-                    LooseVersion(pytest.config.getoption('--release')) ==
-                    '12.0.0', reason='Needs > v12.1.0 TMOS to pass')
+@pytest.mark.skipif(
+    RELEASE_LOOSE_VERSION < '12.1.0' or RELEASE_LOOSE_VERSION == '12.0.0',
+    reason='Needs > v12.1.0 TMOS to pass'
+)
 class TestCreate(object):
     def test_create_no_args(self, mgmt_root):
         with pytest.raises(MissingRequiredCreationParameter):
@@ -105,10 +107,10 @@ class TestCreate(object):
         assert err.value.response.status_code == 409
 
 
-@pytest.mark.skipif(LooseVersion(pytest.config.getoption('--release')) >=
-                    '12.1.0' or
-                    LooseVersion(pytest.config.getoption('--release')) ==
-                    '12.0.0', reason='Needs < v12.1.0 TMOS to pass')
+@pytest.mark.skipif(
+    RELEASE_LOOSE_VERSION >= '12.1.0' or RELEASE_LOOSE_VERSION == '12.0.0',
+    reason='Needs < v12.1.0 TMOS to pass'
+)
 class TestCreate_pre_12_1_0(object):
     def test_create_no_args(self, mgmt_root):
         with pytest.raises(MissingRequiredCreationParameter):
@@ -146,18 +148,20 @@ class TestCreate_pre_12_1_0(object):
         assert err.value.response.status_code == 409
 
 
-@pytest.mark.skipif(LooseVersion(pytest.config.getoption('--release')) ==
-                    '12.0.0', reason='Resource disabled for TMOS 12.0.0')
+@pytest.mark.skipif(
+    RELEASE_LOOSE_VERSION == '12.0.0',
+    reason='Resource disabled for TMOS 12.0.0'
+)
 class TestRefresh(object):
     def test_refresh_raises(self, mgmt_root):
         with pytest.raises(UnsupportedOperation):
             mgmt_root.tm.gtm.topology_s.topology.refresh()
 
 
-@pytest.mark.skipif(LooseVersion(pytest.config.getoption('--release')) <
-                    '12.1.0' or
-                    LooseVersion(pytest.config.getoption('--release')) ==
-                    '12.0.0', reason='Needs > v12.1.0 TMOS to pass')
+@pytest.mark.skipif(
+    RELEASE_LOOSE_VERSION < '12.1.0' or RELEASE_LOOSE_VERSION == '12.0.0',
+    reason='Needs > v12.1.0 TMOS to pass'
+)
 class TestLoad(object):
     def test_load_no_object(self, mgmt_root):
         with pytest.raises(HTTPError) as err:
@@ -174,10 +178,10 @@ class TestLoad(object):
         assert t1.selfLink == t2.selfLink
 
 
-@pytest.mark.skipif(LooseVersion(pytest.config.getoption('--release')) >=
-                    '12.1.0' or
-                    LooseVersion(pytest.config.getoption('--release')) ==
-                    '12.0.0', reason='Needs < v12.1.0 TMOS to pass')
+@pytest.mark.skipif(
+    RELEASE_LOOSE_VERSION >= '12.1.0' or RELEASE_LOOSE_VERSION == '12.0.0',
+    reason='Needs < v12.1.0 TMOS to pass'
+)
 class TestLoad_pre_12_1_0(object):
     def test_load_no_object(self, mgmt_root):
         with pytest.raises(HTTPError) as err:
@@ -194,24 +198,30 @@ class TestLoad_pre_12_1_0(object):
         assert t1.selfLink == t2.selfLink
 
 
-@pytest.mark.skipif(LooseVersion(pytest.config.getoption('--release')) ==
-                    '12.0.0', reason='Resource disabled for TMOS 12.0.0')
+@pytest.mark.skipif(
+    RELEASE_LOOSE_VERSION == '12.0.0',
+    reason='Resource disabled for TMOS 12.0.0'
+)
 class TestUpdate(object):
     def test_update_raises(self, mgmt_root):
         with pytest.raises(UnsupportedOperation):
             mgmt_root.tm.gtm.topology_s.topology.update()
 
 
-@pytest.mark.skipif(LooseVersion(pytest.config.getoption('--release')) ==
-                    '12.0.0', reason='Resource disabled for TMOS 12.0.0')
+@pytest.mark.skipif(
+    RELEASE_LOOSE_VERSION == '12.0.0',
+    reason='Resource disabled for TMOS 12.0.0'
+)
 class TestModify(object):
     def test_modify_raises(self, mgmt_root):
         with pytest.raises(UnsupportedOperation):
             mgmt_root.tm.gtm.topology_s.topology.modify()
 
 
-@pytest.mark.skipif(LooseVersion(pytest.config.getoption('--release')) <
-                    '12.1.0', reason='Needs > v12.1.0 TMOS to pass')
+@pytest.mark.skipif(
+    RELEASE_LOOSE_VERSION < '12.1.0',
+    reason='Needs > v12.1.0 TMOS to pass'
+)
 class TestDelete(object):
     def test_delete(self, request, mgmt_root):
         r1 = setup_basic_test(request, mgmt_root, NAME)
@@ -221,10 +231,10 @@ class TestDelete(object):
         assert err.value.response.status_code == 404
 
 
-@pytest.mark.skipif(LooseVersion(pytest.config.getoption('--release')) >=
-                    '12.1.0' or
-                    LooseVersion(pytest.config.getoption('--release')) ==
-                    '12.0.0', reason='Needs < v12.1.0 TMOS to pass')
+@pytest.mark.skipif(
+    RELEASE_LOOSE_VERSION >= '12.1.0' or RELEASE_LOOSE_VERSION == '12.0.0',
+    reason='Needs < v12.1.0 TMOS to pass'
+)
 class TestDelete_pre_12_1_0(object):
     def test_delete(self, request, mgmt_root):
         r1 = setup_basic_test(request, mgmt_root, NAME_SPACES)
@@ -234,10 +244,10 @@ class TestDelete_pre_12_1_0(object):
         assert err.value.response.status_code == 404
 
 
-@pytest.mark.skipif(LooseVersion(pytest.config.getoption('--release')) <
-                    '12.1.0' or
-                    LooseVersion(pytest.config.getoption('--release')) ==
-                    '12.0.0', reason='Needs > v12.1.0 TMOS to pass')
+@pytest.mark.skipif(
+    RELEASE_LOOSE_VERSION < '12.1.0' or RELEASE_LOOSE_VERSION == '12.0.0',
+    reason='Needs > v12.1.0 TMOS to pass'
+)
 class TestTopologyCollection(object):
     def test_region_collection(self, request, mgmt_root):
         setup_create_test(request, mgmt_root, NAME)
@@ -257,10 +267,10 @@ class TestTopologyCollection(object):
         assert isinstance(rc[0], Topology)
 
 
-@pytest.mark.skipif(LooseVersion(pytest.config.getoption('--release')) >=
-                    '12.1.0' or
-                    LooseVersion(pytest.config.getoption('--release')) ==
-                    '12.0.0', reason='Needs < v12.1.0 TMOS to pass')
+@pytest.mark.skipif(
+    RELEASE_LOOSE_VERSION >= '12.1.0' or RELEASE_LOOSE_VERSION == '12.0.0',
+    reason='Needs < v12.1.0 TMOS to pass'
+)
 class TestTopologyCollection_pre_12_1_0(object):
     def test_region_collection(self, request, mgmt_root):
         setup_create_test(request, mgmt_root, NAME_SPACES)
@@ -280,8 +290,10 @@ class TestTopologyCollection_pre_12_1_0(object):
         assert isinstance(rc[0], Topology)
 
 
-@pytest.mark.skipif(LooseVersion(pytest.config.getoption('--release')) !=
-                    '12.0.0', reason='Only TMOS 12.0.0 test')
+@pytest.mark.skipif(
+    RELEASE_LOOSE_VERSION != '12.0.0',
+    reason='Only TMOS 12.0.0 test'
+)
 class TestTopology_12_0_0(object):
     def test_topology_raises(self, request, mgmt_root):
         with pytest.raises(UnsupportedTmosVersion):

--- a/f5/bigip/tm/ltm/node.py
+++ b/f5/bigip/tm/ltm/node.py
@@ -29,6 +29,7 @@ REST Kind
 
 from f5.bigip.resource import Collection
 from f5.bigip.resource import Resource
+from f5.bigip.resource import Stats
 from f5.sdk_exception import NodeStateModifyUnsupported
 
 
@@ -36,7 +37,7 @@ class Nodes(Collection):
     """BIG-IP® LTM node collection"""
     def __init__(self, ltm):
         super(Nodes, self).__init__(ltm)
-        self._meta_data['allowed_lazy_attributes'] = [Node]
+        self._meta_data['allowed_lazy_attributes'] = [Node, Stats]
         self._meta_data['attribute_registry'] =\
             {'tm:ltm:node:nodestate': Node}
 

--- a/f5/bigip/tm/ltm/pool.py
+++ b/f5/bigip/tm/ltm/pool.py
@@ -31,6 +31,7 @@ from requests.exceptions import HTTPError
 
 from f5.bigip.resource import Collection
 from f5.bigip.resource import Resource
+from f5.bigip.resource import Stats
 from f5.sdk_exception import MemberStateModifyUnsupported
 
 
@@ -38,7 +39,7 @@ class Pools(Collection):
     """BIG-IP® LTM pool collection"""
     def __init__(self, ltm):
         super(Pools, self).__init__(ltm)
-        self._meta_data['allowed_lazy_attributes'] = [Pool]
+        self._meta_data['allowed_lazy_attributes'] = [Pool, Stats]
         self._meta_data['attribute_registry'] =\
             {'tm:ltm:pool:poolstate': Pool}
 

--- a/f5/bigip/tm/ltm/rule.py
+++ b/f5/bigip/tm/ltm/rule.py
@@ -29,13 +29,14 @@ REST Kind
 
 from f5.bigip.resource import Collection
 from f5.bigip.resource import Resource
+from f5.bigip.resource import Stats
 
 
 class Rules(Collection):
     """BIG-IP® LTM rule collection"""
     def __init__(self, ltm):
         super(Rules, self).__init__(ltm)
-        self._meta_data['allowed_lazy_attributes'] = [Rule]
+        self._meta_data['allowed_lazy_attributes'] = [Rule, Stats]
         self._meta_data['attribute_registry'] =\
             {'tm:ltm:rule:rulestate': Rule}
 

--- a/f5/bigip/tm/ltm/test/functional/test_node.py
+++ b/f5/bigip/tm/ltm/test/functional/test_node.py
@@ -214,12 +214,11 @@ class TestNodes(object):
     def test_stats(self, request, mgmt_root, opt_release):
         setup_node_test(request, mgmt_root, 'Common', 'node1', '192.168.100.1')
         nodes_stats = mgmt_root.tm.ltm.nodes.stats.load()
-        assert 'https://localhost/mgmt/tm/ltm/node/' +\
-            '~Common~node1/stats' in nodes_stats.entries
-        nodes_nested_stats = nodes_stats.entries['https://localhost/mgmt/tm/' +\
-            'ltm/node/~Common~node1/stats']['nestedStats']
-        assert nodes_nested_stats['selfLink'] == 'https://localhost/mgmt/tm/' +\
-            'ltm/node/~Common~node1/stats?ver=' + opt_release
-        entries = nodes_nested_stats['entries']
+        stats_link = 'https://localhost/mgmt/tm/ltm/node/' +\
+            '~Common~node1/stats'
+        assert stats_link in nodes_stats.entries
+        node_nested_stats = nodes_stats.entries[stats_link]['nestedStats']
+        assert node_nested_stats['selfLink'] == stats_link+'?ver='+opt_release
+        entries = node_nested_stats['entries']
         assert entries['tmName']['description'] == '/Common/node1'
         assert entries['status.enabledState']['description'] == 'enabled'

--- a/f5/bigip/tm/ltm/test/functional/test_node.py
+++ b/f5/bigip/tm/ltm/test/functional/test_node.py
@@ -210,3 +210,16 @@ class TestNodes(object):
         nodes = sc.get_collection()
         assert len(nodes) >= 1
         assert [n for n in nodes if n.name == 'node1']
+
+    def test_stats(self, request, mgmt_root, opt_release):
+        setup_node_test(request, mgmt_root, 'Common', 'node1', '192.168.100.1')
+        nodes_stats = mgmt_root.tm.ltm.nodes.stats.load()
+        assert 'https://localhost/mgmt/tm/ltm/node/' +\
+            '~Common~node1/stats' in nodes_stats.entries
+        nodes_nested_stats = nodes_stats.entries['https://localhost/mgmt/tm/' +\
+            'ltm/node/~Common~node1/stats']['nestedStats']
+        assert nodes_nested_stats['selfLink'] == 'https://localhost/mgmt/tm/' +\
+            'ltm/node/~Common~node1/stats?ver=' + opt_release
+        entries = nodes_nested_stats['entries']
+        assert entries['tmName']['description'] == '/Common/node1'
+        assert entries['status.enabledState']['description'] == 'enabled'

--- a/f5/bigip/tm/ltm/test/functional/test_pool.py
+++ b/f5/bigip/tm/ltm/test/functional/test_pool.py
@@ -259,6 +259,22 @@ class TestPoolMembersCollection(object):
                                    "'user-up' or 'user-down'"
 
 
+class TestPoolStats(object):
+    def test_get_pools_stats(self, request, mgmt_root, opt_release):
+        m1, pool = setup_member_test(request, mgmt_root, 'membertestpool1',
+                             'Common')
+        pools_stats = mgmt_root.tm.ltm.pools.stats.load()
+        assert 'https://localhost/mgmt/tm/ltm/pool/' +\
+            '~Common~membertestpool1/stats' in pools_stats.entries
+        pool_nested_stats = pools_stats.entries['https://localhost/mgmt/tm/' +\
+            'ltm/pool/~Common~membertestpool1/stats']['nestedStats']
+        assert pool_nested_stats['selfLink'] == 'https://localhost/mgmt/tm/' +\
+            'ltm/pool/~Common~membertestpool1/stats?var=' + opt_release
+        entries = pool_nested_stats['entries']
+        assert entries['tmName']['description'] == '/Common/membertestpool1'
+        assert entries['status.enabledState']['description'] == 'enabled'
+
+
 class TestPool(object):
     def test_create_no_args(self, mgmt_root):
         pool1 = mgmt_root.tm.ltm.pools.pool

--- a/f5/bigip/tm/ltm/test/functional/test_pool.py
+++ b/f5/bigip/tm/ltm/test/functional/test_pool.py
@@ -260,16 +260,15 @@ class TestPoolMembersCollection(object):
 
 
 class TestPoolsStats(object):
-    def test_get_pools_stats(self, request, mgmt_root, opt_release):
+    def test_stats(self, request, mgmt_root, opt_release):
         m1, pool = setup_member_test(request, mgmt_root, 'membertestpool1',
-                             'Common')
+                                     'Common')
         pools_stats = mgmt_root.tm.ltm.pools.stats.load()
-        assert 'https://localhost/mgmt/tm/ltm/pool/' +\
-            '~Common~membertestpool1/stats' in pools_stats.entries
-        pool_nested_stats = pools_stats.entries['https://localhost/mgmt/tm/' +\
-            'ltm/pool/~Common~membertestpool1/stats']['nestedStats']
-        assert pool_nested_stats['selfLink'] == 'https://localhost/mgmt/tm/' +\
-            'ltm/pool/~Common~membertestpool1/stats?ver=' + opt_release
+        stats_link = 'https://localhost/mgmt/tm/ltm/pool/' +\
+            '~Common~membertestpool1/stats'
+        assert stats_link in pools_stats.entries
+        pool_nested_stats = pools_stats.entries[stats_link]['nestedStats']
+        assert pool_nested_stats['selfLink'] == stats_link+'?ver='+opt_release
         entries = pool_nested_stats['entries']
         assert entries['tmName']['description'] == '/Common/membertestpool1'
         assert entries['status.enabledState']['description'] == 'enabled'

--- a/f5/bigip/tm/ltm/test/functional/test_pool.py
+++ b/f5/bigip/tm/ltm/test/functional/test_pool.py
@@ -259,7 +259,7 @@ class TestPoolMembersCollection(object):
                                    "'user-up' or 'user-down'"
 
 
-class TestPoolStats(object):
+class TestPoolsStats(object):
     def test_get_pools_stats(self, request, mgmt_root, opt_release):
         m1, pool = setup_member_test(request, mgmt_root, 'membertestpool1',
                              'Common')
@@ -269,7 +269,7 @@ class TestPoolStats(object):
         pool_nested_stats = pools_stats.entries['https://localhost/mgmt/tm/' +\
             'ltm/pool/~Common~membertestpool1/stats']['nestedStats']
         assert pool_nested_stats['selfLink'] == 'https://localhost/mgmt/tm/' +\
-            'ltm/pool/~Common~membertestpool1/stats?var=' + opt_release
+            'ltm/pool/~Common~membertestpool1/stats?ver=' + opt_release
         entries = pool_nested_stats['entries']
         assert entries['tmName']['description'] == '/Common/membertestpool1'
         assert entries['status.enabledState']['description'] == 'enabled'

--- a/f5/bigip/tm/ltm/test/functional/test_rule.py
+++ b/f5/bigip/tm/ltm/test/functional/test_rule.py
@@ -174,3 +174,18 @@ class TestRuleCollection(object):
         assert isinstance(rc, list)
         assert len(rc)
         assert isinstance(rc[0], Rule)
+
+
+class TestRulesStats(object):
+    def test_stats(self, request, mgmt_root, opt_release):
+        setup_basic_test(request, mgmt_root, 'rule1', 'Common')
+        rules_stats = mgmt_root.tm.ltm.rules.stats.load()
+        assert 'https://localhost/mgmt/tm/ltm/rule/' +\
+            '~Common~rule1:CLIENT_ACCEPTED/stats' in rules_stats.entries
+        rule_nested_stats = rules_stats.entries['https://localhost/mgmt/tm/' +\
+            'ltm/rule/~Common~rule1:CLIENT_ACCEPTED/stats']['nestedStats']
+        assert rule_nested_stats['selfLink'] == 'https://localhost/mgmt/tm/' +\
+            'ltm/rule/~Common~rule1:CLIENT_ACCEPTED/stats?ver=' + opt_release
+        entries = rule_nested_stats['entries']
+        assert entries['tmName']['description'] == '/Common/rule1'
+        assert entries['totalExecutions']['value'] == 0

--- a/f5/bigip/tm/ltm/test/functional/test_rule.py
+++ b/f5/bigip/tm/ltm/test/functional/test_rule.py
@@ -180,12 +180,11 @@ class TestRulesStats(object):
     def test_stats(self, request, mgmt_root, opt_release):
         setup_basic_test(request, mgmt_root, 'rule1', 'Common')
         rules_stats = mgmt_root.tm.ltm.rules.stats.load()
-        assert 'https://localhost/mgmt/tm/ltm/rule/' +\
-            '~Common~rule1:CLIENT_ACCEPTED/stats' in rules_stats.entries
-        rule_nested_stats = rules_stats.entries['https://localhost/mgmt/tm/' +\
-            'ltm/rule/~Common~rule1:CLIENT_ACCEPTED/stats']['nestedStats']
-        assert rule_nested_stats['selfLink'] == 'https://localhost/mgmt/tm/' +\
-            'ltm/rule/~Common~rule1:CLIENT_ACCEPTED/stats?ver=' + opt_release
+        stats_link = 'https://localhost/mgmt/tm/ltm/rule/' +\
+            '~Common~rule1:CLIENT_ACCEPTED/stats'
+        assert stats_link in rules_stats.entries
+        rule_nested_stats = rules_stats.entries[stats_link]['nestedStats']
+        assert rule_nested_stats['selfLink'] == stats_link+'?ver='+opt_release
         entries = rule_nested_stats['entries']
         assert entries['tmName']['description'] == '/Common/rule1'
         assert entries['totalExecutions']['value'] == 0

--- a/f5/bigip/tm/ltm/test/functional/test_virtual.py
+++ b/f5/bigip/tm/ltm/test/functional/test_virtual.py
@@ -256,15 +256,14 @@ class TestPolicies(object):
 
 
 class TestVirtualsStats(object):
-    def test_get_virtuals_stats(self, request, mgmt_root, opt_release):
+    def test_stats(self, request, mgmt_root, opt_release):
         setup_virtual_test(request, mgmt_root, 'Common', 'tv1')
         vs_stats = mgmt_root.tm.ltm.virtuals.stats.load()
-        assert 'https://localhost/mgmt/tm/ltm/virtual/' +\
-            '~Common~tv1/stats' in vs_stats.entries
-        vs_nested_stats = vs_stats.entries['https://localhost/mgmt/tm/' +\
-            'ltm/virtual/~Common~tv1/stats']['nestedStats']
-        assert vs_nested_stats['selfLink'] == 'https://localhost/mgmt/tm/' +\
-            'ltm/virtual/~Common~tv1/stats?ver=' + opt_release
+        stats_link = 'https://localhost/mgmt/tm/ltm/virtual/' +\
+            '~Common~tv1/stats'
+        assert stats_link in vs_stats.entries
+        vs_nested_stats = vs_stats.entries[stats_link]['nestedStats']
+        assert vs_nested_stats['selfLink'] == stats_link+'?ver='+opt_release
         entries = vs_nested_stats['entries']
         assert entries['tmName']['description'] == '/Common/tv1'
         assert entries['status.enabledState']['description'] == 'enabled'

--- a/f5/bigip/tm/ltm/test/functional/test_virtual.py
+++ b/f5/bigip/tm/ltm/test/functional/test_virtual.py
@@ -253,3 +253,18 @@ class TestPolicies(object):
         pclst = v1.policies_s.get_collection()
         assert len(pclst) > 0
         assert isinstance(pclst[0], Policies)
+
+
+class TestVirtualsStats(object):
+    def test_get_virtuals_stats(self, request, mgmt_root, opt_release):
+        setup_virtual_test(request, mgmt_root, 'Common', 'tv1')
+        vs_stats = mgmt_root.tm.ltm.virtuals.stats.load()
+        assert 'https://localhost/mgmt/tm/ltm/virtual/' +\
+            '~Common~tv1/stats' in vs_stats.entries
+        vs_nested_stats = vs_stats.entries['https://localhost/mgmt/tm/' +\
+            'ltm/virtual/~Common~tv1/stats']['nestedStats']
+        assert vs_nested_stats['selfLink'] == 'https://localhost/mgmt/tm/' +\
+            'ltm/virtual/~Common~tv1/stats?ver=' + opt_release
+        entries = vs_nested_stats['entries']
+        assert entries['tmName']['description'] == '/Common/tv1'
+        assert entries['status.enabledState']['description'] == 'enabled'

--- a/f5/bigip/tm/ltm/test/functional/test_virtual_address.py
+++ b/f5/bigip/tm/ltm/test/functional/test_virtual_address.py
@@ -41,6 +41,19 @@ class TestVirtualAddress_s(object):
         assert len(vac) >= 1
         assert [va for va in vac if va.name == '0.0.0.0']
 
+    def test_stats(self, request, mgmt_root, opt_release):
+        setup_virtual_address_s_test(request, mgmt_root, 'va_vs_test-1', 'Common')
+        va_stats = mgmt_root.tm.ltm.virtual_address_s.stats.load()
+        assert 'https://localhost/mgmt/tm/ltm/virtual-address/' +\
+            '~Common~0.0.0.0/stats' in va_stats.entries
+        va_nested_stats = va_stats.entries['https://localhost/mgmt/tm/' +\
+            'ltm/virtual-address/~Common~0.0.0.0/stats']['nestedStats']
+        assert va_nested_stats['selfLink'] == 'https://localhost/mgmt/tm/' +\
+            'ltm/virtual-address/~Common~0.0.0.0/stats?ver=' + opt_release
+        entries = va_nested_stats['entries']
+        assert entries['tmName']['description'] == '/Common/0.0.0.0'
+        assert entries['status.enabledState']['description'] == 'enabled'
+
 
 class TestVirtualAddress(object):
     def test_CURDLE(self, request, mgmt_root):

--- a/f5/bigip/tm/ltm/test/functional/test_virtual_address.py
+++ b/f5/bigip/tm/ltm/test/functional/test_virtual_address.py
@@ -44,12 +44,11 @@ class TestVirtualAddress_s(object):
     def test_stats(self, request, mgmt_root, opt_release):
         setup_virtual_address_s_test(request, mgmt_root, 'va_vs_test-1', 'Common')
         va_stats = mgmt_root.tm.ltm.virtual_address_s.stats.load()
-        assert 'https://localhost/mgmt/tm/ltm/virtual-address/' +\
-            '~Common~0.0.0.0/stats' in va_stats.entries
-        va_nested_stats = va_stats.entries['https://localhost/mgmt/tm/' +\
-            'ltm/virtual-address/~Common~0.0.0.0/stats']['nestedStats']
-        assert va_nested_stats['selfLink'] == 'https://localhost/mgmt/tm/' +\
-            'ltm/virtual-address/~Common~0.0.0.0/stats?ver=' + opt_release
+        stats_link = 'https://localhost/mgmt/tm/ltm/virtual-address/' +\
+            '~Common~0.0.0.0/stats'
+        assert stats_link in va_stats.entries
+        va_nested_stats = va_stats.entries[stats_link]['nestedStats']
+        assert va_nested_stats['selfLink'] == stats_link+'?ver='+opt_release
         entries = va_nested_stats['entries']
         assert entries['tmName']['description'] == '/Common/0.0.0.0'
         assert entries['status.enabledState']['description'] == 'enabled'

--- a/f5/bigip/tm/ltm/virtual.py
+++ b/f5/bigip/tm/ltm/virtual.py
@@ -33,6 +33,7 @@ from f5.bigip.mixins import CheckExistenceMixin
 from f5.bigip.mixins import ExclusiveAttributesMixin
 from f5.bigip.resource import Collection
 from f5.bigip.resource import Resource
+from f5.bigip.resource import Stats
 from f5.sdk_exception import NonExtantVirtualPolicy
 from f5.sdk_exception import UnregisteredKind
 from f5.sdk_exception import URICreationCollision
@@ -44,7 +45,7 @@ class Virtuals(Collection):
     """BIG-IP® LTM virtual collection"""
     def __init__(self, ltm):
         super(Virtuals, self).__init__(ltm)
-        self._meta_data['allowed_lazy_attributes'] = [Virtual]
+        self._meta_data['allowed_lazy_attributes'] = [Virtual, Stats]
         self._meta_data['attribute_registry'] =\
             {'tm:ltm:virtual:virtualstate': Virtual}
 

--- a/f5/bigip/tm/ltm/virtual_address.py
+++ b/f5/bigip/tm/ltm/virtual_address.py
@@ -30,13 +30,14 @@ REST Kind
 
 from f5.bigip.resource import Collection
 from f5.bigip.resource import Resource
+from f5.bigip.resource import Stats
 
 
 class Virtual_Address_s(Collection):
     """BIG-IP® LTM virtual address collection."""
     def __init__(self, ltm):
         super(Virtual_Address_s, self).__init__(ltm)
-        self._meta_data['allowed_lazy_attributes'] = [Virtual_Address]
+        self._meta_data['allowed_lazy_attributes'] = [Virtual_Address, Stats]
         self._meta_data['attribute_registry'] =\
             {'tm:ltm:virtual-address:virtual-addressstate': Virtual_Address}
 

--- a/f5/bigip/tm/net/test/functional/test_trunk.py
+++ b/f5/bigip/tm/net/test/functional/test_trunk.py
@@ -22,9 +22,10 @@ import tempfile
 
 
 pytestmark = pytest.mark.skipif(
-    not symbols or
-    symbols and not hasattr(symbols, 'run_hardware_tests') or
-    symbols and hasattr(symbols, 'run_hardware_tests') and symbols.modules['run_hardware_tests'] is False,
+    not symbols
+    or symbols and not hasattr(symbols, 'run_hardware_tests')
+    or symbols and hasattr(symbols, 'run_hardware_tests')
+    and symbols.modules['run_hardware_tests'] is False,
     reason='This series of tests requires a hardware BIG-IP be specified.'
 )
 

--- a/f5/bigip/tm/security/__init__.py
+++ b/f5/bigip/tm/security/__init__.py
@@ -31,6 +31,7 @@ from f5.bigip.resource import OrganizingCollection
 from f5.bigip.tm.security.analytics import Analytics
 from f5.bigip.tm.security.dos import Dos
 from f5.bigip.tm.security.firewall import Firewall
+from f5.bigip.tm.security.log import Log
 from f5.bigip.tm.security.protocol_inspection import Protocol_Inspection
 
 
@@ -39,4 +40,10 @@ class Security(OrganizingCollection):
 
     def __init__(self, tm):
         super(Security, self).__init__(tm)
-        self._meta_data['allowed_lazy_attributes'] = [Dos, Firewall, Analytics, Protocol_Inspection]
+        self._meta_data['allowed_lazy_attributes'] = [
+            Analytics,
+            Dos,
+            Firewall,
+            Log,
+            Protocol_Inspection,
+        ]

--- a/f5/bigip/tm/security/log.py
+++ b/f5/bigip/tm/security/log.py
@@ -1,0 +1,354 @@
+# coding=utf-8
+#
+# Copyright 2018 F5 Networks Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+from distutils.version import LooseVersion
+from f5.bigip.mixins import CheckExistenceMixin
+from f5.bigip.resource import Collection
+from f5.bigip.resource import OrganizingCollection
+from f5.bigip.resource import Resource
+from requests.exceptions import HTTPError
+from requests import Response
+
+
+class Log(OrganizingCollection):
+    def __init__(self, security):
+        super(Log, self).__init__(security)
+        self._meta_data['allowed_lazy_attributes'] = [
+            Profiles,
+        ]
+
+
+class Profiles(Collection):
+    def __init__(self, log):
+        super(Profiles, self).__init__(log)
+        self._meta_data['allowed_lazy_attributes'] = [Profile]
+        self._meta_data['attribute_registry'] = {
+            'tm:security:log:profile:profilestate': Profile
+        }
+
+
+class Profile(Resource):
+    def __init__(self, profiles):
+        super(Profile, self).__init__(profiles)
+        self._meta_data['required_creation_parameters'].update(('partition',))
+        self._meta_data['required_json_kind'] = 'tm:security:log:profile:profilestate'
+        self._meta_data['allowed_lazy_attributes'] = []
+        self._meta_data['attribute_registry'] = {
+            'tm:security:log:profile:application:applicationcollectionstate': Applications,
+            'tm:security:log:profile:network:networkcollectionstate': Networks,
+            'tm:security:log:profile:protocol-dns:protocol-dnscollectionstate': Protocol_Dns_s,
+            'tm:security:log:profile:protocol-sip:protocol-sipcollectionstate': Protocol_Sips,
+        }
+
+
+class Applications(Collection):
+    def __init__(self, profile):
+        super(Applications, self).__init__(profile)
+        self._meta_data['required_json_kind'] = 'tm:security:log:profile:application:applicationcollectionstate'
+        self._meta_data['allowed_lazy_attributes'] = [Application]
+        self._meta_data['attribute_registry'] = {
+            'tm:security:log:profile:application:applicationstate': Application
+        }
+
+
+class Application(Resource, CheckExistenceMixin):
+    def __init__(self, applications):
+        super(Application, self).__init__(applications)
+        self._meta_data['required_json_kind'] = 'tm:security:log:profile:application:applicationstate'
+        self.tmos_ver = self._meta_data['bigip'].tmos_version
+
+    def load(self, **kwargs):
+        """Custom load method to address issue in 11.6.0 Final,
+
+        where non existing objects would be True.
+        """
+        if LooseVersion(self.tmos_ver) == LooseVersion('11.6.0'):
+            return self._load_11_6(**kwargs)
+        else:
+            return super(Application, self)._load(**kwargs)
+
+    def _load_11_6(self, **kwargs):
+        """Must check if rule actually exists before proceeding with load."""
+        if self._check_existence_by_collection(self._meta_data['container'], kwargs['name']):
+            return super(Application, self)._load(**kwargs)
+        msg = 'The application resource named, {}, does not exist on the device.'.format(kwargs['name'])
+        resp = Response()
+        resp.status_code = 404
+        ex = HTTPError(msg, response=resp)
+        raise ex
+
+    def exists(self, **kwargs):
+        """Some objects when deleted still return when called by their
+
+        direct URI, this is a known issue in 11.6.0.
+        """
+        if LooseVersion(self.tmos_ver) == LooseVersion('11.6.0'):
+            return self._exists_11_6(**kwargs)
+        else:
+            return super(Application, self)._load(**kwargs)
+
+    def _exists_11_6(self, **kwargs):
+        """Check rule existence on device."""
+
+        return self._check_existence_by_collection(self._meta_data['container'], kwargs['name'])
+
+    def modify(self, **kwargs):
+        kwargs = self._mutate_name(kwargs)
+        return self._modify(**kwargs)
+
+    def update(self, **kwargs):
+        kwargs = self._mutate_name(kwargs)
+        return self._update(**kwargs)
+
+    def delete(self, **kwargs):
+        kwargs = self._mutate_name(kwargs)
+        return self._delete(**kwargs)
+
+    def create(self, **kwargs):
+        kwargs = self._mutate_name(kwargs)
+        return self._create(**kwargs)
+
+    def _mutate_name(self, kwargs):
+        partition = kwargs.pop('partition', None)
+        if partition is not None:
+            kwargs['name'] = '/{0}/{1}'.format(partition, kwargs['name'])
+        return kwargs
+
+
+class Networks(Collection):
+    def __init__(self, profile):
+        super(Networks, self).__init__(profile)
+        self._meta_data['required_json_kind'] = 'tm:security:log:profile:application:applicationcollectionstate'
+        self._meta_data['allowed_lazy_attributes'] = [Network]
+        self._meta_data['attribute_registry'] = {
+            'tm:security:log:profile:network:networkstate': Network
+        }
+
+
+class Network(Resource, CheckExistenceMixin):
+    def __init__(self, networks):
+        super(Network, self).__init__(networks)
+        self._meta_data['required_json_kind'] = 'tm:security:log:profile:network:networkstate'
+        self.tmos_ver = self._meta_data['bigip'].tmos_version
+
+    def load(self, **kwargs):
+        """Custom load method to address issue in 11.6.0 Final,
+
+        where non existing objects would be True.
+        """
+        if LooseVersion(self.tmos_ver) == LooseVersion('11.6.0'):
+            return self._load_11_6(**kwargs)
+        else:
+            return super(Network, self)._load(**kwargs)
+
+    def _load_11_6(self, **kwargs):
+        """Must check if rule actually exists before proceeding with load."""
+        if self._check_existence_by_collection(self._meta_data['container'], kwargs['name']):
+            return super(Network, self)._load(**kwargs)
+        msg = 'The application resource named, {}, does not exist on the device.'.format(kwargs['name'])
+        resp = Response()
+        resp.status_code = 404
+        ex = HTTPError(msg, response=resp)
+        raise ex
+
+    def exists(self, **kwargs):
+        """Some objects when deleted still return when called by their
+
+        direct URI, this is a known issue in 11.6.0.
+        """
+
+        if LooseVersion(self.tmos_ver) == LooseVersion('11.6.0'):
+            return self._exists_11_6(**kwargs)
+        else:
+            return super(Network, self)._load(**kwargs)
+
+    def _exists_11_6(self, **kwargs):
+        """Check rule existence on device."""
+
+        return self._check_existence_by_collection(self._meta_data['container'], kwargs['name'])
+
+    def modify(self, **kwargs):
+        kwargs = self._mutate_name(kwargs)
+        return self._modify(**kwargs)
+
+    def update(self, **kwargs):
+        kwargs = self._mutate_name(kwargs)
+        return self._update(**kwargs)
+
+    def delete(self, **kwargs):
+        kwargs = self._mutate_name(kwargs)
+        return self._delete(**kwargs)
+
+    def create(self, **kwargs):
+        kwargs = self._mutate_name(kwargs)
+        return self._create(**kwargs)
+
+    def _mutate_name(self, kwargs):
+        partition = kwargs.pop('partition', None)
+        if partition is not None:
+            kwargs['name'] = '/{0}/{1}'.format(partition, kwargs['name'])
+        return kwargs
+
+
+class Protocol_Dns_s(Collection):
+    def __init__(self, profile):
+        super(Protocol_Dns_s, self).__init__(profile)
+        self._meta_data['required_json_kind'] = 'tm:security:log:profile:protocol-dns:protocol-dnscollectionstate'
+        self._meta_data['allowed_lazy_attributes'] = [Protocol_Dns]
+        self._meta_data['attribute_registry'] = {
+            'tm:security:log:profile:protocol-dns:protocol-dnsstate': Protocol_Dns
+        }
+
+
+class Protocol_Dns(Resource, CheckExistenceMixin):
+    def __init__(self, protocol_dns_s):
+        super(Protocol_Dns, self).__init__(protocol_dns_s)
+        self._meta_data['required_json_kind'] = 'tm:security:log:profile:protocol-dns:protocol-dnsstate'
+        self.tmos_ver = self._meta_data['bigip'].tmos_version
+
+    def load(self, **kwargs):
+        """Custom load method to address issue in 11.6.0 Final,
+
+        where non existing objects would be True.
+        """
+        if LooseVersion(self.tmos_ver) == LooseVersion('11.6.0'):
+            return self._load_11_6(**kwargs)
+        else:
+            return super(Protocol_Dns, self)._load(**kwargs)
+
+    def _load_11_6(self, **kwargs):
+        """Must check if rule actually exists before proceeding with load."""
+        if self._check_existence_by_collection(self._meta_data['container'], kwargs['name']):
+            return super(Protocol_Dns, self)._load(**kwargs)
+        msg = 'The application resource named, {}, does not exist on the device.'.format(kwargs['name'])
+        resp = Response()
+        resp.status_code = 404
+        ex = HTTPError(msg, response=resp)
+        raise ex
+
+    def exists(self, **kwargs):
+        """Some objects when deleted still return when called by their
+
+        direct URI, this is a known issue in 11.6.0.
+        """
+
+        if LooseVersion(self.tmos_ver) == LooseVersion('11.6.0'):
+            return self._exists_11_6(**kwargs)
+        else:
+            return super(Protocol_Dns, self)._load(**kwargs)
+
+    def _exists_11_6(self, **kwargs):
+        """Check rule existence on device."""
+
+        return self._check_existence_by_collection(self._meta_data['container'], kwargs['name'])
+
+    def modify(self, **kwargs):
+        kwargs = self._mutate_name(kwargs)
+        return self._modify(**kwargs)
+
+    def update(self, **kwargs):
+        kwargs = self._mutate_name(kwargs)
+        return self._update(**kwargs)
+
+    def delete(self, **kwargs):
+        kwargs = self._mutate_name(kwargs)
+        return self._delete(**kwargs)
+
+    def create(self, **kwargs):
+        kwargs = self._mutate_name(kwargs)
+        return self._create(**kwargs)
+
+    def _mutate_name(self, kwargs):
+        partition = kwargs.pop('partition', None)
+        if partition is not None:
+            kwargs['name'] = '/{0}/{1}'.format(partition, kwargs['name'])
+        return kwargs
+
+
+class Protocol_Sips(Collection):
+    def __init__(self, profile):
+        super(Protocol_Sips, self).__init__(profile)
+        self._meta_data['required_json_kind'] = 'tm:security:log:profile:protocol-sip:protocol-sipcollectionstate'
+        self._meta_data['allowed_lazy_attributes'] = [Protocol_Sip]
+        self._meta_data['attribute_registry'] = {
+            'tm:security:log:profile:protocol-sip:protocol-sipstate': Protocol_Sip
+        }
+
+
+class Protocol_Sip(Resource, CheckExistenceMixin):
+    def __init__(self, protocol_sips):
+        super(Protocol_Sip, self).__init__(protocol_sips)
+        self._meta_data['required_json_kind'] = 'tm:security:log:profile:protocol-sip:protocol-sipstate'
+        self.tmos_ver = self._meta_data['bigip'].tmos_version
+
+    def load(self, **kwargs):
+        """Custom load method to address issue in 11.6.0 Final,
+
+        where non existing objects would be True.
+        """
+        if LooseVersion(self.tmos_ver) == LooseVersion('11.6.0'):
+            return self._load_11_6(**kwargs)
+        else:
+            return super(Protocol_Sip, self)._load(**kwargs)
+
+    def _load_11_6(self, **kwargs):
+        """Must check if rule actually exists before proceeding with load."""
+        if self._check_existence_by_collection(self._meta_data['container'], kwargs['name']):
+            return super(Protocol_Sip, self)._load(**kwargs)
+        msg = 'The application resource named, {}, does not exist on the device.'.format(kwargs['name'])
+        resp = Response()
+        resp.status_code = 404
+        ex = HTTPError(msg, response=resp)
+        raise ex
+
+    def exists(self, **kwargs):
+        """Some objects when deleted still return when called by their
+
+        direct URI, this is a known issue in 11.6.0.
+        """
+
+        if LooseVersion(self.tmos_ver) == LooseVersion('11.6.0'):
+            return self._exists_11_6(**kwargs)
+        else:
+            return super(Protocol_Sip, self)._load(**kwargs)
+
+    def _exists_11_6(self, **kwargs):
+        """Check rule existence on device."""
+
+        return self._check_existence_by_collection(self._meta_data['container'], kwargs['name'])
+
+    def modify(self, **kwargs):
+        kwargs = self._mutate_name(kwargs)
+        return self._modify(**kwargs)
+
+    def update(self, **kwargs):
+        kwargs = self._mutate_name(kwargs)
+        return self._update(**kwargs)
+
+    def delete(self, **kwargs):
+        kwargs = self._mutate_name(kwargs)
+        return self._delete(**kwargs)
+
+    def create(self, **kwargs):
+        kwargs = self._mutate_name(kwargs)
+        return self._create(**kwargs)
+
+    def _mutate_name(self, kwargs):
+        partition = kwargs.pop('partition', None)
+        if partition is not None:
+            kwargs['name'] = '/{0}/{1}'.format(partition, kwargs['name'])
+        return kwargs

--- a/f5/bigip/tm/security/test/functional/test_log.py
+++ b/f5/bigip/tm/security/test/functional/test_log.py
@@ -1,0 +1,404 @@
+# Copyright 2018 F5 Networks Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import os
+import pytest
+import tempfile
+
+from f5.bigip.tm.security.log import Application
+from f5.bigip.tm.security.log import Network
+from f5.bigip.tm.security.log import Profile
+from f5.bigip.tm.security.log import Protocol_Dns
+from f5.bigip.tm.security.log import Protocol_Sip
+from requests.exceptions import HTTPError
+
+
+@pytest.fixture(scope='function')
+def profile(mgmt_root):
+    file = tempfile.NamedTemporaryFile()
+    name = os.path.basename(file.name)
+    r1 = mgmt_root.tm.security.log.profiles.profile.create(
+        name=name, partition='Common'
+    )
+    yield r1
+    r1.delete()
+
+
+@pytest.fixture(scope='function')
+def application_profile(mgmt_root):
+    file = tempfile.NamedTemporaryFile()
+    name = os.path.basename(file.name)
+    r1 = mgmt_root.tm.security.log.profiles.profile.create(
+        name=name, partition='Common'
+    )
+    r2 = r1.applications.application.create(name=name, partition='Common')
+    yield r2
+    r1.delete()
+
+
+@pytest.fixture(scope='function')
+def network_profile(mgmt_root):
+    file = tempfile.NamedTemporaryFile()
+    name = os.path.basename(file.name)
+    r1 = mgmt_root.tm.security.log.profiles.profile.create(
+        name=name, partition='Common'
+    )
+    r2 = r1.networks.network.create(name=name, partition='Common')
+    yield r2
+    r1.delete()
+
+
+@pytest.fixture(scope='function')
+def protocol_dns_profile(mgmt_root):
+    file = tempfile.NamedTemporaryFile()
+    name = os.path.basename(file.name)
+    r1 = mgmt_root.tm.security.log.profiles.profile.create(
+        name=name, partition='Common'
+    )
+    r2 = r1.protocol_dns_s.protocol_dns.create(name=name, partition='Common')
+    yield r2
+    r1.delete()
+
+
+@pytest.fixture(scope='function')
+def protocol_sip_profile(mgmt_root):
+    file = tempfile.NamedTemporaryFile()
+    name = os.path.basename(file.name)
+    r1 = mgmt_root.tm.security.log.profiles.profile.create(
+        name=name, partition='Common'
+    )
+    r2 = r1.protocol_sips.protocol_sip.create(name=name, partition='Common')
+    yield r2
+    r1.delete()
+
+
+class TestProfileGeneral(object):
+    def test_create_req_args(self, profile):
+        URI = 'https://localhost/mgmt/tm/security/log/profile/~Common~'
+        assert profile.partition == 'Common'
+        assert profile.selfLink.startswith(URI)
+
+    def test_refresh(self, mgmt_root, profile):
+        rc = mgmt_root.tm.security.log.profiles
+        r1 = profile
+        r2 = rc.profile.load(name=profile.name, partition='Common')
+        assert r1.name == r2.name
+        assert r1.kind == r2.kind
+        assert r1.selfLink == r2.selfLink
+        assert not hasattr(r1, 'description')
+        assert not hasattr(r2, 'description')
+        r2.modify(description='my description')
+        assert hasattr(r2, 'description')
+        assert r2.description == 'my description'
+        r1.refresh()
+        assert r1.selfLink == r2.selfLink
+        assert hasattr(r1, 'description')
+        assert r1.description == r2.description
+
+    def test_delete(self, mgmt_root):
+        rc = mgmt_root.tm.security.log.profiles
+        r1 = rc.profile.create(name='delete_me', partition='Common')
+        r1.delete()
+        with pytest.raises(HTTPError) as err:
+            rc.profile.load(name='delete_me', partition='Common')
+        assert err.value.response.status_code == 404
+
+    def test_load_no_object(self, mgmt_root):
+        rc = mgmt_root.tm.security.log.profiles
+        with pytest.raises(HTTPError) as err:
+            rc.profile.load(name='not_exists', partition='Common')
+        assert err.value.response.status_code == 404
+
+    def test_load_and_update(self, mgmt_root, profile):
+        r1 = profile
+        URI = 'https://localhost/mgmt/tm/security/log/profile/~Common~'
+        assert r1.partition == 'Common'
+        assert r1.selfLink.startswith(URI)
+        assert not hasattr(r1, 'description')
+        r1.description = 'my description'
+        r1.update()
+        assert hasattr(r1, 'description')
+        assert r1.description == 'my description'
+        rc = mgmt_root.tm.security.log.profiles
+        r2 = rc.profile.load(name=profile.name, partition='Common')
+        assert r1.name == r2.name
+        assert r1.partition == r2.partition
+        assert r1.selfLink == r2.selfLink
+        assert hasattr(r2, 'description')
+        assert r1.description == r2.description
+
+    def test_profiles_collection(self, mgmt_root, profile):
+        r1 = profile
+        URI = 'https://localhost/mgmt/tm/security/log/profile/~Common~'
+        assert r1.partition == 'Common'
+        assert r1.selfLink.startswith(URI)
+
+        rc = mgmt_root.tm.security.log.profiles.get_collection()
+        assert isinstance(rc, list)
+        assert len(rc)
+        assert isinstance(rc[0], Profile)
+
+
+class TestProfileApplication(object):
+    def test_refresh(self, mgmt_root, application_profile):
+        rc = mgmt_root.tm.security.log.profiles
+        r1 = application_profile
+        r2 = rc.profile.load(name=application_profile.name, partition='Common')
+        r2 = r2.applications.application.load(name=application_profile.name, partition='Common')
+        assert r1.name == r2.name
+        assert r1.kind == r2.kind
+        assert r1.selfLink == r2.selfLink
+        assert r1.guaranteeLogging == r2.guaranteeLogging
+        r2.modify(guaranteeLogging='disabled')
+        assert r2.guaranteeLogging == 'disabled'
+        r1.refresh()
+        assert r1.selfLink == r2.selfLink
+        assert r1.guaranteeLogging == r2.guaranteeLogging
+
+    def test_delete(self, profile):
+        r1 = profile.applications.application.create(name=profile.name, partition='Common')
+        r1.delete()
+        with pytest.raises(HTTPError) as err:
+            profile.applications.application.load(name=profile.name, partition='Common')
+        assert err.value.response.status_code == 404
+
+    def test_load_no_object(self, profile):
+        with pytest.raises(HTTPError) as err:
+            profile.applications.application.load(name='not_exists', partition='Common')
+        assert err.value.response.status_code == 404
+
+    def test_load_and_update(self, mgmt_root, application_profile):
+        r1 = application_profile
+        URI = 'https://localhost/mgmt/tm/security/log/profile/~Common~'
+        assert r1.partition == 'Common'
+        assert r1.selfLink.startswith(URI)
+        r1.guaranteeLogging = 'disabled'
+        r1.update()
+        assert hasattr(r1, 'guaranteeLogging')
+        assert r1.guaranteeLogging == 'disabled'
+        rc = mgmt_root.tm.security.log.profiles.profile.load(name=application_profile.name, partition='Common')
+        r2 = rc.applications.application.load(name=application_profile.name, partition='Common')
+        assert r1.name == r2.name
+        assert r1.partition == r2.partition
+        assert r1.selfLink == r2.selfLink
+        assert hasattr(r2, 'guaranteeLogging')
+        assert r1.guaranteeLogging == r2.guaranteeLogging
+
+    def test_profiles_collection(self, mgmt_root, application_profile):
+        r1 = application_profile
+        URI = 'https://localhost/mgmt/tm/security/log/profile/~Common~'
+        assert r1.partition == 'Common'
+        assert r1.selfLink.startswith(URI)
+
+        rc = mgmt_root.tm.security.log.profiles.get_collection()
+        assert isinstance(rc, list)
+        assert len(rc)
+
+        resource = next((x for x in rc if x.name == application_profile.name), None)
+
+        rc2 = resource.applications.get_collection()
+        assert isinstance(rc, list)
+        assert len(rc)
+
+        assert isinstance(rc2[0], Application)
+
+
+class TestProfileNetwork(object):
+    def test_refresh(self, mgmt_root, network_profile):
+        rc = mgmt_root.tm.security.log.profiles
+        r1 = network_profile
+        r2 = rc.profile.load(name=network_profile.name, partition='Common')
+        r2 = r2.networks.network.load(name=network_profile.name, partition='Common')
+        assert r1.name == r2.name
+        assert r1.kind == r2.kind
+        assert r1.selfLink == r2.selfLink
+        assert r1.filter['logIpErrors'] == r2.filter['logIpErrors']
+
+        r2.modify(filter={'logIpErrors': 'enabled'})
+        assert r2.filter['logIpErrors'] == 'enabled'
+        r1.refresh()
+        assert r1.selfLink == r2.selfLink
+        assert r1.filter['logIpErrors'] == r2.filter['logIpErrors']
+
+    def test_delete(self, profile):
+        r1 = profile.networks.network.create(name=profile.name, partition='Common')
+        r1.delete()
+        with pytest.raises(HTTPError) as err:
+            profile.networks.network.load(name=profile.name, partition='Common')
+        assert err.value.response.status_code == 404
+
+    def test_load_no_object(self, profile):
+        with pytest.raises(HTTPError) as err:
+            profile.networks.network.load(name='not_exists', partition='Common')
+        assert err.value.response.status_code == 404
+
+    def test_load_and_update(self, mgmt_root, network_profile):
+        r1 = network_profile
+        URI = 'https://localhost/mgmt/tm/security/log/profile/~Common~'
+        assert r1.partition == 'Common'
+        assert r1.selfLink.startswith(URI)
+        r1.filter['logIpErrors'] = 'enabled'
+        r1.update()
+        assert r1.filter['logIpErrors'] == 'enabled'
+        rc = mgmt_root.tm.security.log.profiles.profile.load(name=network_profile.name, partition='Common')
+        r2 = rc.networks.network.load(name=network_profile.name, partition='Common')
+        assert r1.name == r2.name
+        assert r1.partition == r2.partition
+        assert r1.selfLink == r2.selfLink
+        assert hasattr(r2, 'filter')
+        assert r1.filter['logIpErrors'] == r2.filter['logIpErrors']
+
+    def test_profiles_collection(self, mgmt_root, network_profile):
+        r1 = network_profile
+        URI = 'https://localhost/mgmt/tm/security/log/profile/~Common~'
+        assert r1.partition == 'Common'
+        assert r1.selfLink.startswith(URI)
+
+        rc = mgmt_root.tm.security.log.profiles.get_collection()
+        assert isinstance(rc, list)
+        assert len(rc)
+
+        resource = next((x for x in rc if x.name == network_profile.name), None)
+
+        rc2 = resource.networks.get_collection()
+        assert isinstance(rc, list)
+        assert len(rc)
+        assert isinstance(rc2[0], Network)
+
+
+class TestProfileProtocolDns(object):
+    def test_refresh(self, mgmt_root, protocol_dns_profile):
+        rc = mgmt_root.tm.security.log.profiles
+        r1 = protocol_dns_profile
+        r2 = rc.profile.load(name=protocol_dns_profile.name, partition='Common')
+        r2 = r2.protocol_dns_s.protocol_dns.load(name=protocol_dns_profile.name, partition='Common')
+        assert r1.name == r2.name
+        assert r1.kind == r2.kind
+        assert r1.selfLink == r2.selfLink
+        assert r1.filter['logDnsDrop'] == r2.filter['logDnsDrop']
+
+        r2.modify(filter={'logDnsDrop': 'enabled'})
+        assert r2.filter['logDnsDrop'] == 'enabled'
+        r1.refresh()
+        assert r1.selfLink == r2.selfLink
+        assert r1.filter['logDnsDrop'] == r2.filter['logDnsDrop']
+
+    def test_delete(self, profile):
+        r1 = profile.protocol_dns_s.protocol_dns.create(name=profile.name, partition='Common')
+        r1.delete()
+        with pytest.raises(HTTPError) as err:
+            profile.protocol_dns_s.protocol_dns.load(name=profile.name, partition='Common')
+        assert err.value.response.status_code == 404
+
+    def test_load_no_object(self, profile):
+        with pytest.raises(HTTPError) as err:
+            profile.protocol_dns_s.protocol_dns.load(name='not_exists', partition='Common')
+        assert err.value.response.status_code == 404
+
+    def test_load_and_update(self, mgmt_root, protocol_dns_profile):
+        r1 = protocol_dns_profile
+        URI = 'https://localhost/mgmt/tm/security/log/profile/~Common~'
+        assert r1.partition == 'Common'
+        assert r1.selfLink.startswith(URI)
+        r1.filter['logDnsDrop'] = 'enabled'
+        r1.update()
+        assert r1.filter['logDnsDrop'] == 'enabled'
+        rc = mgmt_root.tm.security.log.profiles.profile.load(name=protocol_dns_profile.name, partition='Common')
+        r2 = rc.protocol_dns_s.protocol_dns.load(name=protocol_dns_profile.name, partition='Common')
+        assert r1.name == r2.name
+        assert r1.partition == r2.partition
+        assert r1.selfLink == r2.selfLink
+        assert hasattr(r2, 'filter')
+        assert r1.filter['logDnsDrop'] == r2.filter['logDnsDrop']
+
+    def test_profiles_collection(self, mgmt_root, protocol_dns_profile):
+        r1 = protocol_dns_profile
+        URI = 'https://localhost/mgmt/tm/security/log/profile/~Common~'
+        assert r1.partition == 'Common'
+        assert r1.selfLink.startswith(URI)
+
+        rc = mgmt_root.tm.security.log.profiles.get_collection()
+        assert isinstance(rc, list)
+        assert len(rc)
+
+        resource = next((x for x in rc if x.name == protocol_dns_profile.name), None)
+
+        rc2 = resource.protocol_dns_s.get_collection()
+        assert isinstance(rc, list)
+        assert len(rc)
+        assert isinstance(rc2[0], Protocol_Dns)
+
+
+class TestProfileProtocolSip(object):
+    def test_refresh(self, mgmt_root, protocol_sip_profile):
+        rc = mgmt_root.tm.security.log.profiles
+        r1 = protocol_sip_profile
+        r2 = rc.profile.load(name=protocol_sip_profile.name, partition='Common')
+        r2 = r2.protocol_sips.protocol_sip.load(name=protocol_sip_profile.name, partition='Common')
+        assert r1.name == r2.name
+        assert r1.kind == r2.kind
+        assert r1.selfLink == r2.selfLink
+        assert r1.filter['logSipDrop'] == r2.filter['logSipDrop']
+
+        r2.modify(filter={'logSipDrop': 'enabled'})
+        assert r2.filter['logSipDrop'] == 'enabled'
+        r1.refresh()
+        assert r1.selfLink == r2.selfLink
+        assert r1.filter['logSipDrop'] == r2.filter['logSipDrop']
+
+    def test_delete(self, profile):
+        r1 = profile.protocol_sips.protocol_sip.create(name=profile.name, partition='Common')
+        r1.delete()
+        with pytest.raises(HTTPError) as err:
+            profile.protocol_sips.protocol_sip.load(name=profile.name, partition='Common')
+        assert err.value.response.status_code == 404
+
+    def test_load_no_object(self, profile):
+        with pytest.raises(HTTPError) as err:
+            profile.protocol_sips.protocol_sip.load(name='not_exists', partition='Common')
+        assert err.value.response.status_code == 404
+
+    def test_load_and_update(self, mgmt_root, protocol_sip_profile):
+        r1 = protocol_sip_profile
+        URI = 'https://localhost/mgmt/tm/security/log/profile/~Common~'
+        assert r1.partition == 'Common'
+        assert r1.selfLink.startswith(URI)
+        r1.filter['logSipDrop'] = 'enabled'
+        r1.update()
+        assert r1.filter['logSipDrop'] == 'enabled'
+        rc = mgmt_root.tm.security.log.profiles.profile.load(name=protocol_sip_profile.name, partition='Common')
+        r2 = rc.protocol_sips.protocol_sip.load(name=protocol_sip_profile.name, partition='Common')
+        assert r1.name == r2.name
+        assert r1.partition == r2.partition
+        assert r1.selfLink == r2.selfLink
+        assert hasattr(r2, 'filter')
+        assert r1.filter['logSipDrop'] == r2.filter['logSipDrop']
+
+    def test_profiles_collection(self, mgmt_root, protocol_sip_profile):
+        r1 = protocol_sip_profile
+        URI = 'https://localhost/mgmt/tm/security/log/profile/~Common~'
+        assert r1.partition == 'Common'
+        assert r1.selfLink.startswith(URI)
+
+        rc = mgmt_root.tm.security.log.profiles.get_collection()
+        assert isinstance(rc, list)
+        assert len(rc)
+
+        resource = next((x for x in rc if x.name == protocol_sip_profile.name), None)
+
+        rc2 = resource.protocol_sips.get_collection()
+        assert isinstance(rc, list)
+        assert len(rc)
+        assert isinstance(rc2[0], Protocol_Sip)

--- a/f5/bigip/tm/security/test/unit/test_log.py
+++ b/f5/bigip/tm/security/test/unit/test_log.py
@@ -1,0 +1,46 @@
+# Copyright 2018 F5 Networks Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import mock
+import pytest
+
+
+from f5.bigip import ManagementRoot
+from f5.bigip.tm.security.log import Profile
+from f5.sdk_exception import MissingRequiredCreationParameter
+
+
+@pytest.fixture
+def FakeProfile():
+    fake_col = mock.MagicMock()
+    fake_profile = Profile(fake_col)
+    return fake_profile
+
+
+class TestProfile(object):
+    def test_create_two(self, fakeicontrolsession):
+        b = ManagementRoot('192.168.1.1', 'admin', 'admin')
+        r1 = b.tm.security.log.profiles.profile
+        r2 = b.tm.security.log.profiles.profile
+        assert r1 is not r2
+
+    def test_create_no_args(self, FakeProfile):
+        with pytest.raises(MissingRequiredCreationParameter):
+            FakeProfile.create()
+
+    def test_create_mandatory_args_missing(self, fakeicontrolsession):
+        b = ManagementRoot('192.168.1.1', 'admin', 'admin')
+        with pytest.raises(MissingRequiredCreationParameter):
+            b.tm.security.log.profiles.profile.create(name='destined_to_fail')

--- a/f5/bigip/tm/sys/performance.py
+++ b/f5/bigip/tm/sys/performance.py
@@ -44,8 +44,7 @@ class Performances(Collection):
         :raises: :exc:`~f5.BIG-IP.resource.UnsupportedOperation`
         '''
         raise UnsupportedOperation(
-            "The iControl REST URI mgmt/sys/performance/ does not respond " +
-            "GET requests."
+            "The iControl REST URI mgmt/sys/performance/ does not respond GET requests."
         )
 
 
@@ -62,5 +61,4 @@ class All_Stats(UnnamedResource):
 
         :raises: :exc:`~f5.BIG-IP.resource.UnsupportedOperation`
         '''
-        raise UnsupportedOperation(
-            'Stats do not support create, only load and refresh')
+        raise UnsupportedOperation('Stats do not support create, only load and refresh')

--- a/f5/bigip/tm/sys/test/functional/test_snmp.py
+++ b/f5/bigip/tm/sys/test/functional/test_snmp.py
@@ -412,8 +412,7 @@ class TestCommunity(object):
 
 class TestUser(object):
     @pytest.mark.skipif(
-        LooseVersion(pytest.config.getoption('--release')) >
-        LooseVersion('12.0.0'),
+        LooseVersion(pytest.config.getoption('--release')) > LooseVersion('12.0.0'),
         reason='Skip this test if v12.1.0 or above is set.'
     )
     def test_user_create_refresh_update_delete_load(
@@ -465,8 +464,7 @@ class TestUser(object):
         assert user2.selfLink == user1.selfLink
 
     @pytest.mark.skipif(
-        LooseVersion(pytest.config.getoption('--release')) <
-        LooseVersion('12.1.0'),
+        LooseVersion(pytest.config.getoption('--release')) < LooseVersion('12.1.0'),
         reason='Skip if the version is NOT 12.1.0 or above'
     )
     def test_user_create_refresh_delete_load_12_1_0(
@@ -529,13 +527,10 @@ class TestUser(object):
 
 class TestTrap(object):
     @pytest.mark.skipif(
-        LooseVersion(pytest.config.getoption('--release')) >
-        LooseVersion('12.0.0'),
+        LooseVersion(pytest.config.getoption('--release')) > LooseVersion('12.0.0'),
         reason='Skip this test if v12.1.0 or above is set.'
     )
-    def test_trap_create_refresh_update_delete_load(
-            self, request, mgmt_root, setup_device_snapshot
-    ):
+    def test_trap_create_refresh_update_delete_load(self, request, mgmt_root, setup_device_snapshot):
         trap1, t1 = setup_trap_test(
             request=request,
             mgmt_root=mgmt_root,
@@ -577,12 +572,10 @@ class TestTrap(object):
         assert trap2.selfLink == trap1.selfLink
 
     @pytest.mark.skipif(
-        LooseVersion(pytest.config.getoption('--release')) <
-        LooseVersion('12.1.0'),
+        LooseVersion(pytest.config.getoption('--release')) < LooseVersion('12.1.0'),
         reason='Skip if the version is NOT 12.1.0 or above'
     )
-    def test_trap_create_refresh_delete_load_12_1_0(
-            self, request, mgmt_root, setup_device_snapshot):
+    def test_trap_create_refresh_delete_load_12_1_0(self, request, mgmt_root, setup_device_snapshot):
         trap1, t1 = setup_trap_test(
             request=request,
             mgmt_root=mgmt_root,
@@ -618,9 +611,7 @@ class TestTrap(object):
         assert trap1.selfLink.startswith(link1)
         assert trap2.selfLink.startswith(link2)
 
-    def test_trap_create_bad_version(
-            self, request, mgmt_root, setup_device_snapshot
-    ):
+    def test_trap_create_bad_version(self, request, mgmt_root, setup_device_snapshot):
         badVals = ['ads', 12, '12', '#^$%&#%', '', -1, '-1']
         for badVal in badVals:
             with pytest.raises(iControlUnexpectedHTTPError) as err:
@@ -635,9 +626,7 @@ class TestTrap(object):
                 )
             assert 'expected one of the following' in str(err.value)
 
-    def test_trap_create_bad_port(
-            self, request, mgmt_root, setup_device_snapshot
-    ):
+    def test_trap_create_bad_port(self, request, mgmt_root, setup_device_snapshot):
         """Test digit service ports
 
         The port can be a valid digit between 0 and 65,535. This matches
@@ -663,9 +652,7 @@ class TestTrap(object):
                     )
                 assert 'invalid or ambiguous service' in str(err.value)
 
-    def test_trap_create_named_port(
-            self, request, mgmt_root, setup_device_snapshot
-    ):
+    def test_trap_create_named_port(self, request, mgmt_root, setup_device_snapshot):
         """Test named service ports
 
         The port can be a valid service name instead of a digit. This differs
@@ -689,9 +676,7 @@ class TestTrap(object):
                     version=version
                 )
 
-    def test_trap_create_named_port_v3(
-            self, request, mgmt_root, setup_device_snapshot
-    ):
+    def test_trap_create_named_port_v3(self, request, mgmt_root, setup_device_snapshot):
         """Test named service ports
 
         The port can be a valid service name instead of a digit. This differs

--- a/f5/utils/iapp_parser.py
+++ b/f5/utils/iapp_parser.py
@@ -27,8 +27,8 @@ class IappParser(object):
         'role-acl'
     ]
 
-    tcl_list_for_attr_re = '{(\s*(\w+)?\s*)+}'
-    tcl_list_for_section_re = '(\s*\w+\s*)+'
+    tcl_list_for_attr_re = r'{(\s*(\w+)?\s*)+}'
+    tcl_list_for_section_re = r'(\s*\w+\s*)+'
     section_map = {
         'html-help': 'htmlHelp',
         'role-acl': 'roleAcl'
@@ -136,7 +136,7 @@ class IappParser(object):
         :raises: NonextantSectionException
         '''
 
-        sec_start_re = '%s\s*\{' % section
+        sec_start_re = r'%s\s*\{' % section
 
         found = re.search(sec_start_re, self.template_str)
         if found:
@@ -153,9 +153,9 @@ class IappParser(object):
         :raises: NonextantTemplateNameException
         '''
 
-        start_pattern = "sys application template\s+" \
-                        "(\/[\w\.\-]+\/)?" \
-                        "(?P<name>[\w\.\-]+)\s*\{"
+        start_pattern = r"sys application template\s+" \
+                        r"(\/[\w\.\-]+\/)?" \
+                        r"(?P<name>[\w\.\-]+)\s*\{"
 
         template_start = re.search(start_pattern, self.template_str)
         if template_start:
@@ -170,7 +170,7 @@ class IappParser(object):
         :returns: string of attribute value
         '''
 
-        attr_re = '%s\s+.*' % attr
+        attr_re = r'{0}\s+.*'.format(attr)
 
         attr_found = re.search(attr_re, self.template_str)
         if attr_found:
@@ -200,9 +200,9 @@ class IappParser(object):
     def _add_cli_scripts(self):
         '''Add the found external sections to the templ_dict.'''
 
-        pattern = "cli script\s+" \
-                  "(\/[\w\.\-]+\/)?" \
-                  "(?P<name>[\w\.\-]+)\s*\{"
+        pattern = r"cli script\s+" \
+                  r"(\/[\w\.\-]+\/)?" \
+                  r"(?P<name>[\w\.\-]+)\s*\{"
         sections = re.finditer(pattern, self.template_str)
 
         for section in sections:

--- a/tox.ini
+++ b/tox.ini
@@ -20,7 +20,7 @@ basepython =
     pycodestyle: python
     coveralls: python
     docs: python
-passenv = COVERALLS_REPO_TOKEN
+passenv = *
 setenv =
     PYTHONDONTWRITEBYTECODE = 1
 deps =
@@ -51,7 +51,7 @@ commands =
     py{27,35,36}-iwf-v2.1.0: py.test --bigip localhost --port 10443 -s -vv --release 2.1.0 {posargs:f5/iworkflow}
 
     # Misc tests
-    unit: pytest -k "not /functional/" -vv --cov {posargs:f5/}
+    unit: py.test -x -k "not /functional/" -s -vv --cov {posargs:f5}
     pycodestyle: pycodestyle {posargs:f5}
     flake: flake8 {posargs:f5}
     coveralls: coveralls


### PR DESCRIPTION
…on f5.big.tm.ltm collection objects Nodes, Pools, Rules, Virtuals and Virtual_Address_s

This is to allow obtaining all item stats with a single request which may come in handy when stats on large collections are required and calling item.stats.load() in a loop causes massive REST calls and huge delay.
Note that entries have to be mapped by the application, suggested criteria are item.fullPath and stat_entry['nestedStats']['entries']['tmName']['description'].