### PR TITLE
Issue #1464 - Force Common partition on CLE

### DIFF
--- a/f5/bigip/resource.py
+++ b/f5/bigip/resource.py
@@ -995,6 +995,11 @@ class Resource(ResourceBase):
                     "resource, the _meta_data['uri'] is %s and it should"\
                     " not be changed." % (self._meta_data['uri'])
             raise URICreationCollision(error)
+
+        # Forcing Common partition if not supplied to normalize API behavior on fullPath (Issue 1464)
+        if 'partition' not in kwargs:
+            kwargs['partition'] = 'Common'
+
         self._check_exclusive_parameters(**kwargs)
         requests_params = self._handle_requests_params(kwargs)
         self._minimum_one_is_missing(**kwargs)
@@ -1072,6 +1077,11 @@ class Resource(ResourceBase):
                     "resource, the _meta_data['uri'] is %s and it should"\
                     " not be changed." % (self._meta_data['uri'])
             raise URICreationCollision(error)
+
+        # Forcing Common partition if not supplied to normalize API behavior on fullPath (Issue 1464)
+        if 'partition' not in kwargs:
+            kwargs['partition'] = 'Common'
+
         requests_params = self._handle_requests_params(kwargs)
         self._check_load_parameters(**kwargs)
         kwargs['uri_as_parts'] = True
@@ -1177,6 +1187,11 @@ class Resource(ResourceBase):
     def _exists(self, **kwargs):
         """wrapped with exists, override that in a subclass to customize """
         requests_params = self._handle_requests_params(kwargs)
+
+        # Forcing Common partition if not supplied to normalize API behavior on fullPath (Issue 1464)
+        if 'partition' not in kwargs:
+            kwargs['partition'] = 'Common'
+
         self._check_load_parameters(**kwargs)
         kwargs['uri_as_parts'] = True
         session = self._meta_data['bigip']._meta_data['icr_session']

--- a/f5/bigip/tm/ltm/pool.py
+++ b/f5/bigip/tm/ltm/pool.py
@@ -188,6 +188,13 @@ class Members(Resource):
         requests_params = self._handle_requests_params(kwargs)
         self._check_load_parameters(**kwargs)
         kwargs['uri_as_parts'] = True
+
+        # Forcing Common partition if not supplied to normalize API behavior on fullPath (Issue 1464)
+        # Adding here to pool members as this is overridden from resource; this will fix exists false checks
+        # when partition is not supplied as well
+        if 'partition' not in kwargs:
+            kwargs['partition'] = 'Common'
+
         session = self._meta_data['bigip']._meta_data['icr_session']
         base_uri = self._meta_data['container']._meta_data['uri']
         kwargs.update(requests_params)


### PR DESCRIPTION
Problem: inconsistent API behavior on fullPath without partition

Solution: This PR checks for absence of partition kwarg on create, load, and exists and adds it.

Files Changed:

- f5/bigip/tm/ltm/pool.py (changed)
- f5/bigip/resource.py (changed)