### PR TITLE
Cap cryptography version

### DIFF
--- a/requirements.test.txt
+++ b/requirements.test.txt
@@ -9,6 +9,7 @@ pytest-cov==2.2.1
 coverage==4.0.3
 git+https://github.com/F5Networks/pytest-symbols.git
 python-coveralls==2.7.0
+cryptography<3.3
 pyOpenSSL>=17.5.0
 requests-mock==1.2.0
 netaddr


### PR DESCRIPTION
Issues: Travis CI failed due to the code change in cryptography 3.3 
Fixes tbd

Problem: Travis CI failed
https://travis-ci.org/github/F5Networks/f5-common-python/jobs/748472633
```
Traceback (most recent call last):
361  File "/home/travis/virtualenv/python2.7.15/bin/pip", line 11, in <module>
362    sys.exit(main())
363  File "/home/travis/virtualenv/python2.7.15/lib/python2.7/site-packages/pip/_internal/cli/main.py", line 73, in main
364    command = create_command(cmd_name, isolated=("--isolated" in cmd_args))
365  File "/home/travis/virtualenv/python2.7.15/lib/python2.7/site-packages/pip/_internal/commands/__init__.py", line 104, in create_command
366    module = importlib.import_module(module_path)
367  File "/opt/python/2.7.15/lib/python2.7/importlib/__init__.py", line 37, in import_module
368    __import__(name)
369  File "/home/travis/virtualenv/python2.7.15/lib/python2.7/site-packages/pip/_internal/commands/install.py", line 24, in <module>
370    from pip._internal.cli.req_command import RequirementCommand, with_cleanup
371  File "/home/travis/virtualenv/python2.7.15/lib/python2.7/site-packages/pip/_internal/cli/req_command.py", line 16, in <module>
372    from pip._internal.index.package_finder import PackageFinder
373  File "/home/travis/virtualenv/python2.7.15/lib/python2.7/site-packages/pip/_internal/index/package_finder.py", line 21, in <module>
374    from pip._internal.index.collector import parse_links
375  File "/home/travis/virtualenv/python2.7.15/lib/python2.7/site-packages/pip/_internal/index/collector.py", line 14, in <module>
376    from pip._vendor import html5lib, requests
377  File "/home/travis/virtualenv/python2.7.15/lib/python2.7/site-packages/pip/_vendor/requests/__init__.py", line 97, in <module>
378    from pip._vendor.urllib3.contrib import pyopenssl
379  File "/home/travis/virtualenv/python2.7.15/lib/python2.7/site-packages/pip/_vendor/urllib3/contrib/pyopenssl.py", line 46, in <module>
380    import OpenSSL.SSL
381  File "/home/travis/virtualenv/python2.7.15/lib/python2.7/site-packages/OpenSSL/__init__.py", line 8, in <module>
382    from OpenSSL import rand, crypto, SSL
383  File "/home/travis/virtualenv/python2.7.15/lib/python2.7/site-packages/OpenSSL/SSL.py", line 431, in <module>
384    _lib.Cryptography_HAS_TLSEXT_HOSTNAME, "SNI not available"
385AttributeError: 'module' object has no attribute 'Cryptography_HAS_TLSEXT_HOSTNAME'
```


Analysis: Use cryptography version lower than 3.3

Tests: N/A