### PR TITLE
Issue #1457 - Allow Example Resource to Load

### DIFF
--- a/f5/bigip/resource.py
+++ b/f5/bigip/resource.py
@@ -683,14 +683,30 @@ class ResourceBase(PathElement, ToDictMixin):
         # Post-process the response
         new_instance._local_update(response.json())
 
-        if new_instance.kind != new_instance._meta_data['required_json_kind'] \
-           and new_instance.kind != "tm:transaction:commandsstate":
-            error_message = "For instances of type '%r' the corresponding"\
-                " kind must be '%r' but creation returned JSON with kind: %r"\
-                % (new_instance.__class__.__name__,
-                   new_instance._meta_data['required_json_kind'],
-                   new_instance.kind)
-            raise KindTypeMismatch(error_message)
+        # Allow for example files, which are KindTypeMismatches
+        if hasattr(new_instance, 'selfLink'):
+            if new_instance.kind != new_instance._meta_data[
+                'required_json_kind'] \
+                    and new_instance.kind != "tm:transaction:commandsstate" \
+                    and 'example' not in new_instance.selfLink.split('/')[-1]:
+                error_message = "For instances of type '%r' the corresponding" \
+                                " kind must be '%r' but creation returned JSON with kind: %r" \
+                                % (new_instance.__class__.__name__,
+                                   new_instance._meta_data[
+                                       'required_json_kind'],
+                                   new_instance.kind)
+                raise KindTypeMismatch(error_message)
+        else:
+            if new_instance.kind != new_instance._meta_data[
+                'required_json_kind'] \
+                    and new_instance.kind != "tm:transaction:commandsstate":
+                error_message = "For instances of type '%r' the corresponding" \
+                                " kind must be '%r' but creation returned JSON with kind: %r" \
+                                % (new_instance.__class__.__name__,
+                                   new_instance._meta_data[
+                                       'required_json_kind'],
+                                   new_instance.kind)
+                raise KindTypeMismatch(error_message)
 
         # Update the object to have the correct functional uri.
         new_instance._activate_URI(new_instance.selfLink)

--- a/f5/bigip/test/functional/test_resource.py
+++ b/f5/bigip/test/functional/test_resource.py
@@ -29,4 +29,3 @@ def test_load_example_resource(request, mgmt_root):
     assert x.kind == 'tm:ltm:pool:poolcollectionstate'
     assert x.kind != 'tm:ltm:pool:poolstate'
     assert x.items[0].get('name') is None
-    assert x.items[0].get('loadBalancingMode') == 'round-robin'

--- a/f5/bigip/test/functional/test_resource.py
+++ b/f5/bigip/test/functional/test_resource.py
@@ -1,0 +1,32 @@
+# Copyright 2018 F5 Networks Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import pytest
+
+from icontrol.exceptions import iControlUnexpectedHTTPError
+
+
+def test_create_example_resource(request, mgmt_root):
+    with pytest.raises(iControlUnexpectedHTTPError) as error:
+        mgmt_root.tm.ltm.pools.pool.create(name='example')
+    assert 'is a reserved keyword and must not be used as resource name' in str(error.value.message)
+
+
+def test_load_example_resource(request, mgmt_root):
+    x = mgmt_root.tm.ltm.pools.pool.load(name='example')
+    assert x.kind == 'tm:ltm:pool:poolcollectionstate'
+    assert x.kind != 'tm:ltm:pool:poolstate'
+    assert x.items[0].get('name') is None
+    assert x.items[0].get('loadBalancingMode') == 'round-robin'


### PR DESCRIPTION
Problem: the example file is a collection kind, which is a kind
         mismatch on a resource

Solution: Check for example at end of selflink in the _produce_instance
          def and don't error on kind mismatch if present

Files Changed:

 - f5/bigip/resource.py