### PR TITLE
Correct edge case in ltm node api for address + fqdn

### DIFF
--- a/f5/bigip/tm/ltm/node.py
+++ b/f5/bigip/tm/ltm/node.py
@@ -62,6 +62,8 @@ class Node(Resource):
         has_any = [set(x).issubset(args) for x in required_one_of]
         if len([x for x in has_any if x is True]) == 1:
             return self._create(**kwargs)
+        elif 'address' in kwargs and kwargs['address'] == 'any6' and 'fqdn' in kwargs:
+            return self._create(**kwargs)
 
         raise RequiredOneOf(required_one_of)
 


### PR DESCRIPTION
Issues:
Fixes #1500

Problem:
The ltm node api has an edge case with the address value "any6" when
it is specified with the fqdn key.
The patch that originally fixed this issue was causing
the bigip_node module in ansible to break.

Analysis:
This patch handles that edge case and allows it.

Tests:
* functional