### PR TITLE
Fix Python SyntaxWarnings in iapp_parser.py

### DIFF
--- a/f5/utils/iapp_parser.py
+++ b/f5/utils/iapp_parser.py
@@ -120,10 +120,10 @@ class IappParser(object):
             elif char == '}' and not in_quote:
                 brace_count -= 1
 
-            if brace_count is 0:
+            if brace_count == 0:
                 return index + section_start
 
-        if brace_count is not 0:
+        if brace_count != 0:
             raise CurlyBraceMismatchException(
                 'Curly braces mismatch in section %s.' % section
                 )


### PR DESCRIPTION
If I run Python's `compileall` on code of the `f5-sdk` Python package, I get the following SyntaxWarnings:

```
% python3 -m compileall iapp_parser.py
Compiling 'iapp_parser.py'...
iapp_parser.py:123: SyntaxWarning: "is" with a literal. Did you mean "=="?
  if brace_count is 0:
iapp_parser.py:126: SyntaxWarning: "is not" with a literal. Did you mean "!="?
  if brace_count is not 0:
```

This PR fixes these warnings.

Using Python 3.11.2, but I believe these warnings were already introduced in Python 3.8.

Background: https://adamj.eu/tech/2020/01/21/why-does-python-3-8-syntaxwarning-for-is-literal/