### PR TITLE
Added BIGIP license installation

### DIFF
--- a/f5/bigip/tm/sys/license.py
+++ b/f5/bigip/tm/sys/license.py
@@ -41,7 +41,7 @@ class License(UnnamedResource, CommandExecutionMixin):
         super(License, self).__init__(sys)
         self._meta_data['required_json_kind'] =\
             "tm:sys:license:licensestats"
-        self._meta_data['allowed_commands'].append('revoke')
+        self._meta_data['allowed_commands'].extend(['revoke', 'install'])
 
     def exec_cmd(self, command, **kwargs):
         self._is_allowed_command(command)

--- a/f5/bigip/tm/sys/test/unit/test_license.py
+++ b/f5/bigip/tm/sys/test/unit/test_license.py
@@ -37,3 +37,17 @@ def test_delete_raises(FakeLicense):
     with pytest.raises(UnsupportedMethod) as EIO:
         FakeLicense.delete()
     assert str(EIO.value) == "License does not support the delete method"
+
+
+def test_exec_install(FakeLicense):
+    assert "install" in FakeLicense._meta_data['allowed_commands']
+    FakeLicense._meta_data['bigip']._meta_data.__getitem__.return_value = "14.0.0"
+    FakeLicense._exec_cmd = mock.MagicMock()
+    version_dict = {"13.1.0": 13, "14.0.0": 14}
+
+    def get_version(version):
+        return version_dict[version]
+
+    License.LooseVersion = mock.MagicMock(side_effect=get_version)
+    FakeLicense.exec_cmd("install", registrationKey='1234-56789-0')
+    FakeLicense._exec_cmd.assert_called_with("install", registrationKey='1234-56789-0')


### PR DESCRIPTION
Added license installation command similar to the revoking the license:
```python
mgnt = ManagementRoot(bigip_mgnt, user, passwd)
mgnt.tm.sys.license.exec_cmd('install', registrationKey=regkey)
```

Issues:
Fixes #1483

Problem: It was not possible to install BIGIP license via f5-sdk

Analysis:
Added `install` command to the `_meta_data['allowed_commands']` of the `License` object 

Tests:
* Added unit test to make sure that `install` command is allowed and executed with the appropriate arguments
* Performed the functional tests with the hardware BIGIP:
  * With the correct license key, object returned by the `mgnt.tm.sys.license.exec_cmd('install', 
registrationKey=regkey)` command has  `'commandResult': 'New license installed\n'` attribute and BIGIP has installed `regkey` license
  * With the incorrect license key, object returned by the `mgnt.tm.sys.license.exec_cmd('install', registrationKey=incorrect_regkey)` command has  `'commandResult': 'License server has returned an exception.\n   Fault code: XXXX\n   Fault text: Error XXXX, Production Key cannot be used in the Internal Development/PD environment - Key : XXXX\n'` attribute and previous license key remains on the BIGIP