### PR TITLE
Issue #1502 - support Chinese character

### DIFF
--- a/f5/bigip/resource.py
+++ b/f5/bigip/resource.py
@@ -97,6 +97,7 @@ except ImportError:
         message = ("Maybe you're using Python < 2.7 and do not have the "
                    "orderreddict external dependency installed.")
         raise exc(message)
+import json
 import copy
 import keyword
 import re
@@ -401,7 +402,9 @@ class ResourceBase(PathElement, ToDictMixin):
             raise AttemptedMutationOfReadOnly(msg)
 
         patch = self._prepare_request_json(patch)
-        response = session.patch(patch_uri, json=patch, **requests_params)
+        data = json.dumps(patch, ensure_ascii=False)
+        data = data.encode("utf-8")
+        response = session.patch(patch_uri, data=data, **requests_params)
         self._local_update(response.json())
 
     def modify(self, **patch):
@@ -577,7 +580,9 @@ class ResourceBase(PathElement, ToDictMixin):
         # @see https://github.com/requests/requests/issues/2364
         for _ in range(0, 30):
             try:
-                response = session.put(update_uri, json=data_dict, **requests_params)
+                data = json.dumps(data_dict, ensure_ascii=False)
+                data = data.encode("utf-8")
+                response = session.put(update_uri, data=data, **requests_params)
                 self._meta_data = temp_meta
                 self._local_update(response.json())
                 break
@@ -1012,7 +1017,9 @@ class Resource(ResourceBase):
         kwargs = self._prepare_request_json(kwargs)
 
         # Invoke the REST operation on the device.
-        response = session.post(_create_uri, json=kwargs, **requests_params)
+        data = json.dumps(kwargs, ensure_ascii=False)
+        data = data.encode("utf-8")
+        response = session.post(_create_uri, data=data, **requests_params)
 
         # Make new instance of self
         result = self._produce_instance(response)

--- a/f5/bigip/shared/authn.py
+++ b/f5/bigip/shared/authn.py
@@ -15,6 +15,7 @@
 # limitations under the License.
 #
 
+import json
 
 from f5.bigip.resource import Collection
 from f5.bigip.resource import OrganizingCollection
@@ -76,7 +77,9 @@ class Root(Resource):
         kwargs = self._prepare_request_json(kwargs)
 
         # Invoke the REST operation on the device.
-        response = session.post(_create_uri, json=kwargs, **requests_params)
+        data = json.dumps(kwargs, ensure_ascii=False)
+        data = data.encode("utf-8")
+        response = session.post(_create_uri, data=data, **requests_params)
 
         # Make new instance of self
         result = self._produce_instance(response)

--- a/f5/bigip/tm/gtm/pool.py
+++ b/f5/bigip/tm/gtm/pool.py
@@ -26,6 +26,7 @@ GUI Path
 REST Kind
     ``tm:gtm:pools:*``
 """
+import json
 
 from distutils.version import LooseVersion
 
@@ -290,8 +291,10 @@ class MembersResourceA(Resource):
             # fixed in later 12.x release.
 
             try:
+                data = json.dumps(kwargs, ensure_ascii=False)
+                data = data.encode("utf-8")
                 response = session.post(
-                    _create_uri, json=kwargs, **requests_params)
+                    _create_uri, data=data, **requests_params)
 
             except HTTPError as err:
                 if err.response.status_code != 404:
@@ -373,8 +376,10 @@ class MembersResourceAAAA(Resource):
             # fixed in later 12.x release.
 
             try:
+                data = json.dumps(kwargs, ensure_ascii=False)
+                data = data.encode("utf-8")
                 response = session.post(
-                    _create_uri, json=kwargs, **requests_params)
+                    _create_uri, data=data, **requests_params)
 
             except HTTPError as err:
                 if err.response.status_code != 404:

--- a/f5/bigip/tm/gtm/topology.py
+++ b/f5/bigip/tm/gtm/topology.py
@@ -26,6 +26,9 @@ GUI Path
 REST Kind
     ``tm:gtm:topology:*``
 """
+
+import json
+
 from distutils.version import LooseVersion
 from f5.bigip.resource import Collection
 from f5.bigip.resource import Resource
@@ -99,8 +102,10 @@ class Topology(Resource):
         # fixed in later release.
 
         try:
+            data = json.dumps(kwargs, ensure_ascii=False)
+            data = data.encode("utf-8")
             response = session.post(
-                _create_uri, json=kwargs, **requests_params)
+                _create_uri, data=data, **requests_params)
 
         except HTTPError as err:
             if err.response.status_code != 404:

