### PR TITLE
Unable to reset nat translation stats

### DIFF
--- a/f5/bigip/tm/security/nat.py
+++ b/f5/bigip/tm/security/nat.py
@@ -27,6 +27,7 @@ REST Kind
     ``tm:security:nat:*``
 """
 from f5.bigip.mixins import CheckExistenceMixin
+from f5.bigip.mixins import CommandExecutionMixin
 from f5.bigip.resource import Collection
 from f5.bigip.resource import OrganizingCollection
 from f5.bigip.resource import Resource
@@ -99,7 +100,7 @@ class Rule(Resource, CheckExistenceMixin):
         return super(Rule, self)._load(**kwargs)
 
 
-class Source_Translations(Collection):
+class Source_Translations(Collection, CommandExecutionMixin):
     """BIG-IP® AFM® Nat Source Translation collection"""
 
     def __init__(self, nat):
@@ -108,9 +109,10 @@ class Source_Translations(Collection):
         self._meta_data['attribute_registry'] = \
             {'tm:security:nat:source-translation:source-translationstate':
                 Source_Translation}
+        self._meta_data['allowed_commands'].append('reset-stats')
 
 
-class Source_Translation(Resource):
+class Source_Translation(Resource, CommandExecutionMixin):
     def __init__(self, source_translations):
         super(Source_Translation, self).__init__(source_translations)
         self._meta_data['required_json_kind'] = \
@@ -119,9 +121,10 @@ class Source_Translation(Resource):
             ('partition',))
         self._meta_data['required_load_parameters'].update(
             ('partition',))
+        self._meta_data['allowed_commands'].append('reset-stats')
 
 
-class Destination_Translations(Collection):
+class Destination_Translations(Collection, CommandExecutionMixin):
     """BIG-IP® AFM® Nat Destination Translation collection"""
 
     def __init__(self, nat):
@@ -130,9 +133,10 @@ class Destination_Translations(Collection):
         self._meta_data['attribute_registry'] = \
             {'tm:security:nat:destination-translation:destination-translationstate':
                 Destination_Translation}
+        self._meta_data['allowed_commands'].append('reset-stats')
 
 
-class Destination_Translation(Resource):
+class Destination_Translation(Resource, CommandExecutionMixin):
     def __init__(self, destination_translations):
         super(Destination_Translation, self).__init__(destination_translations)
         self._meta_data['required_json_kind'] = \
@@ -141,6 +145,7 @@ class Destination_Translation(Resource):
             ('partition',))
         self._meta_data['required_load_parameters'].update(
             ('partition',))
+        self._meta_data['allowed_commands'].append('reset-stats')
 
 
 class Policy_s(Collection):

--- a/f5/bigip/tm/security/test/functional/test_nat.py
+++ b/f5/bigip/tm/security/test/functional/test_nat.py
@@ -158,6 +158,22 @@ class TestSrcTranslation(object):
         assert len(src)
         assert isinstance(src[0], Source_Translation)
 
+    def test_src_translation_collection_reset_stats(self, mgmt_root):
+        src_coll = mgmt_root.tm.security.nat.source_translations
+        src_coll_reset_stats = src_coll.exec_cmd('reset-stats')
+        assert src_coll_reset_stats.command == 'reset-stats'
+        assert src_coll_reset_stats.kind == 'tm:security:nat:source-translation:reset-statsstate'
+
+    def test_src_translation_reset_stats(self, mgmt_root, srctranslation):
+        s1 = srctranslation
+        assert s1.name == 'fake_src'
+        assert s1.partition == 'Common'
+        src_coll = mgmt_root.tm.security.nat.source_translations
+        src_coll_reset_stats = src_coll.exec_cmd('reset-stats', name='fake_src')
+        assert src_coll_reset_stats.command == 'reset-stats'
+        assert src_coll_reset_stats.kind == 'tm:security:nat:source-translation:reset-statsstate'
+        assert src_coll_reset_stats.name == s1.name
+
 
 @pytest.mark.skipif(
     LooseVersion(pytest.config.getoption('--release')) < LooseVersion('12.1.0'),
@@ -263,6 +279,22 @@ class TestDstTranslation(object):
         assert isinstance(dst, list)
         assert len(dst)
         assert isinstance(dst[0], Destination_Translation)
+
+    def test_dst_translation_collection_reset_stats(self, mgmt_root):
+        dst_coll = mgmt_root.tm.security.nat.destination_translations
+        dst_coll_reset_stats = dst_coll.exec_cmd('reset-stats')
+        assert dst_coll_reset_stats.command == 'reset-stats'
+        assert dst_coll_reset_stats.kind == 'tm:security:nat:destination-translation:reset-statsstate'
+
+    def test_dst_translation_reset_stats(self, mgmt_root, dsttranslation):
+        d1 = dsttranslation
+        assert d1.name == 'fake_dst'
+        assert d1.partition == 'Common'
+        dst_coll = mgmt_root.tm.security.nat.destination_translations
+        dst_coll_reset_stats = dst_coll.exec_cmd('reset-stats', name='fake_dst')
+        assert dst_coll_reset_stats.command == 'reset-stats'
+        assert dst_coll_reset_stats.kind == 'tm:security:nat:destination-translation:reset-statsstate'
+        assert dst_coll_reset_stats.name == d1.name
 
 
 @pytest.mark.skipif(

--- a/f5/bigip/tm/security/test/unit/test_nat.py
+++ b/f5/bigip/tm/security/test/unit/test_nat.py
@@ -22,6 +22,7 @@ from f5.bigip.tm.security.nat import Policy
 from f5.bigip.tm.security.nat import Rule
 from f5.bigip.tm.security.nat import Rules_s
 from f5.bigip.tm.security.nat import Source_Translation
+from f5.sdk_exception import InvalidCommand
 from f5.sdk_exception import MissingRequiredCreationParameter
 
 from six import iterkeys
@@ -60,7 +61,7 @@ def MakeSrcTranslation(fakeicontrolsession):
     p = a.tm.security.nat.source_translations.source_translation
     p._meta_data['uri'] = \
         'https://192.168.1.1:443/mgmt/tm/security/nat/source-translation/~Common' \
-        '~testsrctranslatiom/'
+        '~testsrctranslation/'
     return p
 
 
@@ -102,6 +103,11 @@ class TestSrcTranslation(object):
             b.tm.security.nat.source_translations.source_translation.create(
                 name='destined_to_fail')
 
+    def test_invalid_cmd(self, FakeSrcTranslation):
+        FakeSrcTranslation._meta_data['tmos_version'] = '12.1.0'
+        with pytest.raises(InvalidCommand):
+            FakeSrcTranslation.exec_cmd('restart', name='fake_src')
+
 
 class TestDstTranslation(object):
     def test_create_two(self, fakeicontrolsession):
@@ -121,6 +127,11 @@ class TestDstTranslation(object):
         with pytest.raises(MissingRequiredCreationParameter):
             b.tm.security.nat.destination_translations.destination_translation.create(
                 name='destined_to_fail')
+
+    def test_invalid_cmd(self, FakeDstTranslation):
+        FakeDstTranslation._meta_data['tmos_version'] = '12.1.0'
+        with pytest.raises(InvalidCommand):
+            FakeDstTranslation.exec_cmd('restart', name='fake_dst')
 
 
 class TestPolicy(object):


### PR DESCRIPTION
Issues:Unable to reset nat translation stats
    Fixes #<1488>

Problem:sdk doesnt have the support to reset nat translation objects stats

Analysis: Added CommandExecutionMixin to source and destination translation collection and resource
     modified: f5/bigip/tm/security/nat.py
     modified: f5/bigip/tm/security/test/functional/test_nat.py
     modified: f5/bigip/tm/security/test/unit/test_nat.py

Tests: Added tests
     modified: f5/bigip/tm/security/test/functional/test_nat.py
     modified:   f5/bigip/tm/security/test/unit/test_nat.py