### PR TITLE
Added f5.bigip.resource.Stats to the list of allowed_lazy_attributes …

### DIFF
--- a/f5/bigip/tm/ltm/node.py
+++ b/f5/bigip/tm/ltm/node.py
@@ -29,6 +29,7 @@ REST Kind
 
 from f5.bigip.resource import Collection
 from f5.bigip.resource import Resource
+from f5.bigip.resource import Stats
 from f5.sdk_exception import NodeStateModifyUnsupported
 
 
@@ -36,7 +37,7 @@ class Nodes(Collection):
     """BIG-IP® LTM node collection"""
     def __init__(self, ltm):
         super(Nodes, self).__init__(ltm)
-        self._meta_data['allowed_lazy_attributes'] = [Node]
+        self._meta_data['allowed_lazy_attributes'] = [Node, Stats]
         self._meta_data['attribute_registry'] =\
             {'tm:ltm:node:nodestate': Node}
 

--- a/f5/bigip/tm/ltm/pool.py
+++ b/f5/bigip/tm/ltm/pool.py
@@ -31,6 +31,7 @@ from requests.exceptions import HTTPError
 
 from f5.bigip.resource import Collection
 from f5.bigip.resource import Resource
+from f5.bigip.resource import Stats
 from f5.sdk_exception import MemberStateModifyUnsupported
 
 
@@ -38,7 +39,7 @@ class Pools(Collection):
     """BIG-IP® LTM pool collection"""
     def __init__(self, ltm):
         super(Pools, self).__init__(ltm)
-        self._meta_data['allowed_lazy_attributes'] = [Pool]
+        self._meta_data['allowed_lazy_attributes'] = [Pool, Stats]
         self._meta_data['attribute_registry'] =\
             {'tm:ltm:pool:poolstate': Pool}
 

--- a/f5/bigip/tm/ltm/rule.py
+++ b/f5/bigip/tm/ltm/rule.py
@@ -29,13 +29,14 @@ REST Kind
 
 from f5.bigip.resource import Collection
 from f5.bigip.resource import Resource
+from f5.bigip.resource import Stats
 
 
 class Rules(Collection):
     """BIG-IP® LTM rule collection"""
     def __init__(self, ltm):
         super(Rules, self).__init__(ltm)
-        self._meta_data['allowed_lazy_attributes'] = [Rule]
+        self._meta_data['allowed_lazy_attributes'] = [Rule, Stats]
         self._meta_data['attribute_registry'] =\
             {'tm:ltm:rule:rulestate': Rule}
 

--- a/f5/bigip/tm/ltm/test/functional/test_node.py
+++ b/f5/bigip/tm/ltm/test/functional/test_node.py
@@ -210,3 +210,15 @@ class TestNodes(object):
         nodes = sc.get_collection()
         assert len(nodes) >= 1
         assert [n for n in nodes if n.name == 'node1']
+
+    def test_stats(self, request, mgmt_root, opt_release):
+        setup_node_test(request, mgmt_root, 'Common', 'node1', '192.168.100.1')
+        nodes_stats = mgmt_root.tm.ltm.nodes.stats.load()
+        stats_link = 'https://localhost/mgmt/tm/ltm/node/' +\
+            '~Common~node1/stats'
+        assert stats_link in nodes_stats.entries
+        node_nested_stats = nodes_stats.entries[stats_link]['nestedStats']
+        assert node_nested_stats['selfLink'] == stats_link+'?ver='+opt_release
+        entries = node_nested_stats['entries']
+        assert entries['tmName']['description'] == '/Common/node1'
+        assert entries['status.enabledState']['description'] == 'enabled'

--- a/f5/bigip/tm/ltm/test/functional/test_pool.py
+++ b/f5/bigip/tm/ltm/test/functional/test_pool.py
@@ -259,6 +259,21 @@ class TestPoolMembersCollection(object):
                                    "'user-up' or 'user-down'"
 
 
+class TestPoolsStats(object):
+    def test_stats(self, request, mgmt_root, opt_release):
+        m1, pool = setup_member_test(request, mgmt_root, 'membertestpool1',
+                                     'Common')
+        pools_stats = mgmt_root.tm.ltm.pools.stats.load()
+        stats_link = 'https://localhost/mgmt/tm/ltm/pool/' +\
+            '~Common~membertestpool1/stats'
+        assert stats_link in pools_stats.entries
+        pool_nested_stats = pools_stats.entries[stats_link]['nestedStats']
+        assert pool_nested_stats['selfLink'] == stats_link+'?ver='+opt_release
+        entries = pool_nested_stats['entries']
+        assert entries['tmName']['description'] == '/Common/membertestpool1'
+        assert entries['status.enabledState']['description'] == 'enabled'
+
+
 class TestPool(object):
     def test_create_no_args(self, mgmt_root):
         pool1 = mgmt_root.tm.ltm.pools.pool

--- a/f5/bigip/tm/ltm/test/functional/test_rule.py
+++ b/f5/bigip/tm/ltm/test/functional/test_rule.py
@@ -174,3 +174,17 @@ class TestRuleCollection(object):
         assert isinstance(rc, list)
         assert len(rc)
         assert isinstance(rc[0], Rule)
