### PR TITLE
Issue #1461 - Add sys/connection endpoint

### DIFF
--- a/f5/bigip/tm/sys/__init__.py
+++ b/f5/bigip/tm/sys/__init__.py
@@ -32,6 +32,7 @@ from f5.bigip.tm.sys.application import Application
 from f5.bigip.tm.sys.clock import Clock
 from f5.bigip.tm.sys.cluster import Cluster
 from f5.bigip.tm.sys.config import Config
+from f5.bigip.tm.sys.connection import Connection
 from f5.bigip.tm.sys.crypto import Crypto
 from f5.bigip.tm.sys.daemon_log_settings import Daemon_Log_Settings
 from f5.bigip.tm.sys.db import Dbs
@@ -71,6 +72,7 @@ class Sys(OrganizingCollection):
             Clock,
             Cluster,
             Config,
+            Connection,
             Crypto,
             Daemon_Log_Settings,
             Dbs,

--- a/f5/bigip/tm/sys/connection.py
+++ b/f5/bigip/tm/sys/connection.py
@@ -1,0 +1,47 @@
+# coding=utf-8
+#
+# Copyright 2018 F5 Networks Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""BIG-IP® system connection module
+
+REST URI
+    ``http://localhost/mgmt/tm/sys/connection``
+
+REST Kind
+    ``tm:sys:connection:connectionstats:*``
+"""
+
+from f5.bigip.resource import UnnamedResource
+from f5.sdk_exception import UnsupportedOperation
+
+
+class Connection(UnnamedResource):
+    """BIG-IP® system host info unnamed resource"""
+    def __init__(self, sys):
+        super(Connection, self).__init__(sys)
+        self._meta_data['object_has_stats'] = False
+        self._meta_data['required_load_parameters'] = set()
+        self._meta_data['required_json_kind'] =\
+            'tm:sys:connection:connectionstats'
+
+    def create(self, **kwargs):
+        '''Create is not supported for connection resources.
+
+        :raises: UnsupportedOperation
+        '''
+        raise UnsupportedOperation(
+            "Operation not allowed on connections."
+        )

--- a/f5/bigip/tm/sys/test/functional/test_connection.py
+++ b/f5/bigip/tm/sys/test/functional/test_connection.py
@@ -1,0 +1,34 @@
+# Copyright 2018 F5 Networks Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+
+from f5.bigip.tm.sys.connection import Connection
+
+
+class TestConnection(object):
+    def test_load_refresh(self, mgmt_root):
+        h1 = mgmt_root.tm.sys.connection.load()
+        assert isinstance(h1, Connection)
+        assert hasattr(h1, 'entries') or hasattr(h1, 'apiRawValues')
+        assert h1.kind == 'tm:sys:connection:connectionstats'
+
+        h2 = mgmt_root.tm.sys.connection.load()
+
+        assert isinstance(h2, Connection)
+        assert hasattr(h2, 'entries') or hasattr(h2, 'apiRawValues')
+        assert h2.kind == 'tm:sys:connection:connectionstats'
+
+        h1.refresh()
+
+        assert h1.kind == h2.kind

--- a/f5/bigip/tm/sys/test/unit/test_connection.py
+++ b/f5/bigip/tm/sys/test/unit/test_connection.py
@@ -1,0 +1,33 @@
+# Copyright 2018 F5 Networks Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+
+import mock
+import pytest
+
+from f5.bigip.tm.sys import Connection
+from f5.sdk_exception import UnsupportedOperation
+
+
+@pytest.fixture
+def fake_info():
+    fake_sys = mock.MagicMock()
+    return Connection(fake_sys)
+
+
+def test_create_raises(fake_info):
+    with pytest.raises(UnsupportedOperation) as EIO:
+        fake_info.create()
+    assert str(EIO.value) == "Operation not allowed on connections."


### PR DESCRIPTION
Problem: sys/connection endpoint missing

Solution: This PR adds the endpoint

Files Changed:

- f5/bigip/tm/sys/__init__.py (changed)
- f5/bigip/tm/sys/connection.py (added)
- f5/bigip/tm/sys/test/functional/test_connection.py (added)
- f5/bigip/tm/sys/test/unit/test_connection.py (added)