--- a/f5/bigip/tm/ltm/policy.py
+++ b/f5/bigip/tm/ltm/policy.py
@@ -27,6 +27,8 @@ REST Kind
     ``tm:ltm:policy:*``
 """
 
+import json
+
 from f5.bigip.mixins import CheckExistenceMixin
 from f5.bigip.resource import Collection
 from f5.bigip.resource import Resource
@@ -161,7 +163,9 @@ class Policy(Resource):
             kwargs['command'] = 'publish'
         if 'Drafts' not in self.name:
             kwargs['name'] = self.fullPath
-        session.post(base_uri, json=kwargs, **requests_params)
+        data = json.dumps(kwargs, ensure_ascii=False)
+        data = data.encode("utf-8")
+        session.post(base_uri, data=data, **requests_params)
         get_kwargs = {
             'name': self.name, 'partition': self.partition,
             'uri_as_parts': True

--- a/f5/bigip/tm/ltm/virtual.py
+++ b/f5/bigip/tm/ltm/virtual.py
@@ -27,6 +27,8 @@ REST Kind
     ``tm:ltm:virtual:*``
 """
 
+import json
+
 from distutils.version import LooseVersion
 
 from f5.bigip.mixins import CheckExistenceMixin
@@ -197,8 +199,10 @@ class Policies(Resource, CheckExistenceMixin):
             # this in 11.5.4
 
             try:
+                data = json.dumps(kwargs, ensure_ascii=False)
+                data = data.encode("utf-8")
                 response = session.post(
-                    _create_uri, json=kwargs, **requests_params)
+                    _create_uri, data=data, **requests_params)
 
             except HTTPError as err:
                 if err.response.status_code != 404:

--- a/f5/bigiq/cm/device/licensing/pool/regkey.py
+++ b/f5/bigiq/cm/device/licensing/pool/regkey.py
@@ -27,6 +27,7 @@ REST Kind
 import os
 import time
 import uuid
+import json
 
 from f5.bigiq.resource import Collection
 from f5.bigiq.resource import OrganizingCollection
@@ -172,7 +173,9 @@ class Members(Resource):
         if not force:
             self._check_generation()
 
-        response = session.delete(delete_uri, json=kwargs, **requests_params)
+        data = json.dumps(kwargs, ensure_ascii=False)
+        data = data.encode("utf-8")
+        response = session.delete(delete_uri, data=data, **requests_params)
         if response.status_code == 200:
             self.__dict__ = {'deleted': True}
 

--- a/f5/bigiq/cm/device/licensing/pool/utility.py
+++ b/f5/bigiq/cm/device/licensing/pool/utility.py
@@ -27,6 +27,7 @@ REST Kind
 import os
 import time
 import uuid
+import json
 
 from f5.bigip.mixins import ExclusiveAttributesMixin
 from f5.bigiq.resource import Collection
@@ -174,8 +175,9 @@ class Members(Resource, ExclusiveAttributesMixin):
         force = self._check_force_arg(kwargs.pop('force', True))
         if not force:
             self._check_generation()
-
-        response = session.delete(delete_uri, json=kwargs, **requests_params)
+        data = json.dumps(kwargs, ensure_ascii=False)
+        data = data.encode("utf-8")
+        response = session.delete(delete_uri, data=data, **requests_params)
         if response.status_code == 200:
             self.__dict__ = {'deleted': True}
 

--- a/f5/bigiq/cm/shared/licensing/pools.py
+++ b/f5/bigiq/cm/shared/licensing/pools.py
@@ -23,6 +23,7 @@ REST URI
 REST Kind
     ``cm:shared:licensing:pools:*``
 """
+import json
 
 from f5.bigiq.resource import Collection
 from f5.bigiq.resource import Resource
@@ -127,7 +128,8 @@ class Member(Resource):
         force = self._check_force_arg(kwargs.pop('force', True))
         if not force:
             self._check_generation()
-
-        response = session.delete(delete_uri, json=kwargs, **requests_params)
+        data = json.dumps(kwargs, ensure_ascii=False)
+        data = data.encode("utf-8")
+        response = session.delete(delete_uri, data=data, **requests_params)
         if response.status_code == 200:
             self.__dict__ = {'deleted': True}


### PR DESCRIPTION
Problem: SDK does not support Chinese character

Solution: when Requests library sending requests, The keyword parameter
json is the syntax sugar of the keyword parameter data.
when use keyword parameter json, json.dumps parameter ensure_ascii is
True, so problems arise when parameters contain non-ASCII codes.
Therefore, use the data keyword instead of the json keyword.

Files Changed:
 + f5/bigip/resource.py
 + f5/bigip/shared/authn.py
 + f5/bigip/tm/gtm/pool.py
 + f5/bigip/tm/gtm/topology.py
 + f5/bigip/tm/ltm/policy.py
 + f5/bigip/tm/ltm/virtual.py
 + f5/bigiq/cm/device/licensing/pool/regkey.py
 + f5/bigiq/cm/device/licensing/pool/utility.py
 + f5/bigiq/cm/shared/licensing/pools.py