### PR TITLE
Unable to restart big ip tmm service

### DIFF
--- a/f5/bigip/tm/sys/__init__.py
+++ b/f5/bigip/tm/sys/__init__.py
@@ -55,6 +55,7 @@ from f5.bigip.tm.sys.memory import Memory
 from f5.bigip.tm.sys.ntp import Ntp
 from f5.bigip.tm.sys.performance import Performances
 from f5.bigip.tm.sys.provision import Provision
+from f5.bigip.tm.sys.service import Service
 from f5.bigip.tm.sys.sflow import Sflow
 from f5.bigip.tm.sys.smtp_server import Smtp_Servers
 from f5.bigip.tm.sys.snmp import Snmp
@@ -97,6 +98,7 @@ class Sys(OrganizingCollection):
             Ntp,
             Performances,
             Provision,
+            Service,
             Sflow,
             Smtp_Servers,
             Snmp,

--- a/f5/bigip/tm/sys/service.py
+++ b/f5/bigip/tm/sys/service.py
@@ -1,0 +1,73 @@
+# coding=utf-8
+#
+# Copyright 2016 F5 Networks Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""BIG-IP® system host-info module
+
+REST URI
+    ``http://localhost/mgmt/tm/sys/service``
+
+GUI Path
+    N/A
+
+REST Kind
+    ``tm:sys:service:*``
+"""
+
+from f5.bigip.mixins import CommandExecutionMixin
+from f5.bigip.resource import OrganizingCollection
+from f5.bigip.resource import UnnamedResource
+from f5.sdk_exception import UnsupportedMethod
+
+
+class Service(OrganizingCollection):
+    def __init__(self, sys):
+        super(Service, self).__init__(sys)
+        self._meta_data['allowed_lazy_attributes'] = [Tmm]
+
+
+class Tmm(UnnamedResource,
+          CommandExecutionMixin):
+    """BIG-IP® system  tmm service
+
+    .. note::
+        This is an unnamed resource so it has not ~Partition~Name pattern
+        at the end of its URI.
+    """
+    def __init__(self, service):
+        super(Tmm, self).__init__(service)
+        self._meta_data['allowed_commands'].append('restart')
+        self._meta_data['minimum_version'] = '13.0.0'
+        self._meta_data['required_json_kind'] =\
+            'tm:sys:service:servicestate'
+
+    def update(self, **kwargs):
+        """Update is not supported
+
+        :raises: UnsupportedMethod
+        """
+        raise UnsupportedMethod(
+            "%s does not support the update method" % self.__class__.__name__
+        )
+
+    def modify(self, **kwargs):
+        """Update is not supported
+
+        :raises: UnsupportedMethod
+        """
+        raise UnsupportedMethod(
+            "%s does not support the modify method" % self.__class__.__name__
+        )

--- a/f5/bigip/tm/sys/test/functional/test_service.py
+++ b/f5/bigip/tm/sys/test/functional/test_service.py
@@ -1,0 +1,61 @@
+# Copyright 2016 F5 Networks Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+from f5.multi_device.utils import get_device_info
+from f5.multi_device.utils import pollster
+
+import pytest
+
+
+def get_activation_state(device):
+    '''Get the activation state for a device.'''
+
+    device_name = get_device_info(device).name
+    act = device.tm.cm.devices.device.load(
+        name=device_name,
+        partition='Common'
+    )
+    return act.failoverState
+
+
+def check_device_state_as_expected(device, expected_state):
+    assert get_activation_state(device).lower() == expected_state.lower()
+
+
+@pytest.mark.skipif(
+    pytest.config.getoption('--release') < '13.0.0',
+    reason='This test will fail below 13.0.0'
+    )
+class TestServiceTmm(object):
+    def test_restart_service_tmm(self, mgmt_root):
+        # restart
+        tmm = mgmt_root.tm.sys.service.tmm.load()
+        tmm_restart = tmm.exec_cmd('restart')
+        assert tmm_restart.command == 'restart'
+        get_activation_state(mgmt_root)
+        # Use the pollster to check for expected state. The pollster uses
+        # a method which checks for any exception. If one is found, it keeps
+        # trying.
+        # Check if forced to offline
+        pollster(check_device_state_as_expected)(mgmt_root, 'offline')
+        # Check if device is active
+        pollster(check_device_state_as_expected)(mgmt_root, 'active')
+
+    def test_load_service_tmm(self, mgmt_root):
+        # Load
+        tmm = mgmt_root.tm.sys.service.tmm.load()
+        URI = 'https://localhost/mgmt/tm/sys/service/tmm'
+        assert tmm.name == 'tmm'
+        assert tmm.selfLink.startswith(URI)

--- a/f5/bigip/tm/sys/test/unit/test_service.py
+++ b/f5/bigip/tm/sys/test/unit/test_service.py
@@ -1,0 +1,41 @@
+# Copyright 2016 F5 Networks Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+from f5.bigip import ManagementRoot
+from f5.sdk_exception import InvalidCommand
+from f5.sdk_exception import UnsupportedMethod
+
+
+import pytest
+
+
+class TestServiceTmm(object):
+    def test_update_raises(self, fakeicontrolsession):
+        b = ManagementRoot('192.168.1.1', 'admin', 'admin')
+        b._meta_data['tmos_version'] = '13.0.0'
+        with pytest.raises(UnsupportedMethod):
+            b.tm.sys.service.tmm.update()
+
+    def test_modify_raises(self, fakeicontrolsession):
+        b = ManagementRoot('192.168.1.1', 'admin', 'admin')
+        b._meta_data['tmos_version'] = '13.0.0'
+        with pytest.raises(UnsupportedMethod):
+            b.tm.sys.service.tmm.modify()
+
+    def test_invalid_cmd(self, fakeicontrolsession):
+        b = ManagementRoot('192.168.1.1', 'admin', 'admin')
+        b._meta_data['tmos_version'] = '13.0.0'
+        with pytest.raises(InvalidCommand):
+            b.tm.sys.service.tmm.exec_cmd('reset')


### PR DESCRIPTION
Issues:Unable to restart big ip tmm service
Fixes #<1481>

Problem:sdk doesnt have the support to restart tmm service

Analysis: added new file service.py along with support for tmm
 modified:   f5/bigip/tm/sys/__init__.py
 new file:   f5/bigip/tm/sys/service.py

Tests: Ran the following tests
 new file:   f5/bigip/tm/sys/test/functional/test_service.py
 new file:   f5/bigip/tm/sys/test/unit/test_service.py