### PR TITLE
Issue #1439 - Add sys/memory endpoint support

### DIFF
--- a/f5/bigip/tm/sys/__init__.py
+++ b/f5/bigip/tm/sys/__init__.py
@@ -51,6 +51,7 @@ from f5.bigip.tm.sys.license import License
 from f5.bigip.tm.sys.log_config import Log_Config
 from f5.bigip.tm.sys.management_ip import Management_Ips
 from f5.bigip.tm.sys.management_route import Management_Routes
+from f5.bigip.tm.sys.memory import Memory
 from f5.bigip.tm.sys.ntp import Ntp
 from f5.bigip.tm.sys.performance import Performances
 from f5.bigip.tm.sys.provision import Provision
@@ -92,6 +93,7 @@ class Sys(OrganizingCollection):
             Disk,
             Management_Ips,
             Management_Routes,
+            Memory,
             Ntp,
             Performances,
             Provision,

--- a/f5/bigip/tm/sys/memory.py
+++ b/f5/bigip/tm/sys/memory.py
@@ -1,0 +1,52 @@
+# coding=utf-8
+#
+# Copyright 2018 F5 Networks Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""BIG-IP® system memory module
+
+REST URI
+    ``http://localhost/mgmt/tm/sys/memory``
+
+REST Kind
+    ``tm:sys:memory:memorystats:*``
+"""
+
+from f5.bigip.resource import UnnamedResource
+from f5.sdk_exception import UnsupportedMethod
+
+
+class Memory(UnnamedResource):
+    """BIG-IP® system memory unnamed resource"""
+    def __init__(self, sys):
+        super(Memory, self).__init__(sys)
+        self._meta_data['object_has_stats'] = False
+        self._meta_data['required_load_parameters'] = set()
+        self._meta_data['required_json_kind'] =\
+            'tm:sys:memory:memorystats'
+
+    def update(self, **kwargs):
+        """Update is not supported for memory resources
+
+        :raises: :exc:`~f5.BIG-IP.resource.UnsupportedMethod`
+        """
+        raise UnsupportedMethod("{0} does not support the update method, only load and refresh".format(self.__class__.__name__))
+
+    def modify(self, **kwargs):
+        """Modify is not supported for memory resources
+
+        :raises: :exc:`~f5.BIG-IP.resource.UnsupportedMethod`
+        """
+        raise UnsupportedMethod("{0} does not support the modify method, only load and refresh".format(self.__class__.__name__))

--- a/f5/bigip/tm/sys/test/functional/test_memory.py
+++ b/f5/bigip/tm/sys/test/functional/test_memory.py
@@ -1,0 +1,37 @@
+# Copyright 2018 F5 Networks Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+
+from f5.bigip.tm.sys.memory import Memory
+
+
+class TestMemory(object):
+    def test_load_refresh(self, mgmt_root):
+        h1 = mgmt_root.tm.sys.memory.load()
+        assert isinstance(h1, Memory)
+        assert hasattr(h1, 'entries')
+        assert h1.kind == 'tm:sys:memory:memorystats'
+        assert 'https://localhost/mgmt/tm/sys/memory/memory-host' in h1.entries.keys()
+
+        h2 = mgmt_root.tm.sys.memory.load()
+
+        assert isinstance(h2, Memory)
+        assert hasattr(h2, 'entries')
+        assert h2.kind == 'tm:sys:memory:memorystats'
+        assert 'https://localhost/mgmt/tm/sys/memory/memory-host' in h2.entries.keys()
+
+        h1.refresh()
+
+        assert h1.kind == h2.kind
+        assert h1.entries.keys() == h2.entries.keys()

--- a/f5/bigip/tm/sys/test/unit/test_memory.py
+++ b/f5/bigip/tm/sys/test/unit/test_memory.py
@@ -1,0 +1,39 @@
+# Copyright 2018 F5 Networks Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+
+import mock
+import pytest
+
+from f5.bigip.tm.sys import Memory
+from f5.sdk_exception import UnsupportedMethod
+
+
+@pytest.fixture
+def fake_info():
+    fake_sys = mock.MagicMock()
+    return Memory(fake_sys)
+
+
+def test_update_raises(fake_info):
+    with pytest.raises(UnsupportedMethod) as EIO:
+        fake_info.update()
+    assert str(EIO.value) == "Memory does not support the update method, only load and refresh"
+
+
+def test_modify_raises(fake_info):
+    with pytest.raises(UnsupportedMethod) as EIO:
+        fake_info.modify()
+    assert str(EIO.value) == "Memory does not support the modify method, only load and refresh"


### PR DESCRIPTION
Problem: sys/memory endpoint missing

Solution: This PR adds the endpoint

Files Changed:

- f5/bigip/tm/sys/__init__.py (changed)
- f5/bigip/tm/sys/memory.py (added)
- f5/bigip/tm/sys/test/functional/test_memory.py (added)
- f5/bigip/tm/sys/test/unit/test_memory.py (added)