### PR TITLE
Support bandwidth controller policy

### DIFF
--- a/f5/bigip/tm/net/__init__.py
+++ b/f5/bigip/tm/net/__init__.py
@@ -29,6 +29,7 @@ REST Kind
 
 from f5.bigip.resource import OrganizingCollection
 from f5.bigip.tm.net.arp import Arps
+from f5.bigip.tm.net.bwc import Bwc
 from f5.bigip.tm.net.dns_resolver import Dns_Resolvers
 from f5.bigip.tm.net.fdb import Fdb
 from f5.bigip.tm.net.interface import Interfaces
@@ -47,6 +48,7 @@ class Net(OrganizingCollection):
         super(Net, self).__init__(tm)
         self._meta_data['allowed_lazy_attributes'] = [
             Arps,
+            Bwc,
             Dns_Resolvers,
             Fdb,
             Interfaces,

--- a/f5/bigip/tm/net/bwc.py
+++ b/f5/bigip/tm/net/bwc.py
@@ -1,0 +1,59 @@
+# coding=utf-8
+#
+# Copyright 2020 F5 Networks Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""BIG-IP® Network bwc module.
+
+REST URI
+    ``http://localhost/mgmt/tm/net/bwc``
+
+GUI Path
+    ``Acceleration --> Bandwidth Controllers``
+
+REST Kind
+    ``tm:net:bwc:*``
+"""
+
+from f5.bigip.resource import Collection
+from f5.bigip.resource import OrganizingCollection
+from f5.bigip.resource import Resource
+
+
+class Bwc(OrganizingCollection):
+    """BIG-IP® network bwc collection"""
+    def __init__(self, net):
+        super(Bwc, self).__init__(net)
+        self._meta_data['allowed_lazy_attributes'] = [
+            Policys,
+        ]
+
+
+class Policys(Collection):
+    """BIG-IP® bwc policy sub-collection"""
+    def __init__(self, bwc):
+        super(Policys, self).__init__(bwc)
+        self._meta_data['allowed_lazy_attributes'] = [Policy]
+        self._meta_data['attribute_registry'] =\
+            {'tm:net:bwc:policy:policystate': Policy}
+
+
+class Policy(Resource):
+    """BIG-IP® bwc policy sub-collection resource"""
+    def __init__(self, policy_s):
+        super(Policy, self).__init__(policy_s)
+        self._meta_data['required_creation_parameters'].update(('partition',))
+        self._meta_data['required_json_kind'] =\
+            'tm:net:bwc:policy:policystate'

--- a/f5/bigip/tm/net/test/functional/test_bwc.py
+++ b/f5/bigip/tm/net/test/functional/test_bwc.py
@@ -1,0 +1,71 @@
+# Copyright 2020 F5 Networks Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+from requests.exceptions import HTTPError
+
+
+TEST_DESCR = "TEST DESCRIPTION"
+
+
+def delete_resource(resource):
+    try:
+        resource.delete()
+    except HTTPError as err:
+        if err.response.status_code != 404:
+            raise
+
+
+def setup_policy_test(request, mgmt_root, name, partition, maxRate):
+    def teardown():
+        delete_resource(policy)
+    request.addfinalizer(teardown)
+
+    policy = mgmt_root.tm.net.bwc.policys.policy.create(
+        name=name, partition=partition, maxRate=maxRate)
+    return policy
+
+
+class TestPolicys(object):
+    def test_policy_list(self, mgmt_root):
+        policies = mgmt_root.tm.net.bwc.policys.get_collection()
+        assert len(policies)
+        for policy in policies:
+            assert policy.generation
+
+
+class TestPolicy(object):
+    def test_policy_CURDL(self, request, mgmt_root):
+        # Create and Delete are tested by the setup/teardown
+        p1 = setup_policy_test(
+            request, mgmt_root, 'bwc-policy-test', 'Common', 1000000
+        )
+
+        # Load
+        p2 = mgmt_root.tm.net.bwc.policys.policy.load(
+            name='bwc-policy-test', partition='Common')
+        assert p1.name == 'bwc-policy-test'
+        assert p1.name == p2.name
+        assert p1.generation == p2.generation
+
+        # Update
+        p1.description = TEST_DESCR
+        p1.update()
+        assert p1.description == TEST_DESCR
+        assert p1.generation > p2.generation
+
+        # Refresh
+        p2.refresh()
+        assert p2.description == TEST_DESCR
+        assert p1.generation == p2.generation

--- a/f5/bigip/tm/net/test/unit/test_bwc.py
+++ b/f5/bigip/tm/net/test/unit/test_bwc.py
@@ -1,0 +1,40 @@
+# Copyright 2015 F5 Networks Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import mock
+import pytest
+
+from f5.bigip import ManagementRoot
+from f5.bigip.tm.net.bwc import Policy
+from f5.sdk_exception import MissingRequiredCreationParameter
+
+
+@pytest.fixture
+def FakePolicy():
+    fake_policy_s = mock.MagicMock()
+    fake_policy = Policy(fake_policy_s)
+    return fake_policy
+
+
+class TestCreate(object):
+    def test_create_two(self, fakeicontrolsession):
+        b = ManagementRoot('192.168.1.1', 'admin', 'admin')
+        p1 = b.tm.net.bwc.policys.policy
+        p2 = b.tm.net.bwc.policys.policy
+        assert p1 is not p2
+
+    def test_create_no_args(self, FakePolicy):
+        with pytest.raises(MissingRequiredCreationParameter):
+            FakePolicy.create()


### PR DESCRIPTION
Issues: Bandwidth controller policy support
Fixes tbd

Problem: user cannot create a bandwidth controller policy

Analysis: Added support for user to create bandwidth controller policy
f5/bigip/tm/net/bwc.py

Tests: unit, code style and functional
f5/bigip/tm/net/test/unit/test_bwc.py
f5/bigip/tm/net/test/functional/test_bwc.py

functional test result against BIG-IP v13
```
f5/bigip/tm/net/test/functional/test_bwc.py::TestPolicys::test_policy_list PASSED
f5/bigip/tm/net/test/functional/test_bwc.py::TestPolicy::test_policy_CURDL PASSED
```