### PR TITLE
Added the user APIs to f5/bigip/shared/authz.py, fixed issue in f5/bigip/cm/system.py

### DIFF
--- a/f5/bigip/cm/system.py
+++ b/f5/bigip/cm/system.py
@@ -49,18 +49,33 @@ class Providers(OrganizingCollection):
 class Tmos_s(Collection):
     def __init__(self, providers):
         super(Tmos_s, self).__init__(providers)
-        self._meta_data['required_json_kind'] = 'cm:system:authn:providers:tmos:mcpremoteprovidercollectionstate'
+        if (self._meta_data['bigip']._meta_data['tmos_version'] < '13.1.0'):
+            # Starting from bigip v13.1.0 tmos resources 'kind' was changed
+            # from 'mcpremoteproviderstate' to 'authproviderstate'
+            # and tmos collection 'kind'
+            # from 'mcpremoteprovidercollectionstate' to 'mcpremoteproviderstate"
+            self._meta_data['required_json_kind'] = 'cm:system:authn:providers:tmos:mcpremoteprovidercollectionstate'
+            self._meta_data['attribute_registry'] = {
+                'cm:system:authn:providers:tmos:mcpremoteproviderstate': Tmos
+            }
+        else:
+            self._meta_data['required_json_kind'] = 'cm:system:authn:providers:tmos:authprovidercollectionstate'
+            self._meta_data['attribute_registry'] = {
+                'cm:system:authn:providers:tmos:authproviderstate': Tmos
+            }
         self._meta_data['allowed_lazy_attributes'] = [Tmos]
-        self._meta_data['attribute_registry'] = {
-            'cm:system:authn:providers:tmos:mcpremoteproviderstate': Tmos
-        }
 
 
 class Tmos(Resource):
     def __init__(self, tokens):
         super(Tmos, self).__init__(tokens)
-        self._meta_data['required_json_kind'] = 'cm:system:authn:providers:tmos:mcpremoteproviderstate'
-        self._meta_data['required_load_parameters'] = set(('id',))
+        if (self._meta_data['bigip']._meta_data['tmos_version'] < '13.1.0'):
+            # Starting from bigip v13.1.0 tmos resource 'kind' was changed
+            # from 'mcpremoteproviderstate' to 'authproviderstate'
+            self._meta_data['required_json_kind'] = 'cm:system:authn:providers:tmos:mcpremoteproviderstate'
+        else:
+            self._meta_data['required_json_kind'] = 'ccm:system:authn:providers:tmos:authproviderstate'
+            self._meta_data['required_load_parameters'] = set(('id',))
 
     def create(self, **kwargs):
         raise UnsupportedMethod(

--- a/f5/bigip/shared/authz.py
+++ b/f5/bigip/shared/authz.py
@@ -27,7 +27,8 @@ class Authz(OrganizingCollection):
     def __init__(self, shared):
         super(Authz, self).__init__(shared)
         self._meta_data['allowed_lazy_attributes'] = [
-            Tokens_s
+            Tokens_s,
+            Users_s
         ]
 
 
@@ -38,6 +39,16 @@ class Tokens_s(Collection):
         self._meta_data['allowed_lazy_attributes'] = [Token]
         self._meta_data['attribute_registry'] = {
             'shared:authz:tokens:authtokenitemstate': Token
+        }
+
+
+class Users_s(Collection):
+    def __init__(self, authz):
+        super(Users_s, self).__init__(authz)
+        self._meta_data['required_json_kind'] = 'shared:authz:users:userscollectionstate'
+        self._meta_data['allowed_lazy_attributes'] = [User]
+        self._meta_data['attribute_registry'] = {
+            'shared:authz:tokens:usersworkerstate': User
         }
 
 
@@ -82,3 +93,10 @@ class Token(Resource):
             raise ConstraintError(
                 "The provided timeout must be a number between 1 and 36000."
             )
+
+
+class User(Resource):
+    def __init__(self, users):
+        super(User, self).__init__(users)
+        self._meta_data['required_json_kind'] = 'shared:authz:users:usersworkerstate'
+        self._meta_data['required_creation_parameters'] = {'name', 'password'}

--- a/f5/bigip/shared/test/unit/test_authz.py
+++ b/f5/bigip/shared/test/unit/test_authz.py
@@ -14,6 +14,7 @@
 #
 
 from f5.bigip.shared.authz import Token
+from f5.bigip.shared.authz import User
 from f5.sdk_exception import ConstraintError
 from f5.sdk_exception import MissingRequiredCreationParameter
 
@@ -25,6 +26,13 @@ import pytest
 def FakeToken():
     mo = mock.MagicMock()
     resource = Token(mo)
+    return resource
+
+
+@pytest.fixture
+def FakeUser():
+    mo = mock.MagicMock()
+    resource = User(mo)
     return resource
 
 
@@ -40,3 +48,9 @@ class TestToken(object):
     def test_create_no_args(self, FakeToken):
         with pytest.raises(MissingRequiredCreationParameter):
             FakeToken.create()
+
+
+class TestUser(object):
+    def test_create_user_no_args(self, FakeUser):
+        with pytest.raises(MissingRequiredCreationParameter):
+            FakeUser.create()


### PR DESCRIPTION
1. Added the user APIs to f5/bigip/shared/authz.py:
These APIs are very handy when, let's say, you want to change the password of the existing user by providing the password itself without calculating the encryptedPassword like you should do it with tm.auth.users.user:
```python
collection = mgmt_root.tm.auth.users.user.load(name='admin')
collection.update(encryptedPassword='$6$fAj6uBdO$FwyVZvxAQo6ZXrFz5keM/lTTFssdR1Y8jx.sRfwWbezGQa3AilBgwYD9JX0OLOrzrMz0nQrVj1Efv6LMAh4Ua0')
```

Now you can do:
```python
collection = mgmt_root.shared.authz.users_s
resource = collection.user.load(name='admin')
resource.modify(name='admin', password='f5site02')
```

2. Fixed UnregisteredKind issue in f5/bigip/cm/system.py with bigip v13.1.0 and above:
Right now while running `pytest f5/bigip/shared/test/functional/test_authz.py` on 13.1.0 the exception is raised:
```
f5.sdk_exception.UnregisteredKind: 'cm:system:authn:providers:tmos:authproviderstate' is not registered!

f5/bigip/resource.py:801: UnregisteredKind
```