+
+
+class TestRulesStats(object):
+    def test_stats(self, request, mgmt_root, opt_release):
+        setup_basic_test(request, mgmt_root, 'rule1', 'Common')
+        rules_stats = mgmt_root.tm.ltm.rules.stats.load()
+        stats_link = 'https://localhost/mgmt/tm/ltm/rule/' +\
+            '~Common~rule1:CLIENT_ACCEPTED/stats'
+        assert stats_link in rules_stats.entries
+        rule_nested_stats = rules_stats.entries[stats_link]['nestedStats']
+        assert rule_nested_stats['selfLink'] == stats_link+'?ver='+opt_release
+        entries = rule_nested_stats['entries']
+        assert entries['tmName']['description'] == '/Common/rule1'
+        assert entries['totalExecutions']['value'] == 0

--- a/f5/bigip/tm/ltm/test/functional/test_virtual.py
+++ b/f5/bigip/tm/ltm/test/functional/test_virtual.py
@@ -253,3 +253,17 @@ class TestPolicies(object):
         pclst = v1.policies_s.get_collection()
         assert len(pclst) > 0
         assert isinstance(pclst[0], Policies)
+
+
+class TestVirtualsStats(object):
+    def test_stats(self, request, mgmt_root, opt_release):
+        setup_virtual_test(request, mgmt_root, 'Common', 'tv1')
+        vs_stats = mgmt_root.tm.ltm.virtuals.stats.load()
+        stats_link = 'https://localhost/mgmt/tm/ltm/virtual/' +\
+            '~Common~tv1/stats'
+        assert stats_link in vs_stats.entries
+        vs_nested_stats = vs_stats.entries[stats_link]['nestedStats']
+        assert vs_nested_stats['selfLink'] == stats_link+'?ver='+opt_release
+        entries = vs_nested_stats['entries']
+        assert entries['tmName']['description'] == '/Common/tv1'
+        assert entries['status.enabledState']['description'] == 'enabled'

--- a/f5/bigip/tm/ltm/test/functional/test_virtual_address.py
+++ b/f5/bigip/tm/ltm/test/functional/test_virtual_address.py
@@ -41,6 +41,18 @@ class TestVirtualAddress_s(object):
         assert len(vac) >= 1
         assert [va for va in vac if va.name == '0.0.0.0']
 
+    def test_stats(self, request, mgmt_root, opt_release):
+        setup_virtual_address_s_test(request, mgmt_root, 'va_vs_test-1', 'Common')
+        va_stats = mgmt_root.tm.ltm.virtual_address_s.stats.load()
+        stats_link = 'https://localhost/mgmt/tm/ltm/virtual-address/' +\
+            '~Common~0.0.0.0/stats'
+        assert stats_link in va_stats.entries
+        va_nested_stats = va_stats.entries[stats_link]['nestedStats']
+        assert va_nested_stats['selfLink'] == stats_link+'?ver='+opt_release
+        entries = va_nested_stats['entries']
+        assert entries['tmName']['description'] == '/Common/0.0.0.0'
+        assert entries['status.enabledState']['description'] == 'enabled'
+
 
 class TestVirtualAddress(object):
     def test_CURDLE(self, request, mgmt_root):

--- a/f5/bigip/tm/ltm/virtual.py
+++ b/f5/bigip/tm/ltm/virtual.py
@@ -33,6 +33,7 @@ from f5.bigip.mixins import CheckExistenceMixin
 from f5.bigip.mixins import ExclusiveAttributesMixin
 from f5.bigip.resource import Collection
 from f5.bigip.resource import Resource
+from f5.bigip.resource import Stats
 from f5.sdk_exception import NonExtantVirtualPolicy
 from f5.sdk_exception import UnregisteredKind
 from f5.sdk_exception import URICreationCollision
@@ -44,7 +45,7 @@ class Virtuals(Collection):
     """BIG-IP® LTM virtual collection"""
     def __init__(self, ltm):
         super(Virtuals, self).__init__(ltm)
-        self._meta_data['allowed_lazy_attributes'] = [Virtual]
+        self._meta_data['allowed_lazy_attributes'] = [Virtual, Stats]
         self._meta_data['attribute_registry'] =\
             {'tm:ltm:virtual:virtualstate': Virtual}
 

--- a/f5/bigip/tm/ltm/virtual_address.py
+++ b/f5/bigip/tm/ltm/virtual_address.py
@@ -30,13 +30,14 @@ REST Kind
 
 from f5.bigip.resource import Collection
 from f5.bigip.resource import Resource
+from f5.bigip.resource import Stats
 
 
 class Virtual_Address_s(Collection):
     """BIG-IP® LTM virtual address collection."""
     def __init__(self, ltm):
         super(Virtual_Address_s, self).__init__(ltm)
-        self._meta_data['allowed_lazy_attributes'] = [Virtual_Address]
+        self._meta_data['allowed_lazy_attributes'] = [Virtual_Address, Stats]
         self._meta_data['attribute_registry'] =\
             {'tm:ltm:virtual-address:virtual-addressstate': Virtual_Address}
 


### PR DESCRIPTION
…on f5.big.tm.ltm collection objects Nodes, Pools, Rules, Virtuals and Virtual_Address_s

This is to allow obtaining all item stats with a single request which may come in handy when stats on large collections are required and calling item.stats.load() in a loop causes massive REST calls and huge delay.
Note that entries have to be mapped by the application, suggested criteria are item.fullPath and stat_entry['nestedStats']['entries']['tmName']['description'].