### PR TITLE
Implement REST proxy for BIG-IQ

### DIFF
--- a/f5/bigip/__init__.py
+++ b/f5/bigip/__init__.py
@@ -23,10 +23,15 @@ try:
 except ImportError:
     import urllib.parse as urlparse
 
+from os import environ
+
 try:
-    import signal
-    from signal import SIGALRM
-    HAS_SIGNAL = True
+    if environ.get('F5_NO_SIGNAL') == '1':
+        HAS_SIGNAL = False
+    else:
+        import signal
+        from signal import SIGALRM
+        HAS_SIGNAL = True
 except ImportError:
     HAS_SIGNAL = False
 
@@ -51,10 +56,16 @@ def timeout_handler(signum, frame):
 
 class BaseManagement(PathElement):
     def __init__(self, hostname, username, password, **kwargs):
+        icrs = kwargs.pop('icrs', None)
+        
         self.args = self.parse_arguments(
             hostname, username, password, **kwargs
         )
-        self.icrs = self._get_icr_session(**self.args)
+        
+        if icrs:
+            self.icrs = icrs
+        else:
+            self.icrs = self._get_icr_session(**self.args)
         self.configure_meta_data(**self.args)
         self.set_icr_metadata(self.icrs)
 

--- a/f5/bigip/__init__.py
+++ b/f5/bigip/__init__.py
@@ -57,11 +57,11 @@ def timeout_handler(signum, frame):
 class BaseManagement(PathElement):
     def __init__(self, hostname, username, password, **kwargs):
         icrs = kwargs.pop('icrs', None)
-        
+
         self.args = self.parse_arguments(
             hostname, username, password, **kwargs
         )
-        
+
         if icrs:
             self.icrs = icrs
         else:

--- a/f5/bigiq/__init__.py
+++ b/f5/bigiq/__init__.py
@@ -1,6 +1,6 @@
 # coding=utf-8
 #
-# Copyright 2014 F5 Networks Inc.
+# Copyright 2016 F5 Networks Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/f5/bigiq/__init__.py
+++ b/f5/bigiq/__init__.py
@@ -77,7 +77,6 @@ class BaseManagement(object):
             'hostname': self._args['hostname'],
             'port': self._args['port'],
             'uri': 'https://{0}:{1}/mgmt/'.format(self._args['hostname'], self._args['port']),
-								
             'device_name': None,
             'local_ip': None,
             'bigip': self,

--- a/f5/bigiq/__init__.py
+++ b/f5/bigiq/__init__.py
@@ -62,10 +62,10 @@ class BaseManagement(object):
         return result
 
     def _get_icr_session(self):
-        result = iControlRESTSession(self.args['username'], \
-                                     self.args['password'], \
-                                     timeout=self.args['timeout'], \
-                                     auth_provider=self.args['auth_provider'], \
+        result = iControlRESTSession(self.args['username'],
+                                     self.args['password'],
+                                     timeout=self.args['timeout'],
+                                     auth_provider=self.args['auth_provider'],
                                      verify=self.args['verify'])
         result.debug = self.args['debug']
         return result
@@ -178,7 +178,7 @@ class ManagementProxy(object):
         devices = mgmt.shared.resolver.device_groups.cm_bigip_allbigipdevices.devices_s
         collection = devices.get_collection(
             requests_params={
-                'params' : '$filter=hostname+eq+\'{0}\'&$select=uuid'.format(proxy_to)
+                'params': '$filter=hostname+eq+\'{0}\'&$select=uuid'.format(proxy_to)
             }
         )
         if len(collection) > 1:
@@ -199,7 +199,7 @@ class ManagementProxy(object):
         devices = mgmt.shared.resolver.device_groups.cm_bigip_allbigipdevices.devices_s
         collection = devices.get_collection(
             requests_params={
-                'params' : '$filter=uuid+eq+\'{0}\''.format(uuid)
+                'params': '$filter=uuid+eq+\'{0}\''.format(uuid)
             }
         )
         if len(collection) > 1:


### PR DESCRIPTION
The PR adapts some of the strategies from the iWorkflow REST proxy implementation and allows using the REST proxy on BIG-IQ. The "isRestProxyEnabled" flag will be set, if required (in contrast to iWorkflow it is ***not*** set automatically by BIG-IQ during discovery).

Example:
```python
from bigiq import ManagementRoot
...
bigip = ManagementRoot(bigiq_hostname, username, password, proxy_to=bigip_hostname)
```

To skip enabling the REST proxy, simply pass in an additional parameter: [`enable_proxy=False`]

It also implement an option to pass in an existing iControlRestSession. This is useful when running as a server side application where it may be advisable to reuse an existing session in order to prevent re-authentication every other request.

Example (using Django's caching facilities):
```python
def get_bigiq(hostname, username, password, **kwargs):
    data = { 
        'hostname' : hostname, 
        'username' : username, 
        'password' : password,
    }

    key = 'bigiq-{}'.format(sha1(str(sorted(data.items()))).hexdigest())
    icrs = cache.get(key, None)
    if icrs:
        # Cache hit
        kwargs['icrs'] = icrs
        bigiq = ManagementRoot(hostname, username, password, **kwargs)
    else:
        # Cache miss
        bigiq = ManagementRoot(hostname, username, password, **kwargs)
        icrs = bigiq.icrs
    
    cache.set(key, icrs, getattr(settings, 'CACHE_ICRS_MAXAGE', 600))
    return bigiq
```

When running a server side application, e.g. via WSGI it may be advisable to not register any signal handlers, see e9507f7. Disable it using the following line in your wsgi.py
```python
os.environ.setdefault('F5_NO_SIGNAL', '1')
```