### PR TITLE
Issue #1456 - Add sys/hardware endpoint

### DIFF
--- a/f5/bigip/tm/sys/__init__.py
+++ b/f5/bigip/tm/sys/__init__.py
@@ -42,6 +42,7 @@ from f5.bigip.tm.sys.feature_module import Feature_Module
 from f5.bigip.tm.sys.file import File
 from f5.bigip.tm.sys.folder import Folders
 from f5.bigip.tm.sys.global_settings import Global_Settings
+from f5.bigip.tm.sys.hardware import Hardware
 from f5.bigip.tm.sys.host_info import Host_Info
 from f5.bigip.tm.sys.httpd import Httpd
 from f5.bigip.tm.sys.icall import Icall
@@ -80,6 +81,7 @@ class Sys(OrganizingCollection):
             File,
             Folders,
             Global_Settings,
+            Hardware,
             Host_Info,
             Httpd,
             Icall,

--- a/f5/bigip/tm/sys/hardware.py
+++ b/f5/bigip/tm/sys/hardware.py
@@ -1,0 +1,45 @@
+# coding=utf-8
+#
+# Copyright 2018 F5 Networks Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""BIG-IP® system hardware module
+
+REST URI
+    ``http://localhost/mgmt/tm/sys/hardware``
+
+REST Kind
+    ``tm:sys:hardware:hardwarestats:*``
+"""
+
+from f5.bigip.resource import UnnamedResource
+from f5.sdk_exception import UnsupportedMethod
+
+
+class Hardware(UnnamedResource):
+    """BIG-IP® system host info unnamed resource"""
+    def __init__(self, sys):
+        super(Hardware, self).__init__(sys)
+        self._meta_data['object_has_stats'] = False
+        self._meta_data['required_load_parameters'] = set()
+        self._meta_data['required_json_kind'] =\
+            'tm:sys:hardware:hardwarestats'
+
+    def update(self, **kwargs):
+        """Update is not supported for hardware
+
+        :raises: :exc:`~f5.BIG-IP.resource.UnsupportedMethod`
+        """
+        raise UnsupportedMethod("{0} does not support the update method, only load and refresh".format(self.__class__.__name__))

--- a/f5/bigip/tm/sys/test/functional/test_hardware.py
+++ b/f5/bigip/tm/sys/test/functional/test_hardware.py
@@ -1,0 +1,37 @@
+# Copyright 2018 F5 Networks Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+
+from f5.bigip.tm.sys.hardware import Hardware
+
+
+class TestHardware(object):
+    def test_load_refresh(self, mgmt_root):
+        h1 = mgmt_root.tm.sys.hardware.load()
+        assert isinstance(h1, Hardware)
+        assert hasattr(h1, 'entries')
+        assert h1.kind == 'tm:sys:hardware:hardwarestats'
+        assert 'https://localhost/mgmt/tm/sys/hardware/platform' in h1.entries.keys()
+
+        h2 = mgmt_root.tm.sys.hardware.load()
+
+        assert isinstance(h2, Hardware)
+        assert hasattr(h2, 'entries')
+        assert h2.kind == 'tm:sys:hardware:hardwarestats'
+        assert 'https://localhost/mgmt/tm/sys/hardware/platform' in h2.entries.keys()
+
+        h1.refresh()
+
+        assert h1.kind == h2.kind
+        assert h1.entries.keys() == h2.entries.keys()

--- a/f5/bigip/tm/sys/test/unit/test_hardware.py
+++ b/f5/bigip/tm/sys/test/unit/test_hardware.py
@@ -1,0 +1,33 @@
+# Copyright 2018 F5 Networks Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+
+import mock
+import pytest
+
+from f5.bigip.tm.sys import Hardware
+from f5.sdk_exception import UnsupportedMethod
+
+
+@pytest.fixture
+def fake_info():
+    fake_sys = mock.MagicMock()
+    return Hardware(fake_sys)
+
+
+def test_create_raises(fake_info):
+    with pytest.raises(UnsupportedMethod) as EIO:
+        fake_info.update()
+    assert str(EIO.value) == "Hardware does not support the update method, only load and refresh"


### PR DESCRIPTION
Problem: sys/hardware endpoint missing

Solution: This PR adds the endpoint

Files Changed:

- f5/bigip/tm/sys/__init__.py (changed)
- f5/bigip/tm/sys/hardware.py (added)
- f5/bigip/tm/sys/test/functional/test_hardware.py (added)
- f5/bigip/tm/sys/test/unit/test_hardware.py (added)