### PR TITLE
Handle exceptions raised by signal when used in flask

### DIFF
--- a/f5/bigip/__init__.py
+++ b/f5/bigip/__init__.py
@@ -116,12 +116,16 @@ class BaseManagement(PathElement):
     def _get_tmos_version(self):
         connect = self._meta_data['bigip']._meta_data['icr_session']
         base_uri = self._meta_data['uri'] + 'tm/sys/'
-        if HAS_SIGNAL:
-            signal.signal(SIGALRM, timeout_handler)
-            signal.alarm(int(self.args['timeout']))
-            response = connect.get(base_uri)
-            signal.alarm(0)
-        else:
+        try:
+            if HAS_SIGNAL:
+                signal.signal(SIGALRM, timeout_handler)
+                signal.alarm(int(self.args['timeout']))
+                response = connect.get(base_uri)
+                signal.alarm(0)
+            else:
+                response = connect.get(base_uri)
+        except ValueError:
+            # Flask raises this when running F5-SDK in an instance
             response = connect.get(base_uri)
         ver = response.json()
         version = urlparse.parse_qs(


### PR DESCRIPTION
Issues:
Fixes #<issueid>

Problem:
Using the SDK in flask will raise an exception

Analysis:
This handles (and discards) the exception; disabling hard timeouts.

Tests: