### PR TITLE
added firewall rule creation under policy

### DIFF
--- a/f5/bigip/tm/security/firewall.py
+++ b/f5/bigip/tm/security/firewall.py
@@ -124,13 +124,13 @@ class Rule_List(Resource):
 
 class Rules_s(Collection):
     """BIG-IP® AFM® Rules sub-collection."""
-    def __init__(self, rule_list):
-        super(Rules_s, self).__init__(rule_list)
+    def __init__(self, policy):
+        super(Rules_s, self).__init__(policy)
         self._meta_data['required_json_kind'] = \
-            'tm:security:firewall:rule-list:rules:rulescollectionstate'
+            'tm:security:firewall:policy:rules:rulescollectionstate'
         self._meta_data['allowed_lazy_attributes'] = [Rule]
         self._meta_data['attribute_registry'] = \
-            {'tm:security:firewall:rule-list:rules:rulesstate':
+            {'tm:security:firewall:policy:rules:rulesstate':
                 Rule}
 
 
@@ -148,7 +148,7 @@ class Rule(Resource, CheckExistenceMixin):
     def __init__(self, rules_s):
         super(Rule, self).__init__(rules_s)
         self._meta_data['required_json_kind'] = \
-            'tm:security:firewall:rule-list:rules:rulesstate'
+            'tm:security:firewall:policy:rules:rulesstate'
         self._meta_data['required_creation_parameters'].update(('action',))
         self._meta_data['exclusive_attributes'].append(
             ('place-after', 'place-before'))
@@ -223,7 +223,7 @@ class Policy(Resource):
         self._meta_data['required_load_parameters'].update(('partition',))
         self._meta_data['allowed_lazy_attributes'] = [Rules_s]
         self._meta_data['attribute_registry'] = \
-            {'tm:security:firewall:rule-list:rules:rulescollectionstate':
+            {'tm:security:firewall:policy:rules:rulescollectionstate':
                 Rules_s}
 
 

--- a/f5/bigip/tm/security/test/unit/test_firewall.py
+++ b/f5/bigip/tm/security/test/unit/test_firewall.py
@@ -142,7 +142,7 @@ class TestRuleList(object):
 class TestRulesSubcollection(object):
     def test_rule_subcollection(self, fakeicontrolsession):
         pc = Rules_s(Makerulelist(fakeicontrolsession))
-        kind = 'tm:security:firewall:rule-list:rules:rulesstate'
+        kind = 'tm:security:firewall:policy:rules:rulesstate'
         test_meta = pc._meta_data['attribute_registry']
         test_meta2 = pc._meta_data['allowed_lazy_attributes']
         assert isinstance(pc, Rules_s)
@@ -177,7 +177,7 @@ class TestPolicy(object):
 class TestPolicyRuleSubCollection(object):
     def test_policy_rule_subcollection(self, fakeicontrolsession):
         pc = Rules_s(MakePolicyRules(fakeicontrolsession))
-        kind = 'tm:security:firewall:rule-list:rules:rulesstate'
+        kind = 'tm:security:firewall:policy:rules:rulesstate'
         test_meta = pc._meta_data['attribute_registry']
         test_meta2 = pc._meta_data['allowed_lazy_attributes']
         assert isinstance(pc, Rules_s)


### PR DESCRIPTION
Problem : In current implementation we can create firewall rules under rules list, but the path to attach rule lists to policy is broken, there is no rule-list sub-collection under policy collection, so it is better way to create rules under policy itself because rule-lists cannot be attached to policy.

Solution: Changed rule creation required kind to policy --> rules (tm:security:firewall:policy:rules:rulesstate)
so we can create rule under policy instead of rule_list (tm:security:firewall:rule-list:rules:rulesstate)

files changed- 
f5/bigip/tm/security/firewall.py
f5/bigip/tm/security/test/functional/test_firewall.py
f5/bigip/tm/security/test/unit/test_firewall.py
