### PR TITLE
Cap get-pip.py version (v3.0.11-dev)

### DIFF
--- a/f5-sdk-dist/Docker/redhat/7/Dockerfile
+++ b/f5-sdk-dist/Docker/redhat/7/Dockerfile
@@ -1,7 +1,7 @@
 FROM centos:7
 
 RUN yum update -y && yum install rpm-build make python-setuptools -y
-RUN curl "https://bootstrap.pypa.io/get-pip.py" -o "get-pip.py"
+RUN curl "https://bootstrap.pypa.io/pip/2.7/get-pip.py" -o "get-pip.py"
 RUN python get-pip.py
 
 COPY ./build-rpm.py /build-rpm.py


### PR DESCRIPTION
(cherry picked from commit 47e1197a0853e292b58e4c471211b08a82897fbb)