### PR TITLE
Issue #1487 - Fix issue with Node FQDN required parameters

### DIFF
--- a/f5/bigip/tm/ltm/test/functional/test_node.py
+++ b/f5/bigip/tm/ltm/test/functional/test_node.py
@@ -15,8 +15,8 @@
 
 import pytest
 
-from f5.sdk_exception import MissingRequiredCreationParameter
 from f5.sdk_exception import NodeStateModifyUnsupported
+from f5.sdk_exception import RequiredOneOf
 
 
 TESTDESCRIPTION = "TESTDESCRIPTION"
@@ -40,7 +40,7 @@ def setup_node_test(request, mgmt_root, partition, name, addr):
 class TestNode(object):
     def test_create_missing_args(self, mgmt_root):
         n1 = mgmt_root.tm.ltm.nodes.node
-        with pytest.raises(MissingRequiredCreationParameter):
+        with pytest.raises(RequiredOneOf):
             n1.create(name="n1", partition='Common')
 
     def test_CURDLE(self, request, mgmt_root):

--- a/requirements.test.txt
+++ b/requirements.test.txt
@@ -11,7 +11,6 @@ pyOpenSSL==16.2.0
 requests-mock==1.2.0
 netaddr
 q
-pytest-xdist
 pycodestyle
 jinja2
 tox


### PR DESCRIPTION
Problem: SDK requires address parameter with Node, but the REST API
does not require it for fqdn type nodes

Solution: This PR looks for a set of required parameters that exclusively
permits the fqdn or the address for the create method.

Files Changed:

- f5/bigip/tm/ltm/node.py (changed)
- f5/bigip/tm/ltm/test/functional/test_node.py (changed)