### PR TITLE
Fixing cm/test/unit/test_system.py failing with python3.x

### DIFF
--- a/f5/bigip/cm/system.py
+++ b/f5/bigip/cm/system.py
@@ -49,7 +49,8 @@ class Providers(OrganizingCollection):
 class Tmos_s(Collection):
     def __init__(self, providers):
         super(Tmos_s, self).__init__(providers)
-        if (self._meta_data['bigip']._meta_data['tmos_version'] < '13.1.0'):
+        version = str(self._meta_data['bigip']._meta_data['tmos_version'])
+        if (version < '13.1.0'):
             # Starting from bigip v13.1.0 tmos resources 'kind' was changed
             # from 'mcpremoteproviderstate' to 'authproviderstate'
             # and tmos collection 'kind'
@@ -69,7 +70,8 @@ class Tmos_s(Collection):
 class Tmos(Resource):
     def __init__(self, tokens):
         super(Tmos, self).__init__(tokens)
-        if (self._meta_data['bigip']._meta_data['tmos_version'] < '13.1.0'):
+        version = str(self._meta_data['bigip']._meta_data['tmos_version'])
+        if (version < '13.1.0'):
             # Starting from bigip v13.1.0 tmos resource 'kind' was changed
             # from 'mcpremoteproviderstate' to 'authproviderstate'
             self._meta_data['required_json_kind'] = 'cm:system:authn:providers:tmos:mcpremoteproviderstate'


### PR DESCRIPTION
The cm/test/unit/test_system.py was failing on python 3.x pipelines due to:
```
TypeError: '<' not supported between instances of 'MagicMock' and 'str'
```
Now tests are passing:

f5/bigip/cm/test/unit/test_system.py ....

========================================================================================================================= 4 passed in 0.02 seconds ==========================================================================================================================
