### PR TITLE
Adding the support for cluster stats.

### DIFF
--- a/f5/bigip/tm/sys/cluster.py
+++ b/f5/bigip/tm/sys/cluster.py
@@ -28,6 +28,7 @@ REST Kind
 """
 
 from f5.bigip.resource import OrganizingCollection
+from f5.bigip.resource import Stats
 from f5.bigip.resource import UnnamedResource
 
 
@@ -37,7 +38,7 @@ class Cluster(OrganizingCollection):
         super(Cluster, self).__init__(sys)
         self._meta_data['required_json_kind'] =\
             "tm:sys:cluster:clustercollectionstate"
-        self._meta_data['allowed_lazy_attributes'] = [Default]
+        self._meta_data['allowed_lazy_attributes'] = [Default, Stats]
 
 
 class Default(UnnamedResource):
@@ -46,3 +47,4 @@ class Default(UnnamedResource):
         super(Default, self).__init__(settings)
         self._meta_data['required_json_kind'] = \
             'tm:sys:cluster:clusterstate'
+        self._meta_data['allowed_lazy_attributes'] = [Stats]

--- a/f5/bigip/tm/sys/test/functional/test_cluster.py
+++ b/f5/bigip/tm/sys/test/functional/test_cluster.py
@@ -17,9 +17,23 @@ from icontrol.exceptions import iControlUnexpectedHTTPError
 
 
 def test_cluster_load(request, mgmt_root):
-        # Load will produce exception on non-cluster BIGIP.l
+        # Load will produce exception on non-cluster BIGIP.
         # iControlUnexpectedHTTPError: 404 Unexpected Error: Not Found for uri:
         try:
                 assert str(mgmt_root.tm.sys.cluster.default.load().kind) == 'tm:sys:cluster:clusterstate'
         except iControlUnexpectedHTTPError as err:
-                assert('01020036:3: The requested cluster (default) was not found.' in err.message)
+                assert('01020036:3: The requested cluster (default) was not found.' in str(err))
+
+
+def test_cluster_stats_load(request, mgmt_root):
+        # Load will give the result even on non-cluster BIGIP. However, the payload will be almost empty
+        assert str(mgmt_root.tm.sys.cluster.stats.load().kind) == 'tm:sys:cluster:clustercollectionstats'
+
+
+def test_cluster_default_stats_load(request, mgmt_root):
+        # Load will produce exception on non-cluster BIGIP.
+        # iControlUnexpectedHTTPError: 404 Unexpected Error: Not Found for uri:
+        try:
+                assert str(mgmt_root.tm.sys.cluster.default.stats.load().kind) == 'tm:sys:cluster:clusterstats'
+        except iControlUnexpectedHTTPError as err:
+                assert('01020036:3: The requested cluster (default) was not found.' in str(err))


### PR DESCRIPTION
Cluster stats are useful for providing the information about the state of cluster members, availability, primary blade etc.
Also fixed the issue with the failing functional test.