### PR TITLE
Fixed the license installation issue

### DIFF
--- a/f5/bigip/tm/sys/license.py
+++ b/f5/bigip/tm/sys/license.py
@@ -46,6 +46,6 @@ class License(UnnamedResource, CommandExecutionMixin):
     def exec_cmd(self, command, **kwargs):
         self._is_allowed_command(command)
         self._check_command_parameters(**kwargs)
-        if LooseVersion(self._meta_data['bigip']._meta_data['tmos_version']) < LooseVersion('13.1.0'):
+        if LooseVersion(self._meta_data['bigip']._meta_data['tmos_version']) < LooseVersion('13.1.0') and command == 'revoke':
             raise UnsupportedTmosVersion('%s is not supported until version 13.1' % command)
         return self._exec_cmd(command, **kwargs)


### PR DESCRIPTION
Due to `revoke` command was added only in 13.1.0 version, version check is not actual for the `install` command.
The change allows to install the BIGIP license on versions prior the 13.1.0 as well
Checked the license installation on BIGIP v13.0.0