### PR TITLE
Python 3.8 - Update _check_keys to avoid Runtime Error when sanitizing response for keywords

### DIFF
--- a/f5/bigip/resource.py
+++ b/f5/bigip/resource.py
@@ -488,18 +488,20 @@ class ResourceBase(PathElement, ToDictMixin):
             error_message = "Response contains key '_meta_data' which is "\
                 "incompatible with this API!!\n Response json: %r" % rdict
             raise DeviceProvidesIncompatibleKey(error_message)
-        for x in rdict:
-            if not re.match(tokenize.Name, x):
+
+        copy_rdict = copy.deepcopy(rdict)
+        for key, value in iteritems(copy_rdict):
+            if not re.match(tokenize.Name, key):
                 error_message = "Device provided %r which is disallowed"\
-                    " because it's not a valid Python 2.7 identifier." % x
+                    " because it's not a valid Python 2.7 identifier." % key
                 raise DeviceProvidesIncompatibleKey(error_message)
-            elif keyword.iskeyword(x):
+            elif keyword.iskeyword(key):
                 # If attribute is keyword, append underscore to attribute name
-                rdict[x + '_'] = rdict[x]
-                rdict.pop(x)
-            elif x.startswith('__'):
+                rdict[key + '_'] = value
+                rdict.pop(key)
+            elif key.startswith('__'):
                 error_message = "Device provided %r which is disallowed"\
-                    ", it mangles into a Python non-public attribute." % x
+                    ", it mangles into a Python non-public attribute." % key
                 raise DeviceProvidesIncompatibleKey(error_message)
         return rdict
 


### PR DESCRIPTION
Issues: Runtime error sanitizing python keywords from dictionary
Fixes #1561

Problem: In Python 3.8 a Runtime error is thrown when sanitizing python keywords from response dictionary.

```python
    def _check_keys(self, rdict):
        """Call this from _local_update to validate response keys

            disallowed server-response json keys:
            1. The string-literal '_meta_data'
            2. strings that are not valid Python 2.7 identifiers
            3. strings beginning with '__'.

            :param rdict: from response.json()
            :raises: DeviceProvidesIncompatibleKey
            :returns: checked response rdict
            """
        if '_meta_data' in rdict:
            error_message = "Response contains key '_meta_data' which is "\
                "incompatible with this API!!\n Response json: %r" % rdict
            raise DeviceProvidesIncompatibleKey(error_message)

>       for x in rdict:
E       RuntimeError: dictionary keys changed during iteration
```

Analysis: Changing the iteration to loop through a copy of the response dictionary and update the original, to avoid updating the dictionary while looping through it.

Tests: The following existing tests within bigip/test/unit/test_resource.py cover the proposed changes.
test_Resource__check_keys_python_keyword
test_Resource__check_for_python_keywords
test_Resource__check_for_python_keywords_recursive
