### PR TITLE
Use lower version of pip to build package

### DIFF
--- a/requirements.test.txt
+++ b/requirements.test.txt
@@ -1,6 +1,7 @@
 # Install this directory (will use setup.py and therefore install_requires).
 -e .
 # Test Requirements
+pip<=18.1
 hacking==0.13.0
 mock==2.0.0
 pytest==3.2.1


### PR DESCRIPTION
Issues: Travis CI failed due to AttributeError of ParsedRequirement
Fixes tbd

Problem: Travis CI failed
https://travis-ci.org/github/F5Networks/f5-common-python/jobs/745836639
```
$ ${DIST_REPO}/build_pkgs.py
1945Traceback (most recent call last):
1946  File "f5-sdk-dist/build_pkgs.py", line 416, in <module>
1947    errnum = main()
1948  File "f5-sdk-dist/build_pkgs.py", line 400, in main
1949    error = _preliminary_construct(config)
1950  File "f5-sdk-dist/build_pkgs.py", line 241, in _preliminary_construct
1951    construct_setups._construct_cfgs_from_json(config)
1952  File "/home/travis/build/F5Networks/f5-common-python/f5-sdk-dist/scripts/construct_setups.py", line 68, in _construct_cfgs_from_json
1953    _construct_file(rpm.setup, rpm.reqs, rpm.fmt, rpm.start)
1954  File "/home/travis/build/F5Networks/f5-common-python/f5-sdk-dist/scripts/construct_setups.py", line 130, in _construct_file
1955    parsed_reqs = list(map(lambda x: (x.req), p_reqs(setup, session="pkg")))
1956  File "/home/travis/build/F5Networks/f5-common-python/f5-sdk-dist/scripts/construct_setups.py", line 130, in <lambda>
1957    parsed_reqs = list(map(lambda x: (x.req), p_reqs(setup, session="pkg")))
1958AttributeError: 'ParsedRequirement' object has no attribute 'req'
```


Analysis: Pip library has a very big change at the beginning of this year. We needn't to utilize very latest pip code. Just cap its version and continue to reuse the existing packaging code.

Tests: N/A