### PR TITLE
Add Device DOS support

### DIFF
--- a/f5/bigip/tm/security/dos.py
+++ b/f5/bigip/tm/security/dos.py
@@ -32,6 +32,8 @@ from f5.bigip.resource import Collection
 from f5.bigip.resource import OrganizingCollection
 from f5.bigip.resource import Resource
 from f5.sdk_exception import NonExtantApplication
+from f5.sdk_exception import UnsupportedOperation
+
 
 from distutils.version import LooseVersion
 
@@ -41,7 +43,9 @@ class Dos(OrganizingCollection):
 
     def __init__(self, security):
         super(Dos, self).__init__(security)
-        self._meta_data['allowed_lazy_attributes'] = [Profiles]
+        self._meta_data['allowed_lazy_attributes'] = [
+            Profiles,
+            Device_Configs]
 
 
 class Profiles(Collection):
@@ -297,3 +301,38 @@ class Protocol_Sip(Resource, CheckExistenceMixin):
 
         return self._check_existence_by_collection(
             self._meta_data['container'], kwargs['name'])
+
+
+class Device_Configs(Collection):
+    """BIG-IP® Dos Device collection"""
+    def __init__(self, dos):
+        super(Device_Configs, self).__init__(dos)
+        self._meta_data['allowed_lazy_attributes'] = [Device_Config]
+        self._meta_data['attribute_registry'] = \
+            {'tm:security:dos:device-config:device-configstate': Device_Config}
+
+
+class Device_Config(Resource):
+    """BIG-IP® Dos Device resource"""
+    def __init__(self, device_configs):
+        super(Device_Config, self).__init__(device_configs)
+        self._meta_data['required_json_kind'] = \
+            'tm:security:dos:device-config:device-configstate'
+
+    def create(self, **kwargs):
+        """Create is not supported for Device_Config
+
+        :raises: UnsupportedOperation
+        """
+        raise UnsupportedOperation(
+            "%s does not support the update method" % self.__class__.__name__
+        )
+
+    def delete(self, **kwargs):
+        """Delete is not supported for Device_Config
+
+        :raises: UnsupportedOperation
+        """
+        raise UnsupportedOperation(
+            "%s does not support the delete method" % self.__class__.__name__
+        )

--- a/f5/bigip/tm/security/test/unit/test_dos.py
+++ b/f5/bigip/tm/security/test/unit/test_dos.py
@@ -19,6 +19,7 @@ import pytest
 from f5.bigip import ManagementRoot
 from f5.bigip.tm.security.dos import Application
 from f5.bigip.tm.security.dos import Applications
+from f5.bigip.tm.security.dos import Device_Config
 from f5.bigip.tm.security.dos import Dos_Network
 from f5.bigip.tm.security.dos import Dos_Networks
 from f5.bigip.tm.security.dos import Profile
@@ -27,7 +28,10 @@ from f5.bigip.tm.security.dos import Protocol_Dns_s
 from f5.bigip.tm.security.dos import Protocol_Sip
 from f5.bigip.tm.security.dos import Protocol_Sips
 
+
 from f5.sdk_exception import MissingRequiredCreationParameter
+from f5.sdk_exception import MissingRequiredReadParameter
+from f5.sdk_exception import UnsupportedOperation
 
 from six import iterkeys
 
@@ -37,6 +41,13 @@ def FakeProfile():
     fake_profiles = mock.MagicMock()
     fake_profile = Profile(fake_profiles)
     return fake_profile
+
+
+@pytest.fixture
+def FakeDeviceConfig():
+    fake_device_configs = mock.MagicMock()
+    fake_device_config = Device_Config(fake_device_configs)
+    return fake_device_config
 
 
 def Makeprofile(fakeicontrolsession):
@@ -150,3 +161,19 @@ class TestProtocolSipSubcollection(object):
         pc = Protocol_Sips(Makeprofile(fakeicontrolsession))
         with pytest.raises(MissingRequiredCreationParameter):
             pc.protocol_sip.create()
+
+
+class TestDosDeviceConfig(object):
+    def test_create_raises(self, fakeicontrolsession):
+        b = ManagementRoot('192.168.1.1', 'admin', 'admin')
+        with pytest.raises(UnsupportedOperation):
+            b.tm.security.dos.device_configs.device_config.create()
+
+    def test_delete_raises(self, fakeicontrolsession):
+        b = ManagementRoot('192.168.1.1', 'admin', 'admin')
+        with pytest.raises(UnsupportedOperation):
+            b.tm.security.dos.device_configs.device_config.delete()
+
+    def test_load_no_args(self, FakeDeviceConfig):
+        with pytest.raises(MissingRequiredReadParameter):
+            FakeDeviceConfig.load()


### PR DESCRIPTION
Issues: Dos device vector modification support
Fixes #<1479>

Problem: user cannot modify the device dos vectors thresholds, etc

Analysis: Added support to allow user to modify the device dos vectors
/f5/bigip/tm/security/dos.py

Tests: Ran the unit,funcitonal and style check
/f5/bigip/tm/security/test/unit/test_dos.py
/f5/bigip/tm/security/test/functional/test_dos.py