### PR TITLE
Fixes issue #1524

### DIFF
--- a/f5/bigip/__init__.py
+++ b/f5/bigip/__init__.py
@@ -62,6 +62,7 @@ class BaseManagement(PathElement):
         result = dict(
             timeout=kwargs.pop('timeout', 30),
             port=kwargs.pop('port', 443),
+            proxies=kwargs.pop('proxies', {}),
             icontrol_version=kwargs.pop('icontrol_version', ''),
             token=kwargs.pop('token', False),
             token_to_use=kwargs.pop('token_to_use', None),
@@ -83,6 +84,7 @@ class BaseManagement(PathElement):
             username=kwargs['username'],
             password=kwargs['password'],
             timeout=kwargs['timeout'],
+            proxies=kwargs['proxies'],
             verify=kwargs['verify'],
             token_to_use=kwargs['token_to_use']
         )
@@ -100,6 +102,7 @@ class BaseManagement(PathElement):
             'allowed_lazy_attributes': [Tm, Cm, Shared],
             'hostname': kwargs['hostname'],
             'port': kwargs['port'],
+            'proxies': kwargs['proxies'],
             'device_name': None,
             'local_ip': None,
             'bigip': self,

--- a/f5/bigip/mixins.py
+++ b/f5/bigip/mixins.py
@@ -369,7 +369,7 @@ class AsmFileMixin(object):
 
     """
     def _download_file(self, filepathname):
-            self._download(filepathname)
+        self._download(filepathname)
 
     def _download(self, filepathname):
         session = self._meta_data['icr_session']

--- a/f5/bigip/test/unit/test___init__.py
+++ b/f5/bigip/test/unit/test___init__.py
@@ -47,6 +47,13 @@ def FakeBigIPWithPort(fakeicontrolsession):
     return FBIP
 
 
+@pytest.fixture
+def FakeBigIPWithProxy(fakeicontrolsession):
+    FBIP = ManagementRoot('FakeHostName', 'admin', 'admin', proxies={"https": "https://127.0.0.1:8080"})
+    FBIP.icontrol = mock.MagicMock()
+    return FBIP
+
+
 def test___get__attr(FakeBigIP):
     bigip_dot_asm = FakeBigIP.tm.asm
     assert isinstance(bigip_dot_asm, Asm)
@@ -86,3 +93,8 @@ def test_icontrol_version(FakeBigIPWithPort):
 def test_non_default_port_number(FakeBigIPWithPort):
     uri = urlparse.urlsplit(FakeBigIPWithPort._meta_data['uri'])
     assert uri.port == 10443
+
+
+def test_proxy(FakeBigIPWithProxy):
+    proxy = FakeBigIPWithProxy._meta_data['proxies']
+    assert proxy == {"https": "https://127.0.0.1:8080"}

--- a/f5/bigip/test/unit/test_mixins.py
+++ b/f5/bigip/test/unit/test_mixins.py
@@ -174,10 +174,10 @@ def fake_http_server(uri, **kwargs):
 
 
 class FakeAsmFileMixin(AsmFileMixin):
-        def __init__(self, uri, **kwargs):
-            session = fake_http_server(uri, **kwargs)
-            self._meta_data = {'icr_session': session}
-            self.file_bound_uri = uri
+    def __init__(self, uri, **kwargs):
+        session = fake_http_server(uri, **kwargs)
+        self._meta_data = {'icr_session': session}
+        self.file_bound_uri = uri
 
 
 class TestAsmFileMixin(object):

--- a/f5/bigip/tm/gtm/test/unit/test_pool.py
+++ b/f5/bigip/tm/gtm/test/unit/test_pool.py
@@ -285,7 +285,7 @@ class HelperTest(object):
         session.post.side_effect = error
         memres._meta_data['bigip']._meta_data['icr_session'] = session
         with pytest.raises(HTTPError) as err:
-                memres.create(name='fake', partition='fakepart')
+            memres.create(name='fake', partition='fakepart')
         assert err.value.response.status_code == 500
 
     def test_404_response_v12_1(self, fakeicontrolsession_v12):

--- a/f5/bigip/tm/ltm/test/functional/test_pool.py
+++ b/f5/bigip/tm/ltm/test/functional/test_pool.py
@@ -79,7 +79,7 @@ class TestPoolMembersCollection(object):
             member1.refresh()
         except HTTPError as err:
             if err.response.status_code != 404:
-                    raise
+                raise
         pre_del = set(iterkeys(pool1.__dict__))
         pool1.refresh()
         post_del = set(iterkeys(pool1.__dict__))

--- a/f5/bigip/tm/ltm/test/functional/test_virtual_address.py
+++ b/f5/bigip/tm/ltm/test/functional/test_virtual_address.py
@@ -26,8 +26,8 @@ def setup_virtual_address_s_test(request, mgmt_root, vs_name, vs_partion):
 def setup_virtual_address_test(request, mgmt_root, va_name, va_partition):
     vac = mgmt_root.tm.ltm.virtual_address_s
     if vac.virtual_address.exists(name=va_name, partition=va_partition):
-            vac.virtual_address.load(
-                name=va_name, partition=va_partition).delete()
+        vac.virtual_address.load(
+            name=va_name, partition=va_partition).delete()
     va = vac.virtual_address.create(name=va_name, partition=va_partition)
     request.addfinalizer(va.delete)
     return vac, va

--- a/f5/bigip/tm/security/test/unit/test_shared_objects.py
+++ b/f5/bigip/tm/security/test/unit/test_shared_objects.py
@@ -39,40 +39,40 @@ def FakePortLst():
 
 
 class TestAddresslist_sharedobjects(object):
-        def test_create_two(self, fakeicontrolsession):
-            b = ManagementRoot('192.168.1.1', 'admin', 'admin')
-            b._meta_data['tmos_version'] = '14.0.0'
-            a1 = b.tm.security.shared_objects.address_lists.address_list
-            a2 = b.tm.security.shared_objects.address_lists.address_list
-            assert a1 is not a2
+    def test_create_two(self, fakeicontrolsession):
+        b = ManagementRoot('192.168.1.1', 'admin', 'admin')
+        b._meta_data['tmos_version'] = '14.0.0'
+        a1 = b.tm.security.shared_objects.address_lists.address_list
+        a2 = b.tm.security.shared_objects.address_lists.address_list
+        assert a1 is not a2
 
-        def test_create_no_args(self, FakeAddrLst):
-            with pytest.raises(MissingRequiredCreationParameter):
-                FakeAddrLst.create()
+    def test_create_no_args(self, FakeAddrLst):
+        with pytest.raises(MissingRequiredCreationParameter):
+            FakeAddrLst.create()
 
-        def test_create_mandatory_args_missing(self, fakeicontrolsession):
-            b = ManagementRoot('192.168.1.1.', 'admin', 'admin')
-            b._meta_data['tmos_version'] = '14.0.0'
-            with pytest.raises(MissingRequiredCreationParameter):
-                b.tm.security.shared_objects.address_lists.address_list.create(
-                    name='destined_to_fail', partition='Common')
+    def test_create_mandatory_args_missing(self, fakeicontrolsession):
+        b = ManagementRoot('192.168.1.1.', 'admin', 'admin')
+        b._meta_data['tmos_version'] = '14.0.0'
+        with pytest.raises(MissingRequiredCreationParameter):
+            b.tm.security.shared_objects.address_lists.address_list.create(
+                name='destined_to_fail', partition='Common')
 
 
 class TestPortList_sharedobjects(object):
-        def test_create_two(self, fakeicontrolsession):
-            b = ManagementRoot('192.168.1.1', 'admin', 'admin')
-            b._meta_data['tmos_version'] = '14.0.0'
-            r1 = b.tm.security.shared_objects.port_lists.port_list
-            r2 = b.tm.security.shared_objects.port_lists.port_list
-            assert r1 is not r2
+    def test_create_two(self, fakeicontrolsession):
+        b = ManagementRoot('192.168.1.1', 'admin', 'admin')
+        b._meta_data['tmos_version'] = '14.0.0'
+        r1 = b.tm.security.shared_objects.port_lists.port_list
+        r2 = b.tm.security.shared_objects.port_lists.port_list
+        assert r1 is not r2
 
-        def test_create_no_args(self, FakePortLst):
-            with pytest.raises(MissingRequiredCreationParameter):
-                FakePortLst.create()
+    def test_create_no_args(self, FakePortLst):
+        with pytest.raises(MissingRequiredCreationParameter):
+            FakePortLst.create()
 
-        def test_create_mandatory_args_missing(self, fakeicontrolsession):
-            b = ManagementRoot('192.168.1.1', 'admin', 'admin')
-            b._meta_data['tmos_version'] = '14.0.0'
-            with pytest.raises(MissingRequiredCreationParameter):
-                b.tm.security.shared_objects.port_lists.port_list.create(
-                    name='destined_to_fail', partition='Common')
+    def test_create_mandatory_args_missing(self, fakeicontrolsession):
+        b = ManagementRoot('192.168.1.1', 'admin', 'admin')
+        b._meta_data['tmos_version'] = '14.0.0'
+        with pytest.raises(MissingRequiredCreationParameter):
+            b.tm.security.shared_objects.port_lists.port_list.create(
+                name='destined_to_fail', partition='Common')

--- a/f5/bigip/tm/sys/test/functional/test_clock.py
+++ b/f5/bigip/tm/sys/test/functional/test_clock.py
@@ -17,8 +17,8 @@ from f5.utils.responses.handlers import Stats
 
 
 def test_clock_load(request, mgmt_root):
-        # Load
-        bigipclock = str(Stats(mgmt_root.tm.sys.clock.load()).stat.fullDate['description'])
-        bigipdate = bigipclock.split("T")[0]
+    # Load
+    bigipclock = str(Stats(mgmt_root.tm.sys.clock.load()).stat.fullDate['description'])
+    bigipdate = bigipclock.split("T")[0]
 
-        assert bigipdate == datetime.strptime(bigipdate, "%Y-%m-%d").strftime('%Y-%m-%d')
+    assert bigipdate == datetime.strptime(bigipdate, "%Y-%m-%d").strftime('%Y-%m-%d')

--- a/f5/bigip/tm/sys/test/functional/test_cluster.py
+++ b/f5/bigip/tm/sys/test/functional/test_cluster.py
@@ -17,23 +17,23 @@ from icontrol.exceptions import iControlUnexpectedHTTPError
 
 
 def test_cluster_load(request, mgmt_root):
-        # Load will produce exception on non-cluster BIGIP.
-        # iControlUnexpectedHTTPError: 404 Unexpected Error: Not Found for uri:
-        try:
-                assert str(mgmt_root.tm.sys.cluster.default.load().kind) == 'tm:sys:cluster:clusterstate'
-        except iControlUnexpectedHTTPError as err:
-                assert('01020036:3: The requested cluster (default) was not found.' in str(err))
+    # Load will produce exception on non-cluster BIGIP.
+    # iControlUnexpectedHTTPError: 404 Unexpected Error: Not Found for uri:
+    try:
+        assert str(mgmt_root.tm.sys.cluster.default.load().kind) == 'tm:sys:cluster:clusterstate'
+    except iControlUnexpectedHTTPError as err:
+        assert ('01020036:3: The requested cluster (default) was not found.' in str(err))
 
 
 def test_cluster_stats_load(request, mgmt_root):
-        # Load will give the result even on non-cluster BIGIP. However, the payload will be almost empty
-        assert str(mgmt_root.tm.sys.cluster.stats.load().kind) == 'tm:sys:cluster:clustercollectionstats'
+    # Load will give the result even on non-cluster BIGIP. However, the payload will be almost empty
+    assert str(mgmt_root.tm.sys.cluster.stats.load().kind) == 'tm:sys:cluster:clustercollectionstats'
 
 
 def test_cluster_default_stats_load(request, mgmt_root):
-        # Load will produce exception on non-cluster BIGIP.
-        # iControlUnexpectedHTTPError: 404 Unexpected Error: Not Found for uri:
-        try:
-                assert str(mgmt_root.tm.sys.cluster.default.stats.load().kind) == 'tm:sys:cluster:clusterstats'
-        except iControlUnexpectedHTTPError as err:
-                assert('01020036:3: The requested cluster (default) was not found.' in str(err))
+    # Load will produce exception on non-cluster BIGIP.
+    # iControlUnexpectedHTTPError: 404 Unexpected Error: Not Found for uri:
+    try:
+        assert str(mgmt_root.tm.sys.cluster.default.stats.load().kind) == 'tm:sys:cluster:clusterstats'
+    except iControlUnexpectedHTTPError as err:
+        assert ('01020036:3: The requested cluster (default) was not found.' in str(err))

--- a/f5/utils/testutils/registrytools.py
+++ b/f5/utils/testutils/registrytools.py
@@ -76,13 +76,13 @@ def register_collection_atoms(collection):
         logging.debug(ex)
         return resource_registry
     for resource in resources:
-            try:
-                resource_registry[resource.selfLink] = resource
-            except KeyError as ex:
-                raise ex
-            except UnsupportedTmosVersion as ex:
-                logging.debug(ex)
-                continue
+        try:
+            resource_registry[resource.selfLink] = resource
+        except KeyError as ex:
+            raise ex
+        except UnsupportedTmosVersion as ex:
+            logging.debug(ex)
+            continue
     return resource_registry
 
 

--- a/requirements.test.txt
+++ b/requirements.test.txt
@@ -4,10 +4,11 @@
 hacking==0.13.0
 mock==2.0.0
 pytest==3.2.1
-pytest-cov>=2.2.1
+pytest-cov==2.2.1
+coverage==4.0.3
 git+https://github.com/F5Networks/pytest-symbols.git
 python-coveralls==2.7.0
-pyOpenSSL==16.2.0
+pyOpenSSL>=17.5.0
 requests-mock==1.2.0
 netaddr
 q

--- a/setup_requirements.txt
+++ b/setup_requirements.txt
@@ -1,5 +1,5 @@
 # F5-SDK base install, python requirements
 six>=1.9.0
 six<2.0.0
-f5-icontrol-rest>=1.3.2
+f5-icontrol-rest>=1.3.13
 f5-icontrol-rest<2.0.0


### PR DESCRIPTION
- Adds proxies kwarg to allowed arguments on ManagementRoot
- Adds unit test validating acceptance of kwarg
- Requires f5-icontrol-rest min version 1.3.13 that was also updated to allow proxies kwarg from sdk

Additional Fix
- updates pyOpenSSL min requirement to address security vulnerability in that package